### PR TITLE
remove multiple resource additions

### DIFF
--- a/scidavis/scidavis.pro
+++ b/scidavis/scidavis.pro
@@ -19,16 +19,6 @@ INSTALLS        += translationfiles
 ### icon file (for Windows installer)
 win32:INSTALLS  += win_icon
 
-###################### ICONS ################################################
-RESOURCES    +=        appicons.qrc
-RESOURCES    +=        icons.qrc
-RC_FILE      =         scidavis.rc
-
-win32 {
-  win_icon.files = icons/scidavis.ico
-  win_icon.path = "$$INSTALLBASE"
-}
-
 liborigin {
   LIBS += ../3rdparty/liborigin/liborigin.a
   POST_TARGETDEPS += ../3rdparty/liborigin/liborigin.a


### PR DESCRIPTION
appicons.qrc, icons.qrc & scidavis.rc files along with windows icon files & paths are already added in basic.pri.
