### PR TITLE
+ added PRESET=new_qwt option, improved file locations

### DIFF
--- a/config.pri
+++ b/config.pri
@@ -35,6 +35,9 @@ unix:isEmpty(PRESET) { # allow command-line argument to override settings here
 	### Intended for Linux users building from source (on possibly somewhat
 	### older systems).
 	#PRESET = default_installation
+	
+	### Link statically against Qwt in 3rdparty folder
+	#PRESET = new_qwt
 
 	### Link dynamically against system-wide installed libraries. Intended mainly
 	### for building Linux packages for distributions with Qwt and QwtPlot3D
@@ -230,11 +233,11 @@ contains(PRESET, default_installation) {
 	### Link statically against Qwt and Qwtplot3D (in order to make sure they
 	### are compiled against Qt4), dynamically against everything else.
 
-	INCLUDEPATH  += ../3rdparty/qwt/src
-	LIBS         += ../3rdparty/qwt/lib/libqwt.a
+	INCLUDEPATH  += $$PWD/3rdparty/qwt/src
+	LIBS         += $$PWD/3rdparty/qwt/lib/libqwt.a
 
-	INCLUDEPATH  += ../3rdparty/qwtplot3d/include
-	LIBS         += ../3rdparty/qwtplot3d/lib/libqwtplot3d.a
+	INCLUDEPATH  += $$PWD/3rdparty/qwtplot3d/include
+	LIBS         += $$PWD/3rdparty/qwtplot3d/lib/libqwtplot3d.a
 
 	INCLUDEPATH  += /usr/include/muParser
 	LIBS         += -lgsl -lgslcblas -lz -lGLU
@@ -288,8 +291,29 @@ contains(PRESET, linux_package) {
         INCLUDEPATH = "$(HOME)/usr/include" $$INCLUDEPATH
         QMAKE_LIBDIR = "$(HOME)/usr/lib" $$QMAKE_LIBDIR
 
-	INCLUDEPATH  += /usr/include/qwtplot3d
+	INCLUDEPATH  += /usr/include/qwtplot3d-qt4
 	LIBS         += -lqwtplot3d$${qwtsuff}
+
+	LIBS         += -lz -lGLU 
+
+	INCLUDEPATH  += /usr/include/muParser
+	LIBS         += -lgsl -lgslcblas
+	LIBS         += -lmuparser 
+
+}
+
+contains(PRESET, new_qwt) {
+	### Link statically against Qwt, dynamically against everything else.
+
+
+        INCLUDEPATH  += $$PWD/3rdparty/qwt/src
+	LIBS         += $$PWD/3rdparty/qwt/lib/libqwt.a 
+        
+        INCLUDEPATH = "$(HOME)/usr/include" $$INCLUDEPATH
+        QMAKE_LIBDIR = "$(HOME)/usr/lib" $$QMAKE_LIBDIR
+
+	INCLUDEPATH  += /usr/include/qwtplot3d-qt4
+	LIBS         += -lqwtplot3d-qt4
 
 	LIBS         += -lz -lGLU 
 
@@ -302,14 +326,14 @@ contains(PRESET, linux_package) {
 contains(PRESET, self_contained) {
 	### mostly static linking, for self-contained binaries
 
-	INCLUDEPATH  += ../3rdparty/qwt/src
-	LIBS         += ../3rdparty/qwt/lib/libqwt.a
+	INCLUDEPATH  += $$PWD/3rdparty/qwt/src
+	LIBS         += $$PWD/3rdparty/qwt/lib/libqwt.a
 
-	INCLUDEPATH  += ../3rdparty/qwtplot3d/include
-	LIBS         += ../3rdparty/qwtplot3d/lib/libqwtplot3d.a
+	INCLUDEPATH  += $$PWD/3rdparty/qwtplot3d/include
+	LIBS         += $$PWD/3rdparty/qwtplot3d/lib/libqwtplot3d.a
 
-	INCLUDEPATH  += ../3rdparty/muparser/include
-	LIBS         += ../3rdparty/muparser/lib/libmuparser.a
+	INCLUDEPATH  += $$PWD/3rdparty/muparser/include
+	LIBS         += $$PWD/3rdparty/muparser/lib/libmuparser.a
 
 	LIBS         += /usr/lib/libgsl.a /usr/lib/libgslcblas.a
 

--- a/libscidavis/src/Bar.cpp
+++ b/libscidavis/src/Bar.cpp
@@ -28,8 +28,8 @@
  ***************************************************************************/
 #include <qbitmap.h>
 
-#include <qwtplot3d/qwt3d_color.h>
-#include <qwtplot3d/qwt3d_plot.h>
+#include <qwt3d_color.h>
+#include <qwt3d_plot.h>
 #include "Bar.h"
 
 using namespace Qwt3D;

--- a/libscidavis/src/Bar.h
+++ b/libscidavis/src/Bar.h
@@ -29,7 +29,7 @@
 #ifndef BARS_H
 #define BARS_H
 
-#include <qwtplot3d/qwt3d_plot.h>
+#include <qwt3d_plot.h>
 
 //! 3D bars (modifed enrichment from QwtPlot3D)
 class Bar : public Qwt3D::VertexEnrichment

--- a/libscidavis/src/Cone3D.cpp
+++ b/libscidavis/src/Cone3D.cpp
@@ -27,8 +27,8 @@
  *                                                                         *
  ***************************************************************************/
 #include <math.h>
-#include <qwtplot3d/qwt3d_color.h>
-#include <qwtplot3d/qwt3d_plot.h>
+#include <qwt3d_color.h>
+#include <qwt3d_plot.h>
 #include "Cone3D.h"
 
 using namespace Qwt3D;

--- a/libscidavis/src/Cone3D.h
+++ b/libscidavis/src/Cone3D.h
@@ -29,7 +29,7 @@
 #ifndef MYCONES_H
 #define MYCONES_H
 
-#include <qwtplot3d/qwt3d_plot.h>
+#include <qwt3d_plot.h>
 
 //! 3D cone class (based on QwtPlot3D)
 class Cone3D : public Qwt3D::VertexEnrichment

--- a/libscidavis/src/Graph3D.cpp
+++ b/libscidavis/src/Graph3D.cpp
@@ -43,8 +43,8 @@
 #include <QCursor>
 #include <QImageWriter>
 
-#include <qwtplot3d/qwt3d_io_gl2ps.h>
-#include <qwtplot3d/qwt3d_coordsys.h>
+#include <qwt3d_io_gl2ps.h>
+#include <qwt3d_coordsys.h>
 
 #include <gsl/gsl_vector.h>
 #include <fstream>

--- a/libscidavis/src/Graph3D.h
+++ b/libscidavis/src/Graph3D.h
@@ -29,8 +29,8 @@
 #ifndef GRAPH3D_H
 #define GRAPH3D_H
 
-#include <qwtplot3d/qwt3d_surfaceplot.h>
-#include <qwtplot3d/qwt3d_function.h>
+#include <qwt3d_surfaceplot.h>
+#include <qwt3d_function.h>
 
 #include <QTimer>
 #include <QVector>

--- a/libscidavis/src/Plot3DDialog.cpp
+++ b/libscidavis/src/Plot3DDialog.cpp
@@ -48,7 +48,7 @@
 #include <QFontDialog>
 #include <QColorDialog>
 
-#include <qwtplot3d/qwt3d_color.h>
+#include <qwt3d_color.h>
 
 Plot3DDialog::Plot3DDialog( QWidget* parent, Qt::WFlags fl )
     : QDialog( parent, fl )


### PR DESCRIPTION
PRESET=new_qwt option is added in the hope to solve the
canvas frame export issue by customizing the libqwt.

Not sure about other system, but the modified config.pri
works under ubuntu 16.04.
