### PR TITLE
Fix wrong values on parameters' erros of fits - closes tickets #276/#290

### DIFF
--- a/libscidavis/src/Fit.cpp
+++ b/libscidavis/src/Fit.cpp
@@ -127,9 +127,10 @@ double * Fit::fitGslMultifit(int &iterations, int &status)
 	gsl_multifit_covar (s->J, 0.0, covar);
 #else
         {
-          gsl_matrix J;
-          gsl_multifit_fdfsolver_jac(s,&J);
-          gsl_multifit_covar (&J, 0.0, covar);
+          gsl_matrix *J = gsl_matrix_alloc(d_n, d_p);
+          gsl_multifit_fdfsolver_jac(s,J);
+          gsl_multifit_covar (J, 0.0, covar);
+	  gsl_matrix_free (J);
         }
 #endif
 	if (d_y_error_source == UnknownErrors) {


### PR DESCRIPTION
This simple commit fix the issues related with tickets #276 (Curve fit error estimates in SciDAVis D9) and #290( Wrong (and random) values of errors on fit parameters).