### PR TITLE
add a default table row height settings to preferences

### DIFF
--- a/libscidavis/src/ConfigDialog.h
+++ b/libscidavis/src/ConfigDialog.h
@@ -152,6 +152,8 @@ private:
 	QLabel *lblDefaultNumericFormat;
 	QComboBox *boxDefaultNumericFormat;
 	QLabel *boxSeparatorPreview;
+	QLabel *lblTableRowHeight;
+	QSpinBox *boxTableRowHeight;
 	QSpinBox *boxMinutes, *boxLineWidth, *boxFrameWidth, *boxResolution, *boxMargin, *boxPrecision, *boxAppPrecision;
 	QSpinBox *boxCurveLineWidth, *boxSymbolSize, *boxMinTicksLength, *boxMajTicksLength, *generatePointsBox;
 	QSpinBox *boxUndoLimit;

--- a/libscidavis/src/future/table/TableView.cpp
+++ b/libscidavis/src/future/table/TableView.cpp
@@ -58,6 +58,7 @@
 #include <QGridLayout>
 #include <QScrollArea>
 #include <QMenu>
+#include <QSettings>
 
 #ifndef LEGACY_CODE_0_2_x
 TableView::TableView(future::Table *table)
@@ -94,6 +95,17 @@ void TableView::init()
 	d_main_layout->setContentsMargins(0, 0, 0, 0);
 	
 	d_view_widget = new TableViewWidget(this);
+#ifdef Q_OS_MAC
+    QSettings settings(QSettings::IniFormat,QSettings::UserScope,
+                      "SciDAVis", "SciDAVis");
+#else
+    QSettings settings(QSettings::NativeFormat,QSettings::UserScope,
+                       "SciDAVis", "SciDAVis");
+#endif
+    settings.beginGroup("[Table]");
+    int defaultRowHeight = settings.value("DefaultRowHeight", 20).toInt();
+    settings.endGroup();
+    d_view_widget->verticalHeader()->setDefaultSectionSize(defaultRowHeight);
 	d_view_widget->setModel(d_model);
 	connect(d_view_widget, SIGNAL(advanceCell()), this, SLOT(advanceCell()));
 	d_main_layout->addWidget(d_view_widget);


### PR DESCRIPTION
The default raw height is fixed! This PR can be handy when we use scidavis with various display resolutions. here is the screenshot of added setting.. (default raw height range from 15 to 100)
![table](https://cloud.githubusercontent.com/assets/11949260/12833470/7d1b4a2c-cb66-11e5-8bcd-884d6ff86e11.png)
here is the table view with default raw height set to 20:
![20](https://cloud.githubusercontent.com/assets/11949260/12833495/a70cc504-cb66-11e5-9d33-b9464b21c838.png)
here is the table view with default raw height set to 40:
![40](https://cloud.githubusercontent.com/assets/11949260/12833504/b20c94fc-cb66-11e5-889e-14250e4785a2.png)
