### PR TITLE
Fix mising desktop integration files and icons in Linux packages

### DIFF
--- a/scidavis/scidavis.pro
+++ b/scidavis/scidavis.pro
@@ -43,3 +43,39 @@ liborigin {
 DEFINES += LEGACY_CODE_0_2_x
 INCLUDEPATH += ../libscidavis/src/future
 
+###################### DESKTOP INTEGRATION ##################################
+
+unix {
+	desktop_entry.files = scidavis.desktop
+	desktop_entry.path = "$$INSTALLBASE/share/applications"
+
+	mime_package.files = scidavis.xml
+	mime_package.path = "$$INSTALLBASE/share/mime/packages"
+
+	#deprecated
+	mime_link.files = x-sciprj.desktop
+	mime_link.path = "$$INSTALLBASE/share/mimelnk/application"
+	
+	contains(INSTALLS, icons) {
+		# scalable icon
+		icons.files = icons/scidavis.svg
+		icons.path = "$$INSTALLBASE/share/icons/hicolor/scalable/apps"
+
+		# hicolor icons for different resolutions
+		resolutions = 16 22 32 48 64 128
+		for(res, resolutions) {
+			eval(icon_hicolor_$${res}.files = icons/hicolor-$${res}/scidavis.png)
+			eval(icon_hicolor_$${res}.path = "$$INSTALLBASE/share/icons/hicolor/$${res}x$${res}/apps")
+			INSTALLS += icon_hicolor_$${res}
+		}
+
+		# locolor icons for different resolutions
+		resolutions = 16 22 32
+		for(res, resolutions) {
+			eval(icon_locolor_$${res}.files = icons/locolor-$${res}/scidavis.png)
+			eval(icon_locolor_$${res}.path = "$$INSTALLBASE/share/icons/locolor/$${res}x$${res}/apps")
+
+			INSTALLS += icon_locolor_$${res}
+		}
+	}
+}

--- a/scidavis/translations/scidavis_pt-br.ts
+++ b/scidavis/translations/scidavis_pt-br.ts
@@ -4,454 +4,374 @@
 <context>
     <name>@default</name>
     <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
-    </message>
-    <message>
         <source>Please select two columns for this operation!</source>
-        <translation type="obsolete">Por favor, selecione duas colunas para esta operação!</translation>
+        <translation>Por favor, selecione duas colunas para esta operação!</translation>
     </message>
     <message>
         <source>Could not allocate memory, operation aborted!</source>
-        <translation type="obsolete">Memória insuficiente, operação cancelada!</translation>
+        <translation>Memória insuficiente, operação cancelada!</translation>
     </message>
     <message>
         <source>Error in GSL forward FFT operation!</source>
-        <translation type="obsolete">Erro na operação de FFT direta em GSL!</translation>
+        <translation>Erro na operação de FFT direta em GSL!</translation>
     </message>
     <message>
         <source>Please select a e column to plot!</source>
-        <translation type="obsolete">Por favor, selecione uma coluna e para plotar!</translation>
+        <translation>Por favor, selecione uma coluna e para plotar!</translation>
     </message>
     <message>
         <source>Please set a default X column for this table, first!</source>
-        <translation type="obsolete">Por favor, primeiro defina uma coluna X padrão nesta tabela!</translation>
+        <translation>Por favor, primeiro defina uma coluna X padrão nesta tabela!</translation>
     </message>
     <message>
         <source>Please select a column to plot!</source>
-        <translation type="obsolete">Por favor, selecione uma coluna para plotar!</translation>
+        <translation>Por favor, selecione uma coluna para plotar!</translation>
     </message>
     <message>
         <source>Please select four columns for this operation!</source>
-        <translation type="obsolete">Por favor, selecione quatro colunas para esta operação!</translation>
+        <translation>Por favor, selecione quatro colunas para esta operação!</translation>
     </message>
     <message>
         <source>You need at least two columns for this operation!</source>
-        <translation type="obsolete">São necessárias pelo menos duas colunas para esta operação!</translation>
+        <translation>São necessárias pelo menos duas colunas para esta operação!</translation>
     </message>
     <message>
         <source>Please select a Z column for this operation!</source>
-        <translation type="obsolete">Por favor, selecione uma coluna Z para esta operação!</translation>
+        <translation>Por favor, selecione uma coluna Z para esta operação!</translation>
     </message>
     <message>
         <source>You need to define a X column first!</source>
-        <translation type="obsolete">É necessário definir uma coluna X primeiro!</translation>
+        <translation>É necessário definir uma coluna X primeiro!</translation>
     </message>
     <message>
         <source>You need to define a e column first!</source>
-        <translation type="obsolete">É necessário definir uma coluna e primeiro!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - ASCII Export Error</source>
-        <translation type="obsolete">QtiPlot - Erro de exportação para ASCII</translation>
-    </message>
-    <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
+        <translation>É necessário definir uma coluna e primeiro!</translation>
     </message>
     <message>
         <source>Columns will be deleted from the table!</source>
-        <translation type="obsolete">As colunas serão excluídas da tabela!</translation>
+        <translation>As colunas serão excluídas da tabela!</translation>
     </message>
     <message>
         <source>Do you really want to continue?</source>
-        <translation type="obsolete">Deseja realmente continuar?</translation>
+        <translation>Deseja realmente continuar?</translation>
     </message>
     <message>
         <source>Yes</source>
-        <translation type="obsolete">Sim</translation>
+        <translation>Sim</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">Cancelar</translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
         <source>Please select two columns for this operation:
  the first represents the signal and the second the response function!</source>
-        <translation type="obsolete">Por favor, selecione duas colunas para esta operação: 
+        <translation>Por favor, selecione duas colunas para esta operação: 
 a primeira representando o sinal e a segunda a função resposta!</translation>
     </message>
     <message>
         <source>The response dataset &apos;%1&apos; must be less then half the size of the signal dataset &apos;%2&apos;!</source>
-        <translation type="obsolete">Os dados da resposta &apos;%1&apos; devem ter tamanho menor que a metade dos de sinal &apos;%2&apos;!</translation>
+        <translation>Os dados da resposta &apos;%1&apos; devem ter tamanho menor que a metade dos de sinal &apos;%2&apos;!</translation>
     </message>
     <message>
         <source>The response dataset &apos;%1&apos; must contain an odd number of points!</source>
-        <translation type="obsolete">O conjunto resposta &apos;%1&apos; deve conter um número ímpar de pontos!</translation>
+        <translation>O conjunto resposta &apos;%1&apos; deve conter um número ímpar de pontos!</translation>
     </message>
     <message>
         <source>Frequency</source>
-        <translation type="obsolete">Frequência</translation>
+        <translation>Frequência</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="obsolete">Tempo</translation>
+        <translation>Tempo</translation>
     </message>
     <message>
         <source>Real</source>
-        <translation type="obsolete">Real</translation>
+        <translation>Real</translation>
     </message>
     <message>
         <source>Imaginary</source>
-        <translation type="obsolete">Imaginário</translation>
+        <translation>Imaginário</translation>
     </message>
     <message>
         <source>Amplitude</source>
-        <translation type="obsolete">Amplitude</translation>
+        <translation>Amplitude</translation>
     </message>
     <message>
         <source>Angle</source>
-        <translation type="obsolete">Ângulo</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
-    </message>
-    <message>
-        <source>QtiPlot - untitled</source>
-        <translation type="obsolete">QtiPlot - sem título</translation>
+        <translation>Ângulo</translation>
     </message>
     <message>
         <source>&lt;b&gt; %1 &lt;/b&gt;: Wrong locale option or no translation available!</source>
-        <translation type="obsolete">&lt;b&gt; %1 &lt;/b&gt;: Opções regionais incorretas ou tradução indisponível!</translation>
+        <translation>&lt;b&gt; %1 &lt;/b&gt;: Opções regionais incorretas ou tradução indisponível!</translation>
     </message>
     <message>
         <source>&lt;b&gt; %1 &lt;/b&gt;: Unknown command line option or the file doesn&apos;t exist!</source>
-        <translation type="obsolete">&lt;b&gt; %1 &lt;/b&gt;: Opção de linha de comando desconhecida ou arquivo inexistente!</translation>
+        <translation>&lt;b&gt; %1 &lt;/b&gt;: Opção de linha de comando desconhecida ou arquivo inexistente!</translation>
     </message>
     <message>
         <source>QtiPlot project</source>
-        <translation type="obsolete">Projeto do QtiPlot</translation>
+        <translation>Projeto do QtiPlot</translation>
     </message>
     <message>
         <source>Compressed QtiPlot project</source>
-        <translation type="obsolete">Projeto do QtiPlot compactado</translation>
+        <translation>Projeto do QtiPlot compactado</translation>
     </message>
     <message>
         <source>Origin project</source>
-        <translation type="obsolete">Projeto do Origin</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Open Project</source>
-        <translation type="obsolete">QtiPlot - Abrir projeto</translation>
-    </message>
-    <message>
-        <source>QtiPlot - File openning error</source>
-        <translation type="obsolete">QtiPlot - Erro na abertura de arquivo</translation>
+        <translation>Projeto do Origin</translation>
     </message>
     <message>
         <source>The file: &lt;b&gt;%1&lt;/b&gt; doesn&apos;t exist!</source>
-        <translation type="obsolete">O arquivo: &lt;b&gt; %1 &lt;/b&gt; não existe!</translation>
+        <translation>O arquivo: &lt;b&gt; %1 &lt;/b&gt; não existe!</translation>
     </message>
     <message>
         <source>The file: &lt;b&gt;%1&lt;/b&gt; is not a QtiPlot or Origin project file!</source>
-        <translation type="obsolete">O arquivo: &lt;b&gt; %1 &lt;/b&gt; não é um projeto do Origin ou do QtiPlot!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - File Backup Error</source>
-        <translation type="obsolete">QtiPlot - Erro na cópia de segurança</translation>
+        <translation>O arquivo: &lt;b&gt; %1 &lt;/b&gt; não é um projeto do Origin ou do QtiPlot!</translation>
     </message>
     <message>
         <source>Cannot make a backup copy of &lt;b&gt;%1&lt;/b&gt; (to %2).&lt;br&gt;If you ignore this, you rum  the risk of &lt;b&gt;data loss&lt;/b&gt;.</source>
-        <translation type="obsolete">Não é possível fazer uma cópia de segurança de &lt;b&gt;%1&lt;/b&gt; (para %2). &lt;br&gt;Se isto for ignorado corre-se o risco de &lt;b&gt;perder dados&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>QtiPlot - File Save Error</source>
-        <translation type="obsolete">QtiPlot - Erro ao salvar arquivo</translation>
+        <translation>Não é possível fazer uma cópia de segurança de &lt;b&gt;%1&lt;/b&gt; (para %2). &lt;br&gt;Se isto for ignorado corre-se o risco de &lt;b&gt;perder dados&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>The file: &lt;br&gt;&lt;b&gt;%1&lt;/b&gt; is opened in read-only mode</source>
-        <translation type="obsolete">O arquivo: &lt;br&gt;&lt;b&gt;%1&lt;/b&gt; está aberto no modo &quot;apenas leitura&quot;</translation>
+        <translation>O arquivo: &lt;br&gt;&lt;b&gt;%1&lt;/b&gt; está aberto no modo &quot;apenas leitura&quot;</translation>
     </message>
     <message>
         <source>Save Project As</source>
-        <translation type="obsolete">Salvar projeto como</translation>
-    </message>
-    <message>
-        <source>QtiPlot -- Overwrite File? </source>
-        <translation type="obsolete">QtiPlot -- Sobrescrever arquivo?</translation>
+        <translation>Salvar projeto como</translation>
     </message>
     <message>
         <source>A file called: &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;p&gt;already exists.
 Do you want to overwrite it?</source>
-        <translation type="obsolete">Um arquivo chamado &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;p&gt;já existe.
+        <translation>Um arquivo chamado &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;p&gt;já existe.
 Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Yes</source>
-        <translation type="obsolete">&amp;Sim</translation>
+        <translation>&amp;Sim</translation>
     </message>
     <message>
         <source>&amp;No</source>
-        <translation type="obsolete">&amp;Não</translation>
+        <translation>&amp;Não</translation>
     </message>
     <message>
         <source>&amp;Find...</source>
-        <translation type="obsolete">&amp;Procurar...</translation>
+        <translation>&amp;Procurar...</translation>
     </message>
     <message>
         <source>App&amp;end Project...</source>
-        <translation type="obsolete">Anexar pro&amp;jeto...</translation>
+        <translation>Anexar pro&amp;jeto...</translation>
     </message>
     <message>
         <source>Save &amp;As Project...</source>
-        <translation type="obsolete">Salv&amp;ar como projeto...</translation>
+        <translation>Salv&amp;ar como projeto...</translation>
     </message>
     <message>
         <source>Save Project &amp;As...</source>
-        <translation type="obsolete">Salvar projeto &amp;como...</translation>
+        <translation>Salvar projeto &amp;como...</translation>
     </message>
     <message>
         <source>&amp;Show All Windows</source>
-        <translation type="obsolete">Mo&amp;strar todas as janelas</translation>
+        <translation>Mo&amp;strar todas as janelas</translation>
     </message>
     <message>
         <source>&amp;Hide All Windows</source>
-        <translation type="obsolete">&amp;Ocultar todas as janelas</translation>
+        <translation>&amp;Ocultar todas as janelas</translation>
     </message>
     <message>
         <source>&amp;Delete Folder</source>
-        <translation type="obsolete">E&amp;xcluir pasta</translation>
+        <translation>E&amp;xcluir pasta</translation>
     </message>
     <message>
         <source>&amp;Rename</source>
-        <translation type="obsolete">&amp;Renomear</translation>
+        <translation>&amp;Renomear</translation>
     </message>
     <message>
         <source>New &amp;Window</source>
-        <translation type="obsolete">Nova &amp;janela</translation>
+        <translation>Nova &amp;janela</translation>
     </message>
     <message>
         <source>New F&amp;older</source>
-        <translation type="obsolete">Nova &amp;pasta</translation>
+        <translation>Nova &amp;pasta</translation>
     </message>
     <message>
         <source>&amp;None</source>
-        <translation type="obsolete">&amp;Nenhum</translation>
+        <translation>&amp;Nenhum</translation>
     </message>
     <message>
         <source>&amp;Windows in Active Folder</source>
-        <translation type="obsolete">&amp;Janelas na pasta ativa</translation>
+        <translation>&amp;Janelas na pasta ativa</translation>
     </message>
     <message>
         <source>Windows in &amp;Active Folder &amp;&amp; Subfolders</source>
-        <translation type="obsolete">Janelas na pasta &amp;ativa e subpastas</translation>
+        <translation>Janelas na pasta &amp;ativa e subpastas</translation>
     </message>
     <message>
         <source>&amp;View Windows</source>
-        <translation type="obsolete">&amp;Ver janelas</translation>
+        <translation>&amp;Ver janelas</translation>
     </message>
     <message>
         <source>&amp;Properties...</source>
-        <translation type="obsolete">Propriedades...</translation>
+        <translation>Propriedades...</translation>
     </message>
     <message>
         <source>Hidden</source>
-        <translation type="obsolete">Oculto</translation>
+        <translation>Oculto</translation>
     </message>
     <message>
         <source>Please enter a valid name!</source>
-        <translation type="obsolete">Por favor, forneça um nome válido!</translation>
+        <translation>Por favor, forneça um nome válido!</translation>
     </message>
     <message>
         <source>Name already exists!</source>
-        <translation type="obsolete">Nome já existe!</translation>
+        <translation>Nome já existe!</translation>
     </message>
     <message>
         <source>Please choose another name!</source>
-        <translation type="obsolete">Por favor, escolha outro nome!</translation>
+        <translation>Por favor, escolha outro nome!</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="obsolete">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>Project</source>
-        <translation type="obsolete">Projeto</translation>
+        <translation>Projeto</translation>
     </message>
     <message>
         <source>Path</source>
-        <translation type="obsolete">Caminho</translation>
+        <translation>Caminho</translation>
     </message>
     <message>
         <source>Size</source>
-        <translation type="obsolete">Tamanho</translation>
+        <translation>Tamanho</translation>
     </message>
     <message>
         <source>bytes</source>
-        <translation type="obsolete">bytes</translation>
+        <translation>bytes</translation>
     </message>
     <message>
         <source>Contents</source>
-        <translation type="obsolete">Conteúdos</translation>
+        <translation>Conteúdos</translation>
     </message>
     <message>
         <source>Windows</source>
-        <translation type="obsolete">Janelas</translation>
+        <translation>Janelas</translation>
     </message>
     <message>
         <source>Folders</source>
-        <translation type="obsolete">Pastas</translation>
+        <translation>Pastas</translation>
     </message>
     <message>
         <source>Created</source>
-        <translation type="obsolete">Criado</translation>
+        <translation>Criado</translation>
     </message>
     <message>
         <source>Modified</source>
-        <translation type="obsolete">Modificado</translation>
+        <translation>Modificado</translation>
     </message>
     <message>
         <source>Properties</source>
-        <translation type="obsolete">Propriedades</translation>
+        <translation>Propriedades</translation>
     </message>
     <message>
         <source>Folder</source>
-        <translation type="obsolete">Pasta</translation>
+        <translation>Pasta</translation>
     </message>
     <message>
         <source>New Folder</source>
-        <translation type="obsolete">Nova pasta</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Delete folder?</source>
-        <translation type="obsolete">QtiPlot - Excluir pasta?</translation>
+        <translation>Nova pasta</translation>
     </message>
     <message>
         <source>Delete folder &apos;%1&apos; and all the windows it contains?</source>
-        <translation type="obsolete">Excluir pasta &apos;%1&apos; e todas as janelas que ela contém?</translation>
+        <translation>Excluir pasta &apos;%1&apos; e todas as janelas que ela contém?</translation>
     </message>
     <message>
         <source>No</source>
-        <translation type="obsolete">Não</translation>
+        <translation>Não</translation>
     </message>
     <message>
         <source>Matrix</source>
-        <translation type="obsolete">Matriz</translation>
+        <translation>Matriz</translation>
     </message>
     <message>
         <source>Table</source>
-        <translation type="obsolete">Tabela</translation>
+        <translation>Tabela</translation>
     </message>
     <message>
         <source>Note</source>
-        <translation type="obsolete">Nota</translation>
+        <translation>Nota</translation>
     </message>
     <message>
         <source>Plot</source>
-        <translation type="obsolete">Gráfico</translation>
+        <translation>Gráfico</translation>
     </message>
     <message>
         <source>Plot 3D</source>
-        <translation type="obsolete">Gráfico 3D</translation>
+        <translation>Gráfico 3D</translation>
     </message>
     <message>
         <source>Label</source>
-        <translation type="obsolete">Rótulo</translation>
+        <translation>Rótulo</translation>
     </message>
     <message>
         <source>Status</source>
-        <translation type="obsolete">Status</translation>
-    </message>
-    <message>
-        <source>QtiPlot - No match found</source>
-        <translation type="obsolete">QtiPlot - Nenhuma coincidência encontrada</translation>
+        <translation>Status</translation>
     </message>
     <message>
         <source>Sorry, no match found for string: &apos;%1&apos;</source>
-        <translation type="obsolete">Lamento, nenhuma coicidência encontrada para a cadeia de caracters: &apos;%1&apos;</translation>
+        <translation>Lamento, nenhuma coicidência encontrada para a cadeia de caracters: &apos;%1&apos;</translation>
     </message>
     <message>
         <source>Cannot move an object to itself!</source>
-        <translation type="obsolete">Não é possível mover um ojbeto para ele mesmo!</translation>
+        <translation>Não é possível mover um ojbeto para ele mesmo!</translation>
     </message>
     <message>
         <source>Cannot move a parent folder into a child folder!</source>
-        <translation type="obsolete">Não se pode mover uma pasta pai para dentro de uma pasta filha!</translation>
+        <translation>Não se pode mover uma pasta pai para dentro de uma pasta filha!</translation>
     </message>
     <message>
         <source>Skipped Moving Folder</source>
-        <translation type="obsolete">Omitido movimento de pasta</translation>
+        <translation>Omitido movimento de pasta</translation>
     </message>
     <message>
         <source>The destination folder already contains a folder called &apos;%1&apos;! Folder skipped!</source>
-        <translation type="obsolete">A pasta de destino já contém uma pasta chamada &apos;%1&apos;! Pasta omitida!</translation>
+        <translation>A pasta de destino já contém uma pasta chamada &apos;%1&apos;! Pasta omitida!</translation>
     </message>
     <message>
         <source>Rows will be deleted from the table!</source>
-        <translation type="obsolete">As linhas serão removidas da tabela!</translation>
+        <translation>As linhas serão removidas da tabela!</translation>
     </message>
     <message>
         <source>Graph</source>
-        <translation type="obsolete">Gráfico</translation>
+        <translation>Gráfico</translation>
     </message>
     <message>
         <source>Graph 3D</source>
-        <translation type="obsolete">Gráfico 3D</translation>
-    </message>
-    <message>
-        <source>QtiPlot - HTTP Get Version File</source>
-        <translation type="obsolete">QtiPlot - Obter versão de arquivo HTTP</translation>
+        <translation>Gráfico 3D</translation>
     </message>
     <message>
         <source>Cannot write file %1
 %2.</source>
-        <translation type="obsolete">Não é possível escrever arquivo %1
+        <translation>Não é possível escrever arquivo %1
 %2.</translation>
     </message>
     <message>
         <source>Error while fetching version file with HTTP: %1.</source>
-        <translation type="obsolete">Erro ao buscar versão de arquivo com HTTP: %1.</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Updates Available</source>
-        <translation type="obsolete">QtiPlot - Atualizações disponíveis</translation>
-    </message>
-    <message>
-        <source>There is a newer version of QtiPlot (%1) available for download. Would you like to download it?</source>
-        <translation type="obsolete">Existe uma nova versão do QtiPlot (%1) disponível. Você gostaria de baixá-la?</translation>
-    </message>
-    <message>
-        <source>QtiPlot - No Updates Available</source>
-        <translation type="obsolete">QtiPlot - Não existem atualizações disponíveis</translation>
+        <translation>Erro ao buscar versão de arquivo com HTTP: %1.</translation>
     </message>
     <message>
         <source>No updates available. Your current version %1 is the last version available!</source>
-        <translation type="obsolete">Não existem atualizações disponíveis. Sua versão atual %1 é a mais recente!</translation>
+        <translation>Não existem atualizações disponíveis. Sua versão atual %1 é a mais recente!</translation>
     </message>
     <message>
         <source>This will clear the contents of all the data associated with the table. Are you sure?</source>
-        <translation type="obsolete">Isto apagará os conteúdos de todos os dados associados à tabela. Está certo disso?</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Enter row number</source>
-        <translation type="obsolete">QtiPlot - Introduza o número da linha</translation>
+        <translation>Isto apagará os conteúdos de todos os dados associados à tabela. Está certo disso?</translation>
     </message>
     <message>
         <source>Row</source>
-        <translation type="obsolete">Linha</translation>
-    </message>
-    <message>
-        <source>Qtiplot - Reading file...</source>
-        <translation type="obsolete">QtiPlot - Lendo arquivo...</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Help</source>
-        <translation type="obsolete">QtiPlot - Ajuda</translation>
-    </message>
-    <message>
-        <source>QtiPlot - File opening error</source>
-        <translation type="obsolete">QtiPlot - Erro na abertura de arquivo</translation>
+        <translation>Linha</translation>
     </message>
 </context>
 <context>
@@ -459,91 +379,91 @@ Deseja sobrescrevê-lo?</translation>
     <message>
         <source>XML read error: </source>
         <comment>prefix for XML error messages</comment>
-        <translation type="obsolete">Erro na leitura XML:</translation>
+        <translation>Erro na leitura XML:</translation>
     </message>
     <message>
         <source> (loading failed)</source>
         <comment>postfix for XML error messages</comment>
-        <translation type="obsolete">(o carregamento falhou)</translation>
+        <translation>(o carregamento falhou)</translation>
     </message>
     <message>
         <source>aspect name missing</source>
-        <translation type="obsolete">falta nome do aspecto</translation>
+        <translation>falta nome do aspecto</translation>
     </message>
     <message>
         <source> (non-critical)</source>
         <comment>postfix for XML error messages</comment>
-        <translation type="obsolete">(não-crítico)</translation>
+        <translation>(não-crítico)</translation>
     </message>
     <message>
         <source>aspect name missing or empty</source>
-        <translation type="obsolete">falta (ou está vazio) o nome do aspecto</translation>
+        <translation>falta (ou está vazio) o nome do aspecto</translation>
     </message>
     <message>
         <source>Invalid creation time for &apos;%1&apos;. Using current time.</source>
-        <translation type="obsolete">Hora de criação inválida para &apos;%1&apos;. Usando hora atual.</translation>
+        <translation>Hora de criação inválida para &apos;%1&apos;. Usando hora atual.</translation>
     </message>
     <message>
         <source>%1: add %2.</source>
-        <translation type="obsolete">%1: adicionar %2.</translation>
+        <translation>%1: adicionar %2.</translation>
     </message>
     <message>
         <source>Renaming &quot;%1&quot; to &quot;%2&quot; in order to avoid name collision.</source>
-        <translation type="obsolete">Renomeando &quot;%1&quot; para &quot;%2&quot; para evitar conflito de nomes.</translation>
+        <translation>Renomeando &quot;%1&quot; para &quot;%2&quot; para evitar conflito de nomes.</translation>
     </message>
     <message>
         <source>%1: insert %2 at position %3.</source>
-        <translation type="obsolete">%1: inserir %2 na posição %3.</translation>
+        <translation>%1: inserir %2 na posição %3.</translation>
     </message>
     <message>
         <source>%1: remove %2.</source>
-        <translation type="obsolete">%1: remover %2.</translation>
+        <translation>%1: remover %2.</translation>
     </message>
     <message>
         <source>%1: move %2 to %3.</source>
-        <translation type="obsolete">%1: mover %2 para %3.</translation>
+        <translation>%1: mover %2 para %3.</translation>
     </message>
     <message>
         <source>Tabs and line breaks in object names are currently not supported. They have been removed.</source>
-        <translation type="obsolete">Tabulação e quebras de linha em nomes de objetos não são suportados atualmente. Eles foram removidos.</translation>
+        <translation>Tabulação e quebras de linha em nomes de objetos não são suportados atualmente. Eles foram removidos.</translation>
     </message>
     <message>
         <source>Intended name &quot;%1&quot; diverted to &quot;%2&quot; in order to avoid name collision.</source>
-        <translation type="obsolete">Nome pretendido &quot;%1&quot; alterado para &quot;%2&quot; para evitar conflito de noimes.</translation>
+        <translation>Nome pretendido &quot;%1&quot; alterado para &quot;%2&quot; para evitar conflito de nomes.</translation>
     </message>
     <message>
         <source>%1: remove all children.</source>
-        <translation type="obsolete">%1: remover todos os filhos.</translation>
+        <translation>%1: remover todos os filhos.</translation>
     </message>
 </context>
 <context>
     <name>AbstractPart</name>
     <message>
         <source>&amp;Restore</source>
-        <translation type="obsolete">&amp;Restaurar</translation>
+        <translation>&amp;Restaurar</translation>
     </message>
     <message>
         <source>Mi&amp;nimize</source>
-        <translation type="obsolete">Mi&amp;nimizar</translation>
+        <translation>Mi&amp;nimizar</translation>
     </message>
     <message>
         <source>Ma&amp;ximize</source>
-        <translation type="obsolete">Ma&amp;ximizar</translation>
+        <translation>Ma&amp;ximizar</translation>
     </message>
 </context>
 <context>
     <name>AbstractSimpleFilter</name>
     <message>
         <source>incompatible filter type</source>
-        <translation type="obsolete">filtro incompatível</translation>
+        <translation>filtro incompatível</translation>
     </message>
     <message>
         <source>unknown element &apos;%1&apos;</source>
-        <translation type="obsolete">elemento &apos;%1&apos; desconhecido</translation>
+        <translation>elemento &apos;%1&apos; desconhecido</translation>
     </message>
     <message>
         <source>no simple filter element found</source>
-        <translation type="obsolete">não foi encontrado nenhum elemento de filtro simples</translation>
+        <translation>não foi encontrado nenhum elemento de filtro simples</translation>
     </message>
 </context>
 <context>
@@ -585,11 +505,11 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Zoom</source>
-        <translation type="obsolete">Zoom</translation>
+        <translation>Zoom</translation>
     </message>
     <message>
         <source>Show data display</source>
-        <translation type="obsolete">Exibir mostrador de dados</translation>
+        <translation>Exibir mostrador de dados</translation>
     </message>
     <message>
         <source>Select data range</source>
@@ -597,7 +517,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Show data cursor</source>
-        <translation type="obsolete">Exibir cursor de dados</translation>
+        <translation>Exibir cursor de dados</translation>
     </message>
     <message>
         <source>Move data points</source>
@@ -617,7 +537,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Data Display</source>
-        <translation type="obsolete">Mostrador de dados</translation>
+        <translation>Mostrador de dados</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -629,7 +549,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Recent projects</source>
-        <translation type="obsolete">P&amp;rojetos recentes</translation>
+        <translation>P&amp;rojetos recentes</translation>
     </message>
     <message>
         <source>&amp;Export Graph</source>
@@ -637,7 +557,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Import ASCII</source>
-        <translation type="obsolete">&amp;Importar ASCII</translation>
+        <translation>&amp;Importar ASCII</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
@@ -653,7 +573,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Plot3D</source>
-        <translation type="obsolete">Gráfico 3D</translation>
+        <translation>Gráfico 3D</translation>
     </message>
     <message>
         <source>&amp;Matrix</source>
@@ -673,23 +593,23 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Plot 2D</source>
-        <translation type="obsolete">&amp;Gráfico 2D</translation>
+        <translation>&amp;Gráfico 2D</translation>
     </message>
     <message>
         <source>Plot &amp;3D</source>
-        <translation type="obsolete">Gráfico &amp;3D</translation>
+        <translation>Gráfico &amp;3D</translation>
     </message>
     <message>
         <source>&amp;Data</source>
-        <translation type="obsolete">&amp;Dados</translation>
+        <translation>&amp;Dados</translation>
     </message>
     <message>
         <source>Inter&amp;polate</source>
-        <translation type="obsolete">Inter&amp;polação</translation>
+        <translation>Inter&amp;polação</translation>
     </message>
     <message>
         <source>&amp;FFT</source>
-        <translation type="obsolete">&amp;FFT</translation>
+        <translation>&amp;FFT</translation>
     </message>
     <message>
         <source>Fit E&amp;xponential Decay</source>
@@ -716,36 +636,20 @@ Deseja sobrescrevê-lo?</translation>
         <translation>&lt;h4&gt;Não há tabelas disponíveis neste projeto.&lt;/h4&gt;&lt;p&gt;&lt;h4&gt;Por favor, crie uma tabela e tente novamente!&lt;/h4&gt;</translation>
     </message>
     <message>
-        <source>QtiPlot - Choose data set</source>
-        <translation type="obsolete">QtiPlot - Escolher conjunto de dados</translation>
-    </message>
-    <message>
         <source>&lt;h4&gt;There are no matrixes available in this project.&lt;/h4&gt;&lt;p&gt;&lt;h4&gt;Please create a matrix and try again!&lt;/h4&gt;</source>
-        <translation type="obsolete">&lt;h4&gt;Não há matrizes disponíveis neste projeto.&lt;/h4&gt;&lt;p&gt;&lt;h4&gt;Por favor, crie uma matriz e tente novamente!&lt;/h4&gt;</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Choose matrix to plot</source>
-        <translation type="obsolete">QtiPlot - Escolha matriz para plotar</translation>
+        <translation>&lt;h4&gt;Não há matrizes disponíveis neste projeto.&lt;/h4&gt;&lt;p&gt;&lt;h4&gt;Por favor, crie uma matriz e tente novamente!&lt;/h4&gt;</translation>
     </message>
     <message>
         <source>Data Plot 3D</source>
-        <translation type="obsolete">Gráfico 3D de dados</translation>
+        <translation>Gráfico 3D de dados</translation>
     </message>
     <message>
         <source>Matrix Plot 3D</source>
-        <translation type="obsolete">Gráfico 3D de matriz</translation>
+        <translation>Gráfico 3D de matriz</translation>
     </message>
     <message>
         <source>Function Plot 3D</source>
-        <translation type="obsolete">Gráfico 3D de função</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Import image from file</source>
-        <translation type="obsolete">QtiPlot - Importar imagem de arquivo</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Load image from file</source>
-        <translation type="obsolete">QtiPlot - Carregar imagem de arquivo</translation>
+        <translation>Gráfico 3D de função</translation>
     </message>
     <message>
         <source>Matrix</source>
@@ -760,24 +664,12 @@ Deseja sobrescrevê-lo?</translation>
         <translation>&lt;h4&gt;Não há camadas de gráfico disponíveis nesta janela.&lt;/h4&gt;&lt;p&gt;&lt;h4&gt;Por favor, adicione uma camada e tente novamente!&lt;/h4&gt;</translation>
     </message>
     <message>
-        <source>QtiPlot - Error bars error</source>
-        <translation type="obsolete">QtiPlot - Erro nas barras de erro</translation>
-    </message>
-    <message>
         <source>This feature is not available for user defined function curves!</source>
         <translation>Esta característica não está disponível para curvas de função definidas por usuários!</translation>
     </message>
     <message>
-        <source>QtiPlot - File Open Error</source>
-        <translation type="obsolete">QtiPlot - Erro ao abrir arquivo</translation>
-    </message>
-    <message>
         <source>&lt;h4&gt;There are no plot layers available in this window!&lt;/h4&gt;</source>
         <translation>&lt;h4&gt;Não há camadas de gráfico disponíveis nesta janela!&lt;/h4&gt;</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Overwrite File?</source>
-        <translation type="obsolete">QtiPlot - Sobrescrever arquivo?</translation>
     </message>
     <message>
         <source>A file called: &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;p&gt;already exists. Do you want to overwrite it?</source>
@@ -796,21 +688,9 @@ Deseja sobrescrevê-lo?</translation>
         <translation>&amp;Cancelar</translation>
     </message>
     <message>
-        <source>QtiPlot - Export Error</source>
-        <translation type="obsolete">QtiPlot - Erro de exportação</translation>
-    </message>
-    <message>
-        <source>QtiPlot - File Save Error</source>
-        <translation type="obsolete">QtiPlot - Erro ao salvar arquivo</translation>
-    </message>
-    <message>
-        <source>QtiPlot -- Overwrite File? </source>
-        <translation type="obsolete">QtiPlot -- Sobrescrever arquivo?</translation>
-    </message>
-    <message>
         <source>A file called: &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;p&gt;already exists.
 Do you want to overwrite it?</source>
-        <translation type="obsolete">Um arquivo chamado &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;p&gt;já existe.
+        <translation>Um arquivo chamado &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;p&gt;já existe.
 Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
@@ -819,27 +699,15 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Rename Window</source>
-        <translation type="obsolete">Renomear janela</translation>
+        <translation>Renomear janela</translation>
     </message>
     <message>
         <source>Please choose a name</source>
-        <translation type="obsolete">Por favor, escolha um nome</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
+        <translation>Por favor, escolha um nome</translation>
     </message>
     <message>
         <source>Not available for empty 3D surface plots!</source>
         <translation>Não disponível para superfícies 3D vazias!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Custom curves</source>
-        <translation type="obsolete">Curvas personalizadas</translation>
     </message>
     <message>
         <source>&lt;h4&gt;There are no plot layers available in this window.&lt;/h4&gt;</source>
@@ -848,10 +716,6 @@ Deseja sobrescrevê-lo?</translation>
     <message>
         <source>Sorry, there are no results to display!</source>
         <translation>Lamento, não existem resultados para mostrar!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Add new layer?</source>
-        <translation type="obsolete">QtiPlot - Adicionar nova camada?</translation>
     </message>
     <message>
         <source>Do you want to add the text on a new layer or on the active layer?</source>
@@ -866,40 +730,19 @@ Deseja sobrescrevê-lo?</translation>
         <translation>Na camada &amp;ativa</translation>
     </message>
     <message>
-        <source>QtiPlot - Define Layout</source>
-        <translation type="obsolete">Definir esquema</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Layer Geometry</source>
-        <translation type="obsolete">QtiPlot - Geometria da camada</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Duplicate error</source>
-        <translation type="obsolete">QtiPlot - Error de duplicação</translation>
+        <translation>Definir esquema</translation>
     </message>
     <message>
         <source>Empty 3D surface plots can not be duplicated!</source>
-        <translation type="obsolete">Superfícies 3D vazias não podem ser duplicadas!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Duplicate window error</source>
-        <translation type="obsolete">QtiPlot - Erro ao duplicar janela</translation>
+        <translation>Superfícies 3D vazias não podem ser duplicadas!</translation>
     </message>
     <message>
         <source>There are no windows available in this project!</source>
         <translation>Não há janelas disponíveis neste projeto!</translation>
     </message>
     <message>
-        <source>QtiPlot - Window Geometry</source>
-        <translation type="obsolete">QtiPlot - Geometria da janela</translation>
-    </message>
-    <message>
-        <source>About QtiPlot</source>
-        <translation type="obsolete">Sobre o QtiPlot</translation>
-    </message>
-    <message>
         <source>&amp;View pixel line profile</source>
-        <translation type="obsolete">&amp;Ver perfil de linha de pixel</translation>
+        <translation>&amp;Ver perfil de linha de pixel</translation>
     </message>
     <message>
         <source>&amp;Intensity Matrix</source>
@@ -926,40 +769,36 @@ Deseja sobrescrevê-lo?</translation>
         <translation>Por favor, use o navegador de projeto para selecionar uma janela!</translation>
     </message>
     <message>
-        <source>QtiPlot - index.html File Not Found!</source>
-        <translation type="obsolete">QtiPlot - index.html - Arquivo não encontrado</translation>
-    </message>
-    <message>
         <source>There is no file called &lt;b&gt;index.html&lt;/b&gt; in this folder.&lt;br&gt;Please choose another folder!</source>
         <translation>Não existe um arquivo chamado &lt;b&gt;index.html&lt;/b&gt; nesta pasta.&lt;br&gt;Por favor, escolha outra pasta!</translation>
     </message>
     <message>
         <source>Print</source>
-        <translation type="obsolete">Imprimir</translation>
+        <translation>Imprimir</translation>
     </message>
     <message>
         <source>Backward</source>
-        <translation type="obsolete">Para tráz</translation>
+        <translation>Para tráz</translation>
     </message>
     <message>
         <source>Forward</source>
-        <translation type="obsolete">Para frente</translation>
+        <translation>Para frente</translation>
     </message>
     <message>
         <source>Home</source>
-        <translation type="obsolete">Início</translation>
+        <translation>Início</translation>
     </message>
     <message>
         <source>Surface 3D</source>
-        <translation type="obsolete">Superfície 3D</translation>
+        <translation>Superfície 3D</translation>
     </message>
     <message>
         <source>Coordinates</source>
-        <translation type="obsolete">Coordenadas</translation>
+        <translation>Coordenadas</translation>
     </message>
     <message>
         <source>&amp;Coord</source>
-        <translation type="obsolete">&amp;Coord</translation>
+        <translation>&amp;Coord</translation>
     </message>
     <message>
         <source>Box</source>
@@ -979,59 +818,59 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>grid</source>
-        <translation type="obsolete">grade</translation>
+        <translation>grade</translation>
     </message>
     <message>
         <source>Action</source>
-        <translation type="obsolete">Ação</translation>
+        <translation>Ação</translation>
     </message>
     <message>
         <source>Front Grid</source>
-        <translation type="obsolete">Grade frontal</translation>
+        <translation>Grade frontal</translation>
     </message>
     <message>
         <source>Action_2</source>
-        <translation type="obsolete">Ação_2</translation>
+        <translation>Ação_2</translation>
     </message>
     <message>
         <source>Back Grid</source>
-        <translation type="obsolete">Grade posterior</translation>
+        <translation>Grade posterior</translation>
     </message>
     <message>
         <source>Action_3</source>
-        <translation type="obsolete">Ação_3</translation>
+        <translation>Ação_3</translation>
     </message>
     <message>
         <source>Right Grid</source>
-        <translation type="obsolete">Grade direita</translation>
+        <translation>Grade direita</translation>
     </message>
     <message>
         <source>Action_4</source>
-        <translation type="obsolete">Ação_4</translation>
+        <translation>Ação_4</translation>
     </message>
     <message>
         <source>Left Grid</source>
-        <translation type="obsolete">Grade esquerda</translation>
+        <translation>Grade esquerda</translation>
     </message>
     <message>
         <source>Action_5</source>
-        <translation type="obsolete">Ação_5</translation>
+        <translation>Ação_5</translation>
     </message>
     <message>
         <source>Ceiling Grid</source>
-        <translation type="obsolete">Grade superior</translation>
+        <translation>Grade superior</translation>
     </message>
     <message>
         <source>Action_6</source>
-        <translation type="obsolete">Ação_6</translation>
+        <translation>Ação_6</translation>
     </message>
     <message>
         <source>Floor Grid</source>
-        <translation type="obsolete">Grade inferior</translation>
+        <translation>Grade inferior</translation>
     </message>
     <message>
         <source>Plot Style</source>
-        <translation type="obsolete">Estilo de gráfico</translation>
+        <translation>Estilo de gráfico</translation>
     </message>
     <message>
         <source>Wireframe</source>
@@ -1063,11 +902,11 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Cross Hairs</source>
-        <translation type="obsolete">Cruzes</translation>
+        <translation>Cruzes</translation>
     </message>
     <message>
         <source>Floor Style</source>
-        <translation type="obsolete">Estilo de chão</translation>
+        <translation>Estilo de chão</translation>
     </message>
     <message>
         <source>Floor Data Projection</source>
@@ -1080,16 +919,6 @@ Deseja sobrescrevê-lo?</translation>
     <message>
         <source>Empty Floor</source>
         <translation>Chão vazio</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Guess best origin for the new layer?</source>
-        <translation type="obsolete">QtiPlot - Buscar melhor origem para a nova camada?</translation>
-    </message>
-    <message>
-        <source>Do you want QtiPlot to guess the best position for the new layer?
- Warning: this will rearrange existing layers!</source>
-        <translation type="obsolete">Deseja que o QtiPlot busque a melhor posição para a nova camada?
- Atenção: isto irá rearrumar as camadas existentes!</translation>
     </message>
     <message>
         <source>&amp;Guess</source>
@@ -1117,7 +946,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>New spreadsheet</source>
-        <translation type="obsolete">Nova planilha</translation>
+        <translation>Nova planilha</translation>
     </message>
     <message>
         <source>New &amp;Matrix</source>
@@ -1137,7 +966,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>New &amp;Surface 3D Plot</source>
-        <translation type="obsolete">Nova &amp;superfície 3D</translation>
+        <translation>Nova &amp;superfície 3D</translation>
     </message>
     <message>
         <source>Ctrl+Z</source>
@@ -1157,7 +986,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Open image &amp;file</source>
-        <translation type="obsolete">Abrir arquivo de imagem</translation>
+        <translation>Abrir arquivo de imagem</translation>
     </message>
     <message>
         <source>Ctrl+I</source>
@@ -1165,7 +994,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Import &amp;image...</source>
-        <translation type="obsolete">Importar imagem...</translation>
+        <translation>Importar imagem...</translation>
     </message>
     <message>
         <source>&amp;Save Project</source>
@@ -1177,23 +1006,23 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Save Project &amp;as...</source>
-        <translation type="obsolete">Salvar projeto &amp; como...</translation>
+        <translation>Salvar projeto &amp; como...</translation>
     </message>
     <message>
         <source>&amp;Single file...</source>
-        <translation type="obsolete">Arquivo único...</translation>
+        <translation>Arquivo único...</translation>
     </message>
     <message>
         <source>Import data file</source>
-        <translation type="obsolete">Importar arquivo de dados</translation>
+        <translation>Importar arquivo de dados</translation>
     </message>
     <message>
         <source>&amp;Multiple files...</source>
-        <translation type="obsolete">&amp;Múltipos arquivos...</translation>
+        <translation>&amp;Múltipos arquivos...</translation>
     </message>
     <message>
         <source>Import multiple data files</source>
-        <translation type="obsolete">Importar múltiplos arquivos de dados</translation>
+        <translation>Importar múltiplos arquivos de dados</translation>
     </message>
     <message>
         <source>&amp;Undo</source>
@@ -1201,7 +1030,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Ctrl+U</source>
-        <translation type="obsolete">Ctrl+U</translation>
+        <translation>Ctrl+U</translation>
     </message>
     <message>
         <source>&amp;Redo</source>
@@ -1221,7 +1050,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Cu&amp;t selection</source>
-        <translation type="obsolete">Cor&amp;tar seleção</translation>
+        <translation>Cor&amp;tar seleção</translation>
     </message>
     <message>
         <source>Ctrl+X</source>
@@ -1229,7 +1058,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Copy selection</source>
-        <translation type="obsolete">C&amp;opiar seleção</translation>
+        <translation>C&amp;opiar seleção</translation>
     </message>
     <message>
         <source>Ctrl+C</source>
@@ -1237,7 +1066,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Paste selection</source>
-        <translation type="obsolete">Co&amp;lar seleção</translation>
+        <translation>Co&amp;lar seleção</translation>
     </message>
     <message>
         <source>Ctrl+V</source>
@@ -1245,15 +1074,15 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Delete selection</source>
-        <translation type="obsolete">E&amp;xcluir seleção</translation>
+        <translation>E&amp;xcluir seleção</translation>
     </message>
     <message>
         <source>Delete</source>
-        <translation type="obsolete">Excluir</translation>
+        <translation>Excluir</translation>
     </message>
     <message>
         <source>Project &amp;explorer</source>
-        <translation type="obsolete">&amp;Explorador de projeto</translation>
+        <translation>&amp;Explorador de projeto</translation>
     </message>
     <message>
         <source>Ctrl+E</source>
@@ -1269,7 +1098,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Show calculus results</source>
-        <translation type="obsolete">Mostrar resultados de cálculos</translation>
+        <translation>Mostrar resultados de cálculos</translation>
     </message>
     <message>
         <source>Add La&amp;yer</source>
@@ -1305,11 +1134,11 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Print graph</source>
-        <translation type="obsolete">Imprimir gráfico</translation>
+        <translation>Imprimir gráfico</translation>
     </message>
     <message>
         <source>Print &amp;All Plots</source>
-        <translation type="obsolete">Imprimir tod&amp;os os gráficos</translation>
+        <translation>Imprimir tod&amp;os os gráficos</translation>
     </message>
     <message>
         <source>E&amp;xport ASCII</source>
@@ -1317,7 +1146,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Set import &amp;options</source>
-        <translation type="obsolete">Configurar &amp;opções de importação</translation>
+        <translation>Configurar &amp;opções de importação</translation>
     </message>
     <message>
         <source>&amp;Quit</source>
@@ -1329,11 +1158,11 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Clear &amp;log information</source>
-        <translation type="obsolete">&amp;Limpar registro de resultados</translation>
+        <translation>&amp;Limpar registro de resultados</translation>
     </message>
     <message>
         <source>Plot &amp;wizard</source>
-        <translation type="obsolete">Assistente de gráfico</translation>
+        <translation>Assistente de gráfico</translation>
     </message>
     <message>
         <source>Ctrl+Alt+W</source>
@@ -1345,7 +1174,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Add/Remove curve</source>
-        <translation type="obsolete">&amp;Adicionar/Remover curva</translation>
+        <translation>&amp;Adicionar/Remover curva</translation>
     </message>
     <message>
         <source>Add curve to graph</source>
@@ -1353,7 +1182,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Add &amp;Error Bars</source>
-        <translation type="obsolete">Adicionar barras de &amp;erro</translation>
+        <translation>Adicionar barras de &amp;erro</translation>
     </message>
     <message>
         <source>Ctrl+B</source>
@@ -1361,7 +1190,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Add &amp;function curve</source>
-        <translation type="obsolete">Adicionar &amp;curva de função</translation>
+        <translation>Adicionar &amp;curva de função</translation>
     </message>
     <message>
         <source>Ctrl+Alt+F</source>
@@ -1369,7 +1198,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Rescale to show all</source>
-        <translation type="obsolete">&amp;Reescalar para mostrar tudo</translation>
+        <translation>&amp;Reescalar para mostrar tudo</translation>
     </message>
     <message>
         <source>Best fit</source>
@@ -1397,7 +1226,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Draw arrow/line</source>
-        <translation type="obsolete">&amp;Desenhar flecha/linha</translation>
+        <translation>&amp;Desenhar flecha/linha</translation>
     </message>
     <message>
         <source>&amp;Line</source>
@@ -1405,7 +1234,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Plot with line</source>
-        <translation type="obsolete">Plotar com linha</translation>
+        <translation>Plotar com linha</translation>
     </message>
     <message>
         <source>&amp;Scatter</source>
@@ -1413,7 +1242,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Plot with symbols</source>
-        <translation type="obsolete">Plotar com símbolos</translation>
+        <translation>Plotar com símbolos</translation>
     </message>
     <message>
         <source>Line + S&amp;ymbol</source>
@@ -1421,11 +1250,11 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Plot with line + symbols</source>
-        <translation type="obsolete">Plotar com linha e símbolos</translation>
+        <translation>Plotar com linha e símbolos</translation>
     </message>
     <message>
         <source>Vertical &amp;drop lines</source>
-        <translation type="obsolete">Linhas verticais (gotículas)</translation>
+        <translation>Linhas verticais (gotículas)</translation>
     </message>
     <message>
         <source>&amp;Spline</source>
@@ -1437,7 +1266,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Columns</source>
-        <translation type="obsolete">&amp;Colunas</translation>
+        <translation>&amp;Colunas</translation>
     </message>
     <message>
         <source>Plot with vertical bars</source>
@@ -1445,7 +1274,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Rows</source>
-        <translation type="obsolete">&amp;Linhas</translation>
+        <translation>&amp;Linhas</translation>
     </message>
     <message>
         <source>Plot with horizontal bars</source>
@@ -1469,7 +1298,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Vectors &amp;XYXY</source>
-        <translation type="obsolete">&amp;Vetores &amp;XYXY</translation>
+        <translation>&amp;Vetores &amp;XYXY</translation>
     </message>
     <message>
         <source>&amp;Histogram</source>
@@ -1501,7 +1330,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Plot 3D Ribbon</source>
-        <translation type="obsolete">Gráfico de fita 3D</translation>
+        <translation>Gráfico de fita 3D</translation>
     </message>
     <message>
         <source>&amp;Bars</source>
@@ -1509,11 +1338,11 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Plot 3D Bars</source>
-        <translation type="obsolete">Gráfico de barras 3D</translation>
+        <translation>Gráfico de barras 3D</translation>
     </message>
     <message>
         <source>Plot 3D Scatter</source>
-        <translation type="obsolete">Gráfico de dispersão 3D</translation>
+        <translation>Gráfico de dispersão 3D</translation>
     </message>
     <message>
         <source>&amp;Trajectory</source>
@@ -1521,7 +1350,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Plot 3D Trajectory</source>
-        <translation type="obsolete">Gráfico trajetória 3D</translation>
+        <translation>Gráfico trajetória 3D</translation>
     </message>
     <message>
         <source>Ctrl+M</source>
@@ -1585,7 +1414,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Non-linear Curve Fit ...</source>
-        <translation type="obsolete">Ajuste &amp;não linear...</translation>
+        <translation>Ajuste &amp;não linear...</translation>
     </message>
     <message>
         <source>Ctrl+Y</source>
@@ -1601,15 +1430,15 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Columns...</source>
-        <translation type="obsolete">&amp;Colunas...</translation>
+        <translation>&amp;Colunas...</translation>
     </message>
     <message>
         <source>&amp;Rows...</source>
-        <translation type="obsolete">&amp;Linhas...</translation>
+        <translation>&amp;Linhas...</translation>
     </message>
     <message>
         <source>&amp;About</source>
-        <translation type="obsolete">&amp;Sobre</translation>
+        <translation>&amp;Sobre</translation>
     </message>
     <message>
         <source>F1</source>
@@ -1621,7 +1450,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Choose help folder...</source>
-        <translation type="obsolete">Escolher &amp;pasta de ajuda ...</translation>
+        <translation>Escolher &amp;pasta de ajuda ...</translation>
     </message>
     <message>
         <source>&amp;Rename Window</source>
@@ -1637,7 +1466,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Add column</source>
-        <translation type="obsolete">Adicionar coluna</translation>
+        <translation>Adicionar coluna</translation>
     </message>
     <message>
         <source>Window &amp;Geometry...</source>
@@ -1653,7 +1482,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Intensity table</source>
-        <translation type="obsolete">Tabela de &amp;intensidade</translation>
+        <translation>Tabela de &amp;intensidade</translation>
     </message>
     <message>
         <source>&amp;Activate Window</source>
@@ -1677,23 +1506,23 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Layer geometry</source>
-        <translation type="obsolete">&amp;Geometria da camada</translation>
+        <translation>&amp;Geometria da camada</translation>
     </message>
     <message>
         <source>Set &amp;Properties...</source>
-        <translation type="obsolete">Definir &amp;propiedades...</translation>
+        <translation>Definir &amp;propiedades...</translation>
     </message>
     <message>
         <source>Set &amp;Dimensions...</source>
-        <translation type="obsolete">Definir &amp;dimensões...</translation>
+        <translation>Definir &amp;dimensões...</translation>
     </message>
     <message>
         <source>Set &amp;Values...</source>
-        <translation type="obsolete">Definir &amp;valores...</translation>
+        <translation>Definir &amp;valores...</translation>
     </message>
     <message>
         <source>&amp;Transpose</source>
-        <translation type="obsolete">&amp;Transpor</translation>
+        <translation>&amp;Transpor</translation>
     </message>
     <message>
         <source>&amp;Invert</source>
@@ -1705,7 +1534,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Convert to spreadsheet</source>
-        <translation type="obsolete">&amp;Converter para tabela</translation>
+        <translation>&amp;Converter para tabela</translation>
     </message>
     <message>
         <source>3D &amp;Wire Frame</source>
@@ -1724,16 +1553,8 @@ Deseja sobrescrevê-lo?</translation>
         <translation>&amp;Superfície de fios 3D</translation>
     </message>
     <message>
-        <source>QtiPlot - File openning error</source>
-        <translation type="obsolete">QtiPlot - Erro de abertura de arquivo</translation>
-    </message>
-    <message>
         <source>The file: &lt;b&gt; %1 &lt;/b&gt; doesn&apos;t exist!</source>
-        <translation type="obsolete">O arquivo: &lt;b&gt; %1 &lt;/b&gt; não existe!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Project Explorer</source>
-        <translation type="obsolete">QtiPlot - Explorador de proyeto</translation>
+        <translation>O arquivo: &lt;b&gt; %1 &lt;/b&gt; não existe!</translation>
     </message>
     <message>
         <source>Name</source>
@@ -1760,24 +1581,20 @@ Deseja sobrescrevê-lo?</translation>
         <translation>Rótulo</translation>
     </message>
     <message>
-        <source>QtiPlot - Results Log</source>
-        <translation type="obsolete">QtiPlot - Registro de Resultados</translation>
-    </message>
-    <message>
         <source>Disable &amp;tools</source>
         <translation>Desativar &amp;ferramentas</translation>
     </message>
     <message>
         <source>&amp;Zoom</source>
-        <translation type="obsolete">&amp;Zoom</translation>
+        <translation>&amp;Zoom</translation>
     </message>
     <message>
         <source>ALT+Z</source>
-        <translation type="obsolete">ALT+Z</translation>
+        <translation>ALT+Z</translation>
     </message>
     <message>
         <source>&amp;Data reader</source>
-        <translation type="obsolete">Leitor de &amp;dados</translation>
+        <translation>Leitor de &amp;dados</translation>
     </message>
     <message>
         <source>CTRL+D</source>
@@ -1789,7 +1606,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Select data range</source>
-        <translation type="obsolete">&amp;Selecionar faixa de dados</translation>
+        <translation>&amp;Selecionar faixa de dados</translation>
     </message>
     <message>
         <source>ALT+S</source>
@@ -1797,7 +1614,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>S&amp;creen reader</source>
-        <translation type="obsolete">Leitor de &amp;tela</translation>
+        <translation>Leitor de &amp;tela</translation>
     </message>
     <message>
         <source>Screen reader</source>
@@ -1821,7 +1638,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Draw &amp;Arrow/Line</source>
-        <translation type="obsolete">Desenhar flech&amp;a/linha</translation>
+        <translation>Desenhar flech&amp;a/linha</translation>
     </message>
     <message>
         <source>CTRL+ALT+L</source>
@@ -1837,15 +1654,15 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;FFT filter</source>
-        <translation type="obsolete">Filtro FF&amp;T</translation>
+        <translation>Filtro FF&amp;T</translation>
     </message>
     <message>
         <source>Set columns &amp;as</source>
-        <translation type="obsolete">Definir colun&amp;as como</translation>
+        <translation>Definir colun&amp;as como</translation>
     </message>
     <message>
         <source>&amp;Fill columns with</source>
-        <translation type="obsolete">&amp;Preencher colunas com</translation>
+        <translation>&amp;Preencher colunas com</translation>
     </message>
     <message>
         <source>&amp;Table</source>
@@ -1853,7 +1670,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Plot 3&amp;D</source>
-        <translation type="obsolete">Gráfico &amp;3D</translation>
+        <translation>Gráfico &amp;3D</translation>
     </message>
     <message>
         <source>&amp;Plot</source>
@@ -1861,11 +1678,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Normalize</source>
-        <translation type="obsolete">Normali&amp;zar</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Plot error</source>
-        <translation type="obsolete">QtiPlot - Erro ao plotar</translation>
+        <translation>Normali&amp;zar</translation>
     </message>
     <message>
         <source>You must select exactly one column for plotting!</source>
@@ -1873,7 +1686,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>This operation can not be performed on curves plotted from columns having a non-numerical format.</source>
-        <translation type="obsolete">Esta operação não pode ser realizada em curvas plotadas a partir de colunas com formato não numérico.</translation>
+        <translation>Esta operação não pode ser realizada em curvas plotadas a partir de colunas com formato não numérico.</translation>
     </message>
     <message>
         <source>Y Axis Title</source>
@@ -1885,7 +1698,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Please select a e column to plot!</source>
-        <translation type="obsolete">Selecione uma coluna e para plotar!</translation>
+        <translation>Selecione uma coluna e para plotar!</translation>
     </message>
     <message>
         <source>This functionality is not available for pie plots!</source>
@@ -1897,15 +1710,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>The selected error column is empty!</source>
-        <translation type="obsolete">A coluna de erro selecionada está vazia!</translation>
-    </message>
-    <message>
-        <source>The file: &lt;b&gt; %1 &lt;/b&gt; was not created using QtiPlot!</source>
-        <translation type="obsolete">O arquivo &lt;b&gt; %1 &lt;/b&gt; não foi criado usando o QtiPlot!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Open Project</source>
-        <translation type="obsolete">QtiPlot - Abrir projeto</translation>
+        <translation>A coluna de erro selecionada está vazia!</translation>
     </message>
     <message>
         <source>The file: &lt;b&gt;%1&lt;/b&gt; is the current file!</source>
@@ -1917,7 +1722,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>The file: &lt;b&gt;%1&lt;/b&gt; is not a QtiPlot or Origin project file!</source>
-        <translation type="obsolete">O arquivo &lt;b&gt; %1 &lt;/b&gt; não é um projeto do Origin ou QtiPlot!</translation>
+        <translation>O arquivo &lt;b&gt; %1 &lt;/b&gt; não é um projeto do Origin ou QtiPlot!</translation>
     </message>
     <message>
         <source>The file: &lt;b&gt; %1 &lt;/b&gt; &lt;p&gt;does not exist anymore!&lt;p&gt;It will be removed from the list.</source>
@@ -1925,7 +1730,7 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>The file: &lt;b&gt; %1 &lt;/b&gt; is the current file!</source>
-        <translation type="obsolete">O arquivo &lt;b&gt; %1 &lt;/b&gt; é o arquivo atual!</translation>
+        <translation>O arquivo &lt;b&gt; %1 &lt;/b&gt; é o arquivo atual!</translation>
     </message>
     <message>
         <source>Could not write to file: &lt;br&gt;&lt;h4&gt; %1 &lt;/h4&gt;&lt;p&gt;Please verify that you have the right to write to this location!</source>
@@ -1944,24 +1749,12 @@ Deseja sobrescrevê-lo?</translation>
         <translation>Escolha o nome do arquivo para salvar</translation>
     </message>
     <message>
-        <source>QtiPlot - Enter rows number</source>
-        <translation type="obsolete">QtiPlot - Introduza o número de linhas</translation>
-    </message>
-    <message>
         <source>Rows</source>
-        <translation type="obsolete">Linhas</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Enter columns number</source>
-        <translation type="obsolete">QtiPlot - Introduza o número de colunas</translation>
+        <translation>Linhas</translation>
     </message>
     <message>
         <source>Columns</source>
-        <translation type="obsolete">Colunas</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Column selection error</source>
-        <translation type="obsolete">QtiPlot - Erro na seleção de coluna</translation>
+        <translation>Colunas</translation>
     </message>
     <message>
         <source>Please select a column first!</source>
@@ -1969,27 +1762,27 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Line + s&amp;ymbol</source>
-        <translation type="obsolete">Linha + &amp;Símbolo</translation>
+        <translation>Linha + &amp;Símbolo</translation>
     </message>
     <message>
         <source>3D Ribbo&amp;n</source>
-        <translation type="obsolete">Fi&amp;ta 3D</translation>
+        <translation>Fi&amp;ta 3D</translation>
     </message>
     <message>
         <source>3D &amp;Bars</source>
-        <translation type="obsolete">&amp;Barras 3D</translation>
+        <translation>&amp;Barras 3D</translation>
     </message>
     <message>
         <source>3&amp;D Scatter</source>
-        <translation type="obsolete">Dispersão 3&amp;D</translation>
+        <translation>Dispersão 3&amp;D</translation>
     </message>
     <message>
         <source>3D &amp;Trajectory</source>
-        <translation type="obsolete">&amp;Trajetoria 3D</translation>
+        <translation>&amp;Trajetoria 3D</translation>
     </message>
     <message>
         <source>&amp;Stacked Histograms</source>
-        <translation type="obsolete">Hi&amp;stogramas Empilhados</translation>
+        <translation>Hi&amp;stogramas Empilhados</translation>
     </message>
     <message>
         <source>Cu&amp;t</source>
@@ -1997,27 +1790,27 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Past&amp;e</source>
-        <translation type="obsolete">Co&amp;lar</translation>
+        <translation>Co&amp;lar</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="obsolete">Nenhum</translation>
+        <translation>Nenhum</translation>
     </message>
     <message>
         <source>Set as</source>
-        <translation type="obsolete">Definir como</translation>
+        <translation>Definir como</translation>
     </message>
     <message>
         <source>Set column &amp;values...</source>
-        <translation type="obsolete">Definir &amp;valores das colunas...</translation>
+        <translation>Definir &amp;valores das colunas...</translation>
     </message>
     <message>
         <source>&amp;Fill column with</source>
-        <translation type="obsolete">Preenc&amp;her coluna com</translation>
+        <translation>Preenc&amp;her coluna com</translation>
     </message>
     <message>
         <source>&amp;Column</source>
-        <translation type="obsolete">&amp;Coluna</translation>
+        <translation>&amp;Coluna</translation>
     </message>
     <message>
         <source>Clea&amp;r</source>
@@ -2025,27 +1818,27 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Insert</source>
-        <translation type="obsolete">&amp;Inserir</translation>
+        <translation>&amp;Inserir</translation>
     </message>
     <message>
         <source>&amp;Add column</source>
-        <translation type="obsolete">Adicio&amp;nar coluna</translation>
+        <translation>Adicio&amp;nar coluna</translation>
     </message>
     <message>
         <source>&amp;Ascending</source>
-        <translation type="obsolete">&amp;Ascendente</translation>
+        <translation>&amp;Ascendente</translation>
     </message>
     <message>
         <source>&amp;Descending</source>
-        <translation type="obsolete">&amp;Descendente</translation>
+        <translation>&amp;Descendente</translation>
     </message>
     <message>
         <source>Sort Colu&amp;mn</source>
-        <translation type="obsolete">Ordemar Col&amp;una</translation>
+        <translation>Ordemar Col&amp;una</translation>
     </message>
     <message>
         <source>Pr&amp;operties</source>
-        <translation type="obsolete">Pr&amp;opriedades</translation>
+        <translation>Pr&amp;opriedades</translation>
     </message>
     <message>
         <source>Vectors &amp;XYXY</source>
@@ -2057,27 +1850,19 @@ Deseja sobrescrevê-lo?</translation>
     </message>
     <message>
         <source>Clea&amp;r Row</source>
-        <translation type="obsolete">Lim&amp;par linha</translation>
+        <translation>Lim&amp;par linha</translation>
     </message>
     <message>
         <source>&amp;Delete Row</source>
-        <translation type="obsolete">Excluir linha</translation>
+        <translation>Excluir linha</translation>
     </message>
     <message>
         <source>&amp;Worksheet</source>
         <translation>&amp;Planilha de trabalho</translation>
     </message>
     <message>
-        <source>QtiPlot - Empty plot</source>
-        <translation type="obsolete">QtiPlot - Gráfico vazio</translation>
-    </message>
-    <message>
         <source>There are actually  no curves on the active layer!</source>
-        <translation type="obsolete">Atualmente não existem curvas na camada ativa!</translation>
-    </message>
-    <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
+        <translation>Atualmente não existem curvas na camada ativa!</translation>
     </message>
     <message>
         <source>This will modify the data in the worksheets!
@@ -2099,7 +1884,7 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Click on plot or move cursor to display coordinates!</source>
-        <translation type="obsolete">Clique no gráfico ou mova o cursor para mostrar as coordenadas!</translation>
+        <translation>Clique no gráfico ou mova o cursor para mostrar as coordenadas!</translation>
     </message>
     <message>
         <source>There are no plot layers available in this window!</source>
@@ -2107,7 +1892,7 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Click on plot to display information!</source>
-        <translation type="obsolete">Clique no gráfico para mostrar a informação!</translation>
+        <translation>Clique no gráfico para mostrar a informação!</translation>
     </message>
     <message>
         <source>There are no plot layers available in this window.</source>
@@ -2135,11 +1920,11 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>&amp;Next</source>
-        <translation type="obsolete">&amp;Próximo</translation>
+        <translation>&amp;Próximo</translation>
     </message>
     <message>
         <source>&amp;Previous</source>
-        <translation type="obsolete">&amp;Anterior</translation>
+        <translation>&amp;Anterior</translation>
     </message>
     <message>
         <source>&amp;Properties...</source>
@@ -2155,19 +1940,19 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Não</source>
-        <translation type="obsolete">Não</translation>
+        <translation>Não</translation>
     </message>
     <message>
         <source>&amp;Delete Window</source>
-        <translation type="obsolete">Remover janela</translation>
+        <translation>Remover janela</translation>
     </message>
     <message>
         <source>D&amp;epending Plots</source>
-        <translation type="obsolete">Gráficos D&amp;ependentes</translation>
+        <translation>Gráficos D&amp;ependentes</translation>
     </message>
     <message>
         <source>D&amp;epending 3D Plots</source>
-        <translation type="obsolete">Gráficos 3D D&amp;ependentes</translation>
+        <translation>Gráficos 3D D&amp;ependentes</translation>
     </message>
     <message>
         <source>D&amp;epends on</source>
@@ -2175,31 +1960,31 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Function</source>
-        <translation type="obsolete">Função</translation>
+        <translation>Função</translation>
     </message>
     <message>
         <source>Re&amp;move pie curve</source>
-        <translation type="obsolete">Re&amp;mover curva tipo pizza</translation>
+        <translation>Re&amp;mover curva tipo pizza</translation>
     </message>
     <message>
         <source>Anal&amp;yse</source>
-        <translation type="obsolete">Anali&amp;zar</translation>
+        <translation>Anali&amp;zar</translation>
     </message>
     <message>
         <source>&amp;Paste layer</source>
-        <translation type="obsolete">Co&amp;lar canada</translation>
+        <translation>Co&amp;lar canada</translation>
     </message>
     <message>
         <source>&amp;Paste text</source>
-        <translation type="obsolete">Co&amp;lar texto</translation>
+        <translation>Co&amp;lar texto</translation>
     </message>
     <message>
         <source>&amp;Paste line/arrow</source>
-        <translation type="obsolete">Co&amp;lar linha/flecha</translation>
+        <translation>Co&amp;lar linha/flecha</translation>
     </message>
     <message>
         <source>&amp;Paste image</source>
-        <translation type="obsolete">Co&amp;lar imagem</translation>
+        <translation>Co&amp;lar imagem</translation>
     </message>
     <message>
         <source>&amp;Layer</source>
@@ -2239,7 +2024,7 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Clea&amp;r Rows</source>
-        <translation type="obsolete">Lim&amp;par linhas</translation>
+        <translation>Lim&amp;par linhas</translation>
     </message>
     <message>
         <source>&amp;Delete Rows</source>
@@ -2247,7 +2032,7 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>&amp;Plot 3D</source>
-        <translation type="obsolete">&amp;Gráfico 3D</translation>
+        <translation>&amp;Gráfico 3D</translation>
     </message>
     <message>
         <source>&amp;Matrix...</source>
@@ -2274,28 +2059,16 @@ Tem certeza que quer continuar?</translation>
         <translation>E&amp;xportar</translation>
     </message>
     <message>
-        <source>QtiPlot - Help Files Not Found!</source>
-        <translation type="obsolete">QtiPlot - Não foram encontrados arquivos de ajuda!</translation>
-    </message>
-    <message>
         <source>Please indicate the location of the help file!&lt;br&gt;&lt;br&gt;&lt;p&gt;The manual can be downloaded from the following internet address:&lt;/p&gt;&lt;p&gt;&lt;font color=blue&gt;&apos;http://soft.proindependent.com/manuals.html&apos;&lt;/font&gt;&lt;/p&gt;</source>
-        <translation type="obsolete">Por favor, indique a localização do arquivo de ajuda! &lt;br&gt;&lt;br&gt;&lt;p&gt;O manual pode ser obtido no seguinte endereço na internet: &lt;/p&gt;&lt;p&gt;&lt;font color=blue&gt;&apos;http://soft.proindependent.com/manuals.html&apos;&lt;/font&gt;&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Help Browser</source>
-        <translation type="obsolete">QtiPlot - Navegador de ajuda</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Edit function</source>
-        <translation type="obsolete">QtiPlot - Editar função</translation>
+        <translation>Por favor, indique a localização do arquivo de ajuda! &lt;br&gt;&lt;br&gt;&lt;p&gt;O manual pode ser obtido no seguinte endereço na internet: &lt;/p&gt;&lt;p&gt;&lt;font color=blue&gt;&apos;http://soft.proindependent.com/manuals.html&apos;&lt;/font&gt;&lt;/p&gt;</translation>
     </message>
     <message>
         <source>Curve:</source>
-        <translation type="obsolete">Curva:</translation>
+        <translation>Curva:</translation>
     </message>
     <message>
         <source>Import i&amp;mage...</source>
-        <translation type="obsolete">Importar ima&amp;gem...</translation>
+        <translation>Importar ima&amp;gem...</translation>
     </message>
     <message>
         <source>ALT+L</source>
@@ -2315,7 +2088,7 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Delete &amp;fit tables</source>
-        <translation type="obsolete">Apagar tabelas de rea&amp;ressão</translation>
+        <translation>Apagar tabelas de rea&amp;ressão</translation>
     </message>
     <message>
         <source>Add/Remove &amp;Curve...</source>
@@ -2335,7 +2108,7 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Add time stamp</source>
-        <translation type="obsolete">Adicionar estampa de hora</translation>
+        <translation>Adicionar estampa de hora</translation>
     </message>
     <message>
         <source>Ctrl+ALT+T</source>
@@ -2343,7 +2116,7 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Date &amp; Time </source>
-        <translation type="obsolete">Data &amp;e hora</translation>
+        <translation>Data &amp;e hora</translation>
     </message>
     <message>
         <source>ALT+I</source>
@@ -2399,11 +2172,11 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Column &amp;Options ...</source>
-        <translation type="obsolete">Opções de coluna...</translation>
+        <translation>Opções de coluna...</translation>
     </message>
     <message>
         <source>Set Column &amp;Values ...</source>
-        <translation type="obsolete">Definir &amp;valores das colunas...</translation>
+        <translation>Definir &amp;valores das colunas...</translation>
     </message>
     <message>
         <source>&amp;Remove Layer</source>
@@ -2411,7 +2184,7 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Edit 3D &amp;Surface</source>
-        <translation type="obsolete">Editar &amp;superfície 3D</translation>
+        <translation>Editar &amp;superfície 3D</translation>
     </message>
     <message>
         <source>&amp;Surface...</source>
@@ -2423,15 +2196,15 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Convert to &amp;matrix</source>
-        <translation type="obsolete">Converter em &amp;matriz</translation>
+        <translation>Converter em &amp;matriz</translation>
     </message>
     <message>
         <source>Sort Ta&amp;ble</source>
-        <translation type="obsolete">Ordemar ta&amp;bela</translation>
+        <translation>Ordemar ta&amp;bela</translation>
     </message>
     <message>
         <source>Sort Columns</source>
-        <translation type="obsolete">Ordemar col&amp;unas</translation>
+        <translation>Ordemar col&amp;unas</translation>
     </message>
     <message>
         <source>Co&amp;rrelate</source>
@@ -2455,11 +2228,11 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Ro&amp;w Numbers</source>
-        <translation type="obsolete">Número de &amp;linhas</translation>
+        <translation>Número de &amp;linhas</translation>
     </message>
     <message>
         <source>&amp;Random values</source>
-        <translation type="obsolete">Valores aleató&amp;rios</translation>
+        <translation>Valores aleató&amp;rios</translation>
     </message>
     <message>
         <source>&amp;None</source>
@@ -2482,52 +2255,40 @@ Tem certeza que quer continuar?</translation>
         <translation>&amp;Lorentziana...</translation>
     </message>
     <message>
-        <source>QtiPlot - Enter the number of peaks</source>
-        <translation type="obsolete">QtiPlot - Introduza o número de picos</translation>
-    </message>
-    <message>
         <source>Peaks</source>
         <translation>Picos</translation>
     </message>
     <message>
         <source>Move cursor and click to select a point and double-click/press &apos;Enter&apos; to set the position of a peak!</source>
-        <translation type="obsolete">Mova o cursor e clique para selecionar um ponto e dê um duplo clique ou tecle &apos;Enter&apos; para determinar a posição do pico!</translation>
+        <translation>Mova o cursor e clique para selecionar um ponto e dê um duplo clique ou tecle &apos;Enter&apos; para determinar a posição do pico!</translation>
     </message>
     <message>
         <source>Too many command line options (maximum accepted is 2)!</source>
-        <translation type="obsolete">Muitas opções de linha de comando (o máximo aceito são 2)!</translation>
+        <translation>Muitas opções de linha de comando (o máximo aceito são 2)!</translation>
     </message>
     <message>
         <source>&lt;b&gt; %1 &lt;/b&gt;: Unknown command line option or the file doesn&apos;t exist!</source>
-        <translation type="obsolete">&lt;b&gt; %1 &lt;/b&gt;: Opção de linha de comando desconhecida ou arquivo inexistente!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - untitled</source>
-        <translation type="obsolete">QtiPlot - Sem título</translation>
+        <translation>&lt;b&gt; %1 &lt;/b&gt;: Opção de linha de comando desconhecida ou arquivo inexistente!</translation>
     </message>
     <message>
         <source>&amp;Search for Updates</source>
-        <translation type="obsolete">P&amp;rocurar atualizações</translation>
-    </message>
-    <message>
-        <source>&amp;QtiPlot Homepage</source>
-        <translation type="obsolete">Página inicial do &amp;QtiPlot</translation>
+        <translation>P&amp;rocurar atualizações</translation>
     </message>
     <message>
         <source>Download &amp;manual</source>
-        <translation type="obsolete">Baixar &amp;manual</translation>
+        <translation>Baixar &amp;manual</translation>
     </message>
     <message>
         <source>&amp;Translations</source>
-        <translation type="obsolete">&amp;Traduções</translation>
+        <translation>&amp;Traduções</translation>
     </message>
     <message>
         <source>Make a &amp;donation</source>
-        <translation type="obsolete">Fazer uma &amp;doação</translation>
+        <translation>Fazer uma &amp;doação</translation>
     </message>
     <message>
         <source>Technical &amp;support</source>
-        <translation type="obsolete">Asis&amp;tência técnica</translation>
+        <translation>Asis&amp;tência técnica</translation>
     </message>
     <message>
         <source>Open a new project</source>
@@ -2567,7 +2328,7 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>English</source>
-        <translation type="obsolete">Português</translation>
+        <translation>Português</translation>
     </message>
     <message>
         <source>There are no available columns with plot designation set to Z!</source>
@@ -2575,31 +2336,23 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Plot 3D</source>
-        <translation type="obsolete">Gráfico 3D</translation>
+        <translation>Gráfico 3D</translation>
     </message>
     <message>
         <source>Determinant of </source>
         <translation>Determinante de </translation>
     </message>
     <message>
-        <source>QtiPlot - Open Template File</source>
-        <translation type="obsolete">QtiPlot - Abrir arquivo de modelo</translation>
-    </message>
-    <message>
         <source>graph1</source>
-        <translation type="obsolete">gráfico1</translation>
+        <translation>gráfico1</translation>
     </message>
     <message>
         <source>table1</source>
-        <translation type="obsolete">tabela1</translation>
+        <translation>tabela1</translation>
     </message>
     <message>
         <source>Matrix1</source>
-        <translation type="obsolete">Matriz1</translation>
-    </message>
-    <message>
-        <source>The file: &lt;b&gt;%1&lt;/b&gt; is not a QtiPlot template file!</source>
-        <translation type="obsolete">O arquivo: &lt;b&gt;%1&lt;/b&gt; não é um arquivo de modelo do QtiPlot!</translation>
+        <translation>Matriz1</translation>
     </message>
     <message>
         <source>Save Window As Template</source>
@@ -2607,7 +2360,7 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>There are actually no curves on the active layer!</source>
-        <translation type="obsolete">Não existem curvas na camada ativa!</translation>
+        <translation>Não existem curvas na camada ativa!</translation>
     </message>
     <message>
         <source>&amp;Insert Row</source>
@@ -2627,27 +2380,23 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Save as &amp;Template...</source>
-        <translation type="obsolete">Salvar como mode&amp;lo...</translation>
+        <translation>Salvar como mode&amp;lo...</translation>
     </message>
     <message>
         <source>&amp;Curves ...</source>
-        <translation type="obsolete">&amp;Curvas...</translation>
+        <translation>&amp;Curvas...</translation>
     </message>
     <message>
         <source>&amp;Scales...</source>
         <translation>E&amp;scalas...</translation>
     </message>
     <message>
-        <source>&amp;About QtiPlot</source>
-        <translation type="obsolete">&amp;Sobre oQtiPlot</translation>
-    </message>
-    <message>
         <source>New Table</source>
-        <translation type="obsolete">Nova tabela</translation>
+        <translation>Nova tabela</translation>
     </message>
     <message>
         <source>Save Project</source>
-        <translation type="obsolete">Salvar projeto</translation>
+        <translation>Salvar projeto</translation>
     </message>
     <message>
         <source>Open Te&amp;mplate...</source>
@@ -2655,15 +2404,15 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Open Template</source>
-        <translation type="obsolete">Abrir modelo</translation>
+        <translation>Abrir modelo</translation>
     </message>
     <message>
         <source>Save Window as Template</source>
-        <translation type="obsolete">Salvar janela como modelo</translation>
+        <translation>Salvar janela como modelo</translation>
     </message>
     <message>
         <source>&amp;Vectors XYXY</source>
-        <translation type="obsolete">&amp;Vetores XYXY</translation>
+        <translation>&amp;Vetores XYXY</translation>
     </message>
     <message>
         <source>Vectors XYXY</source>
@@ -2671,11 +2420,11 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>&amp;Curves...</source>
-        <translation type="obsolete">&amp;Curvas...</translation>
+        <translation>&amp;Curvas...</translation>
     </message>
     <message>
         <source>Box and Whiskers Plot</source>
-        <translation type="obsolete">Gráfico de caixa e barbas</translation>
+        <translation>Gráfico de caixa e barbas</translation>
     </message>
     <message>
         <source>&lt;b&gt; %1 &lt;/b&gt;: Wrong locale option or no translation available!</source>
@@ -2702,40 +2451,28 @@ Tem certeza que quer continuar?</translation>
         <translation>Nota</translation>
     </message>
     <message>
-        <source>QtiPlot - File opening error</source>
-        <translation type="obsolete">QtiPlot - Erro na abertura de arquivo</translation>
-    </message>
-    <message>
         <source>The file &lt;b&gt;%1&lt;/b&gt; is corrupted, but there exists a backup copy.&lt;br&gt;Do you want to open the backup instead?</source>
         <translation>O arquivo &lt;b&gt;%1&lt;/b&gt; está corrompido, mas existe uma cópia de segurança.&lt;br&gt;Deseja abrir a cópia em seu lugar?</translation>
     </message>
     <message>
-        <source>QtiPlot - Opening file</source>
-        <translation type="obsolete">QtiPlot - Abrindo arquivo</translation>
-    </message>
-    <message>
         <source>QtiPlot project</source>
-        <translation type="obsolete">Projeto do QtiPlot</translation>
+        <translation>Projeto do QtiPlot</translation>
     </message>
     <message>
         <source>Compressed QtiPlot project</source>
-        <translation type="obsolete">Projeto do QtiPlot comprimido</translation>
+        <translation>Projeto do QtiPlot comprimido</translation>
     </message>
     <message>
         <source>Origin project</source>
-        <translation type="obsolete">Projeto do Origin</translation>
+        <translation>Projeto do Origin</translation>
     </message>
     <message>
         <source>All files</source>
-        <translation type="obsolete">Todos os arquivos</translation>
-    </message>
-    <message>
-        <source>QtiPlot - File Backup Error</source>
-        <translation type="obsolete">QtiPlot - Erro na cópia de segurança</translation>
+        <translation>Todos os arquivos</translation>
     </message>
     <message>
         <source>Cannot make a backup copy of &lt;b&gt;%1&lt;/b&gt; (to %2).&lt;br&gt;If you ignore this, you rum  the risk of &lt;b&gt;data loss&lt;/b&gt;.</source>
-        <translation type="obsolete">Não foi possível fazer a cópia de segurança de &lt;b&gt;%1&lt;/b&gt; (a %2). &lt;br&gt;Se isto for ignorado os dados&lt;/b&gt; poderão ser &lt;b&gt;perdidos.</translation>
+        <translation>Não foi possível fazer a cópia de segurança de &lt;b&gt;%1&lt;/b&gt; (a %2). &lt;br&gt;Se isto for ignorado os dados&lt;/b&gt; poderão ser &lt;b&gt;perdidos.</translation>
     </message>
     <message>
         <source>The file: &lt;br&gt;&lt;b&gt;%1&lt;/b&gt; is opened in read-only mode</source>
@@ -2744,38 +2481,6 @@ Tem certeza que quer continuar?</translation>
     <message>
         <source>Save Project As</source>
         <translation>Salvar projeto como</translation>
-    </message>
-    <message>
-        <source>QtiPlot Matrix Template</source>
-        <translation type="obsolete">Modelo de matriz do QtiPlot</translation>
-    </message>
-    <message>
-        <source>QtiPlot 2D Plot Template</source>
-        <translation type="obsolete">Modelo de gráfico 2D do QtiPlot</translation>
-    </message>
-    <message>
-        <source>QtiPlot Table Template</source>
-        <translation type="obsolete">Modelo de tabela do QtiPlot</translation>
-    </message>
-    <message>
-        <source>QtiPlot 3D Surface Template</source>
-        <translation type="obsolete">Modelo de superfície 3D do QtiPlot</translation>
-    </message>
-    <message>
-        <source>QtiPlot - X Axis Title</source>
-        <translation type="obsolete">QtiPlot - Título do eixo X</translation>
-    </message>
-    <message>
-        <source>QtiPlot - e Axis Title</source>
-        <translation type="obsolete">QtiPlot - Título do eixo Y</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Right Axis Title</source>
-        <translation type="obsolete">QtiPlot - Título do eixo direito</translation>
-    </message>
-    <message>
-        <source>QtiPLot - Top Axis Title</source>
-        <translation type="obsolete">QtiPlot - Título do eixo superior</translation>
     </message>
     <message>
         <source>New &amp;Graph</source>
@@ -2803,7 +2508,7 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Create an empty note window</source>
-        <translation type="obsolete">Criar uma janela de notas vazia</translation>
+        <translation>Criar uma janela de notas vazia</translation>
     </message>
     <message>
         <source>Print window</source>
@@ -2835,7 +2540,7 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>The matrix &apos;%1&apos; already exists. It has been renamed &apos;%2&apos;.</source>
-        <translation type="obsolete">A matriz &apos;%1&apos; já existe.Foi renomeada &apos;%2&apos;.</translation>
+        <translation>A matriz &apos;%1&apos; já existe.Foi renomeada &apos;%2&apos;.</translation>
     </message>
     <message>
         <source>Please enter a valid name!</source>
@@ -2875,15 +2580,11 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Key_Delete</source>
-        <translation type="obsolete">Tecla_Apagar</translation>
+        <translation>Tecla_Apagar</translation>
     </message>
     <message>
         <source>Double-click on plot to select a data point!</source>
-        <translation type="obsolete">Dê um duplo clique no gráfico para selecionar um ponto!</translation>
-    </message>
-    <message>
-        <source>Sorry, QtiPlot couldn&apos;t start the default browser! Please start a browser manually and visit the following link</source>
-        <translation type="obsolete">Lamento, QtiPlot no podo iniciar o navegador padrão! Por favor, inicie o navegador manualmente e visite o seguinte link</translation>
+        <translation>Dê um duplo clique no gráfico para selecionar um ponto!</translation>
     </message>
     <message>
         <source>Scripting Console</source>
@@ -2922,24 +2623,16 @@ Tem certeza que quer continuar?</translation>
         <translation>Desenhar li&amp;nha</translation>
     </message>
     <message>
-        <source>QtiPlot - Python Script Window</source>
-        <translation type="obsolete">QtiPlot - janela de programação em Python</translation>
-    </message>
-    <message>
         <source>S&amp;cripting</source>
-        <translation type="obsolete">Programar</translation>
+        <translation>Programar</translation>
     </message>
     <message>
         <source>This operation cannot be performed on curves plotted from columns having a non-numerical format.</source>
-        <translation type="obsolete">Esta operação não pode ser realizada em curvas plotadas a partir de colunas com  formato numérico.</translation>
+        <translation>Esta operação não pode ser realizada em curvas plotadas a partir de colunas com  formato numérico.</translation>
     </message>
     <message>
         <source>&lt;h4&gt;There are no matrizes available in this project.&lt;/h4&gt;&lt;p&gt;&lt;h4&gt;Please create a matrix and try again!&lt;/h4&gt;</source>
-        <translation type="obsolete">&lt;h4&gt;Não existen matrizes disponíveis neste projeto.&lt;/h4&gt;&lt;p&gt;&lt;h4&gt;Por favor, crie uma matriz e tente novamente!&lt;/h4&gt;</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Renamed Window</source>
-        <translation type="obsolete">QtiPlot - Janela renomeada</translation>
+        <translation>&lt;h4&gt;Não existen matrizes disponíveis neste projeto.&lt;/h4&gt;&lt;p&gt;&lt;h4&gt;Por favor, crie uma matriz e tente novamente!&lt;/h4&gt;</translation>
     </message>
     <message>
         <source>Notes</source>
@@ -2947,19 +2640,15 @@ Tem certeza que quer continuar?</translation>
     </message>
     <message>
         <source>Text</source>
-        <translation type="obsolete">Texto</translation>
+        <translation>Texto</translation>
     </message>
     <message>
         <source>Data</source>
-        <translation type="obsolete">Dados</translation>
+        <translation>Dados</translation>
     </message>
     <message>
         <source>Comma Separated Values</source>
-        <translation type="obsolete">Valores separados por vírgula</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Import ASCII File</source>
-        <translation type="obsolete">QtiPlot - Importar arquivo ASCII</translation>
+        <translation>Valores separados por vírgula</translation>
     </message>
     <message>
         <source>The file &quot;%1&quot; was created using &quot;%2&quot; as scripting language.
@@ -2976,16 +2665,12 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
         <translation>Janela</translation>
     </message>
     <message>
-        <source>QtiPlot - Scripting Error</source>
-        <translation type="obsolete">QtiPlot - Erro de programação</translation>
-    </message>
-    <message>
         <source>Scripting language &quot;%1&quot; failed to initialize.</source>
         <translation>Falha na inicialização da linguagem de programação &quot;%1&quot;.</translation>
     </message>
     <message>
         <source>Get existing directory</source>
-        <translation type="obsolete">Obter diretório existente</translation>
+        <translation>Obter diretório existente</translation>
     </message>
     <message>
         <source>Choose a directory to export the graphs to</source>
@@ -2993,23 +2678,15 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     </message>
     <message>
         <source>Python Source</source>
-        <translation type="obsolete">Fonte Python</translation>
+        <translation>Fonte Python</translation>
     </message>
     <message>
         <source>All Files</source>
-        <translation type="obsolete">Todos os arquivos</translation>
+        <translation>Todos os arquivos</translation>
     </message>
     <message>
         <source>Save Notes As...</source>
-        <translation type="obsolete">Salvar notas como...</translation>
-    </message>
-    <message>
-        <source>QtiPlot 2D Graph Template</source>
-        <translation type="obsolete">Modelo para gráfico 2D do QtiPlot</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Row selection error</source>
-        <translation type="obsolete">QtiPlot - Erro na seleção de linha</translation>
+        <translation>Salvar notas como...</translation>
     </message>
     <message>
         <source>Please select a row first!</source>
@@ -3017,23 +2694,23 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     </message>
     <message>
         <source>X</source>
-        <translation type="obsolete">X</translation>
+        <translation>X</translation>
     </message>
     <message>
         <source>Y</source>
-        <translation type="obsolete">Y</translation>
+        <translation>Y</translation>
     </message>
     <message>
         <source>Z</source>
-        <translation type="obsolete">Z</translation>
+        <translation>Z</translation>
     </message>
     <message>
         <source>X Error</source>
-        <translation type="obsolete">Erro em X</translation>
+        <translation>Erro em X</translation>
     </message>
     <message>
         <source>Y Error</source>
-        <translation type="obsolete">Erro em Y</translation>
+        <translation>Erro em Y</translation>
     </message>
     <message>
         <source>&amp;Edit Function...</source>
@@ -3045,15 +2722,11 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     </message>
     <message>
         <source>Click on data point to display information!</source>
-        <translation type="obsolete">Clique no ponto para mostrar a informação!</translation>
+        <translation>Clique no ponto para mostrar a informação!</translation>
     </message>
     <message>
         <source>Images</source>
         <translation>imagens</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Insert image from file</source>
-        <translation type="obsolete">QtiPlot - Inserir imagem do arquivo</translation>
     </message>
     <message>
         <source>Empty 3D surface plots cannot be duplicated!</source>
@@ -3069,19 +2742,11 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     </message>
     <message>
         <source>&amp;Graph 3D</source>
-        <translation type="obsolete">&amp;Gráfico 3D</translation>
-    </message>
-    <message>
-        <source>Choose the location of the QtiPlot help folder!</source>
-        <translation type="obsolete">Escolha a localização da pasta de ajuda do QtiPlot!</translation>
+        <translation>&amp;Gráfico 3D</translation>
     </message>
     <message>
         <source>Open File</source>
-        <translation type="obsolete">Abrir arquivo</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Set the number of pixels to average</source>
-        <translation type="obsolete">QtiPlot - Selecione o número de pixels para fazer a média</translation>
+        <translation>Abrir arquivo</translation>
     </message>
     <message>
         <source>Number of averaged pixels</source>
@@ -3089,7 +2754,7 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     </message>
     <message>
         <source>Scripting &amp;Console</source>
-        <translation type="obsolete">&amp;Terminal de programação</translation>
+        <translation>&amp;Terminal de programação</translation>
     </message>
     <message>
         <source>Alt+G</source>
@@ -3097,7 +2762,7 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     </message>
     <message>
         <source>Alt+F4</source>
-        <translation type="obsolete">Alt+F4</translation>
+        <translation>Alt+F4</translation>
     </message>
     <message>
         <source>Ctrl+Shift+R</source>
@@ -3105,11 +2770,11 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     </message>
     <message>
         <source>Ctrl+Alt+O</source>
-        <translation type="obsolete">Ctrl+Alt+O</translation>
+        <translation>Ctrl+Alt+O</translation>
     </message>
     <message>
         <source>Recalculate</source>
-        <translation type="obsolete">Recalcular</translation>
+        <translation>Recalcular</translation>
     </message>
     <message>
         <source>Ctrl+Return</source>
@@ -3117,35 +2782,35 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     </message>
     <message>
         <source>&amp;Go to Row...</source>
-        <translation type="obsolete">Ir para a linha...</translation>
+        <translation>Ir para a linha...</translation>
     </message>
     <message>
         <source>Ctrl+Alt+G</source>
-        <translation type="obsolete">Ctrl+Alt+G</translation>
+        <translation>Ctrl+Alt+G</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="obsolete">Limp&amp;ar</translation>
+        <translation>Limp&amp;ar</translation>
     </message>
     <message>
         <source>&amp;X</source>
-        <translation type="obsolete">&amp;X</translation>
+        <translation>&amp;X</translation>
     </message>
     <message>
         <source>&amp;Y</source>
-        <translation type="obsolete">&amp;Y</translation>
+        <translation>&amp;Y</translation>
     </message>
     <message>
         <source>&amp;Z</source>
-        <translation type="obsolete">&amp;Z</translation>
+        <translation>&amp;Z</translation>
     </message>
     <message>
         <source>X E&amp;rror</source>
-        <translation type="obsolete">E&amp;rro em X</translation>
+        <translation>E&amp;rro em X</translation>
     </message>
     <message>
         <source>Y &amp;Error</source>
-        <translation type="obsolete">&amp;Erro em Y</translation>
+        <translation>&amp;Erro em Y</translation>
     </message>
     <message>
         <source>Search for &amp;Updates</source>
@@ -3153,11 +2818,11 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     </message>
     <message>
         <source>Scripting &amp;language</source>
-        <translation type="obsolete">&amp;Linguagem de programação</translation>
+        <translation>&amp;Linguagem de programação</translation>
     </message>
     <message>
         <source>&amp;Restart scripting</source>
-        <translation type="obsolete">&amp;Reiniciar programação</translation>
+        <translation>&amp;Reiniciar programação</translation>
     </message>
     <message>
         <source>E&amp;xecute</source>
@@ -3181,11 +2846,11 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     </message>
     <message>
         <source>&amp;Python Script Window</source>
-        <translation type="obsolete">Janela de programação &amp;Python</translation>
+        <translation>Janela de programação &amp;Python</translation>
     </message>
     <message>
         <source>F3</source>
-        <translation type="obsolete">F3</translation>
+        <translation>F3</translation>
     </message>
     <message>
         <source>&amp;Console</source>
@@ -3209,7 +2874,7 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     </message>
     <message>
         <source>Fit</source>
-        <translation type="obsolete">Regredir</translation>
+        <translation>Regredir</translation>
     </message>
     <message>
         <source>&amp;Find...</source>
@@ -3273,11 +2938,11 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     </message>
     <message>
         <source>Windows</source>
-        <translation type="obsolete">Janelas</translation>
+        <translation>Janelas</translation>
     </message>
     <message>
         <source>Folders</source>
-        <translation type="obsolete">Pastas</translation>
+        <translation>Pastas</translation>
     </message>
     <message>
         <source>Modified</source>
@@ -3292,20 +2957,12 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
         <translation>Nova Pasta</translation>
     </message>
     <message>
-        <source>QtiPlot - Delete folder?</source>
-        <translation type="obsolete">QtiPlot - Apagar pasta?</translation>
-    </message>
-    <message>
         <source>Delete folder &apos;%1&apos; and all the windows it contains?</source>
         <translation>Excluir a pasta &apos;%1&apos; e todas as janelas que contém?</translation>
     </message>
     <message>
         <source>Status</source>
         <translation>Status</translation>
-    </message>
-    <message>
-        <source>QtiPlot - No match found</source>
-        <translation type="obsolete">QtiPlot - Não foi encontrada coincidência</translation>
     </message>
     <message>
         <source>Sorry, no match found for string: &apos;%1&apos;</source>
@@ -3321,7 +2978,7 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     </message>
     <message>
         <source>Skipped Moving Folder</source>
-        <translation type="obsolete">Movimento de pasta cancelado</translation>
+        <translation>Movimento de pasta cancelado</translation>
     </message>
     <message>
         <source>The destination folder already contains a folder called &apos;%1&apos;! Folder skipped!</source>
@@ -3329,16 +2986,12 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     </message>
     <message>
         <source>Graph 3D</source>
-        <translation type="obsolete">Gráfico 3D</translation>
-    </message>
-    <message>
-        <source>QtiPlot - HTTP Get Version File</source>
-        <translation type="obsolete">QtiPlot - Obter arquivo de versão HTTP</translation>
+        <translation>Gráfico 3D</translation>
     </message>
     <message>
         <source>Cannot write file %1
 %2.</source>
-        <translation type="obsolete">Não foi possível escrever o arquivo %1
+        <translation>Não foi possível escrever o arquivo %1
 %2.</translation>
     </message>
     <message>
@@ -3346,40 +2999,20 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
         <translation>Erro ao obter versão de arquivo com HTTP: %1.</translation>
     </message>
     <message>
-        <source>QtiPlot - Updates Available</source>
-        <translation type="obsolete">QtiPlot - Atualizações disponíveis</translation>
-    </message>
-    <message>
-        <source>There is a newer version of QtiPlot (%1) available for download. Would you like to download it?</source>
-        <translation type="obsolete">Existe uma nova versão do QtiPlot (%1) disponível. Gostaria de baixá-la?</translation>
-    </message>
-    <message>
-        <source>QtiPlot - No Updates Available</source>
-        <translation type="obsolete">QtiPlot - Não existen atualizações disponíveis</translation>
-    </message>
-    <message>
         <source>No updates available. Your current version %1 is the last version available!</source>
-        <translation type="obsolete">Não existem atualizações disponíveis. Sua versão actual %1 á a última versão disponível!</translation>
+        <translation>Não existem atualizações disponíveis. Sua versão actual %1 á a última versão disponível!</translation>
     </message>
     <message>
         <source>This will clear the contents of all the data associated with the table. Are you sure?</source>
         <translation>Isto apagará os conteúdos de todos os dados associados com a tabela. Está certo disto?</translation>
     </message>
     <message>
-        <source>QtiPlot - Enter row number</source>
-        <translation type="obsolete">QtiPlot - Introduza o número da linha</translation>
-    </message>
-    <message>
         <source>Row</source>
-        <translation type="obsolete">Linha</translation>
+        <translation>Linha</translation>
     </message>
     <message>
         <source>Matrix Plot</source>
         <translation>Gráfico de matriz</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Script Window</source>
-        <translation type="obsolete">QtiPlot - Janela de programação</translation>
     </message>
     <message>
         <source>The file: &lt;p&gt;&lt;b&gt; %1 &lt;/b&gt;&lt;p&gt; is the current file!</source>
@@ -3398,20 +3031,12 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
         <translation>Escalas &amp;horizontais</translation>
     </message>
     <message>
-        <source>QtiPlot - Help Profile Not Found!</source>
-        <translation type="obsolete">QtiPlot - Não foi encontrado o perfil de ajuda!</translation>
-    </message>
-    <message>
-        <source>The assistant could not start because the file &lt;b&gt;%1&lt;/b&gt; was not found in the help file directory!&lt;p&gt;This file is provided with the QtiPlot manual which can be downloaded from the following internet address:&lt;/p&gt;&lt;p&gt;&lt;font color=blue&gt;&apos;http://soft.proindependent.com/manuals.html&apos;&lt;/font&gt;&lt;/p&gt;</source>
-        <translation type="obsolete">O assistente não pode ser iniciado porque o arquivo &lt;b&gt;%1&lt;/b&gt; não se encontra na pasta de ajuda!&lt;p&gt;Este arquivo é distribuído com o manual do QtiPlot que pode ser baixado do seguinte endereço:&lt;/p&gt;&lt;p&gt;&lt;font color=blue&gt;&apos;http://soft.proindependent.com/manuals.html&apos;&lt;/font&gt;&lt;/p&gt;</translation>
-    </message>
-    <message>
         <source>Ctrl+K</source>
         <translation>Ctrl+K</translation>
     </message>
     <message>
         <source>Ctrl+Alt+K</source>
-        <translation type="obsolete">Ctrl+Alt+K</translation>
+        <translation>Ctrl+Alt+K</translation>
     </message>
     <message>
         <source>Automatic Layout</source>
@@ -3419,7 +3044,7 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     </message>
     <message>
         <source>Alt+Q</source>
-        <translation type="obsolete">Alt+Q</translation>
+        <translation>Alt+Q</translation>
     </message>
     <message>
         <source>Contour - &amp;Color Fill</source>
@@ -3435,7 +3060,7 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     </message>
     <message>
         <source>Script Window</source>
-        <translation type="obsolete">Janela de programação</translation>
+        <translation>Janela de programação</translation>
     </message>
     <message>
         <source>Add Layer</source>
@@ -3496,22 +3121,22 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     <message>
         <source>&amp;Next</source>
         <comment>Next window</comment>
-        <translation type="obsolete">&amp;Próxima</translation>
+        <translation>&amp;Próxima</translation>
     </message>
     <message>
         <source>F5</source>
         <comment>Shortcut for next window</comment>
-        <translation type="obsolete">F5</translation>
+        <translation>F5</translation>
     </message>
     <message>
         <source>&amp;Previous</source>
         <comment>Janela anterior</comment>
-        <translation type="obsolete">&amp;Anterior</translation>
+        <translation>&amp;Anterior</translation>
     </message>
     <message>
         <source>F6</source>
         <comment>Atalho para a janela anterior</comment>
-        <translation type="obsolete">F6</translation>
+        <translation>F6</translation>
     </message>
     <message>
         <source>Disable &amp;Tools</source>
@@ -3547,11 +3172,11 @@ Varias partes deste arquivo podem não ser apresentadas como o esperado.</transl
     </message>
     <message>
         <source>Set Columns &amp;As</source>
-        <translation type="obsolete">&amp;Definir colunas como</translation>
+        <translation>&amp;Definir colunas como</translation>
     </message>
     <message>
         <source>&amp;Fill Columns With</source>
-        <translation type="obsolete">&amp;Preencher colunas com</translation>
+        <translation>&amp;Preencher colunas com</translation>
     </message>
     <message>
         <source>&amp;FFT Filter</source>
@@ -3601,15 +3226,15 @@ a primeira representa o sinal e a segunda a função resposta!</translation>
     </message>
     <message>
         <source>Set As</source>
-        <translation type="obsolete">Definir como</translation>
+        <translation>Definir como</translation>
     </message>
     <message>
         <source>&amp;Fill Column With</source>
-        <translation type="obsolete">Preencher coluna com</translation>
+        <translation>Preencher coluna com</translation>
     </message>
     <message>
         <source>&amp;Add Column</source>
-        <translation type="obsolete">Adicio&amp;nar coluna</translation>
+        <translation>Adicio&amp;nar coluna</translation>
     </message>
     <message>
         <source>Could not write to file: &lt;h4&gt;%1&lt;/h4&gt;&lt;p&gt;Please verify that you have the right to write to this location or that the file is not being used by another application!</source>
@@ -3617,7 +3242,7 @@ a primeira representa o sinal e a segunda a função resposta!</translation>
     </message>
     <message>
         <source>Released</source>
-        <translation type="obsolete">Atualizado em</translation>
+        <translation>Atualizado em</translation>
     </message>
     <message>
         <source>Re&amp;move Pie Curve</source>
@@ -3645,7 +3270,7 @@ a primeira representa o sinal e a segunda a função resposta!</translation>
     </message>
     <message>
         <source>The assistant could not start because the file &lt;b&gt;%1&lt;/b&gt; was not found in the help file directory!</source>
-        <translation type="obsolete">O assistente não pode ser iniciado porque o arquivo &lt;b&gt;%1&lt;/b&gt; não foi encontrado na pasta de ajuda!</translation>
+        <translation>O assistente não pode ser iniciado porque o arquivo &lt;b&gt;%1&lt;/b&gt; não foi encontrado na pasta de ajuda!</translation>
     </message>
     <message>
         <source>Please indicate the location of the help file!</source>
@@ -3727,7 +3352,7 @@ a primeira representa o sinal e a segunda a função resposta!</translation>
     </message>
     <message>
         <source>Add Column</source>
-        <translation type="obsolete">Adicionar coluna</translation>
+        <translation>Adicionar coluna</translation>
     </message>
     <message>
         <source>&amp;View Pixel Line Profile</source>
@@ -3743,7 +3368,7 @@ a primeira representa o sinal e a segunda a função resposta!</translation>
     </message>
     <message>
         <source>&amp;Convert to Spreadsheet</source>
-        <translation type="obsolete">&amp;Converter em planilha</translation>
+        <translation>&amp;Converter em planilha</translation>
     </message>
     <message>
         <source>Convert to &amp;Matrix</source>
@@ -3755,7 +3380,7 @@ a primeira representa o sinal e a segunda a função resposta!</translation>
     </message>
     <message>
         <source>&amp;Random Values</source>
-        <translation type="obsolete">Valores aleató&amp;rios</translation>
+        <translation>Valores aleató&amp;rios</translation>
     </message>
     <message>
         <source>Report a &amp;Bug</source>
@@ -3910,10 +3535,6 @@ a primeira representa o sinal e a segunda a função resposta!</translation>
         <translation>Chão vazio</translation>
     </message>
     <message>
-        <source>QtiPlot - Help</source>
-        <translation type="obsolete">QtiPlot - Ajuda</translation>
-    </message>
-    <message>
         <source>SciDAVis - untitled</source>
         <translation>SciDAVis - sem título</translation>
     </message>
@@ -3959,7 +3580,7 @@ a primeira representa o sinal e a segunda a função resposta!</translation>
     </message>
     <message>
         <source>SciDAVis does not support QtiPlot project files from versions later than 0.9.0.</source>
-        <translation>SciDAVIs não suporta arquivos de projeto do Qtiplot de versões posteriores à 0.9.0. </translation>
+        <translation>SciDAVis não suporta arquivos de projeto do Qtiplot de versões posteriores à 0.9.0. </translation>
     </message>
     <message>
         <source>SciDAVis</source>
@@ -4041,7 +3662,7 @@ a primeira representa o sinal e a segunda a função resposta!</translation>
     </message>
     <message>
         <source>About SciDAVis</source>
-        <translation type="obsolete">Sobre o SciDAVis</translation>
+        <translation>Sobre o SciDAVis</translation>
     </message>
     <message>
         <source>&amp;View Pixel Line profile</source>
@@ -4053,11 +3674,11 @@ a primeira representa o sinal e a segunda a função resposta!</translation>
     </message>
     <message>
         <source>This file is provided with the SciDAVis manual which can be downloaded from the following internet address:</source>
-        <translation type="obsolete">Este arquivo vem junto com omanual do SciDAVis, o qual pode ser baixado da seguinte localização na internet:</translation>
+        <translation>Este arquivo vem junto com omanual do SciDAVis, o qual pode ser baixado da seguinte localização na internet:</translation>
     </message>
     <message>
         <source>Import image...</source>
-        <translation type="obsolete">Importar imagem...</translation>
+        <translation>Importar imagem...</translation>
     </message>
     <message>
         <source>Do you want SciDAVis to guess the best position for the new layer?
@@ -4079,7 +3700,7 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
     </message>
     <message>
         <source>&amp;Go to Cell...</source>
-        <translation type="obsolete">&amp;Ir para a célula...</translation>
+        <translation>&amp;Ir para a célula...</translation>
     </message>
     <message>
         <source>&amp;SciDAVis Homepage</source>
@@ -4167,7 +3788,7 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
     </message>
     <message>
         <source>can be any .sciprj, .sciprj.gz, .qti, qti.gz, .opj, .ogm, .ogw, .ogg, .py or ASCII file</source>
-        <translation type="obsolete">pode ser qualquer arquivo .sciprj, .sciprj.gz, .qti, qti.gz, .opj, .ogm, .ogw, .ogg, .py ou ASCII</translation>
+        <translation>pode ser qualquer arquivo .sciprj, .sciprj.gz, .qti, qti.gz, .opj, .ogm, .ogw, .ogg, .py ou ASCII</translation>
     </message>
     <message>
         <source>SciDAVis - Help</source>
@@ -4235,15 +3856,15 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
     </message>
     <message>
         <source>Go to Cell</source>
-        <translation type="obsolete">Ir para a célula</translation>
+        <translation>Ir para a célula</translation>
     </message>
     <message>
         <source>Enter row</source>
-        <translation type="obsolete">Inserir linha</translation>
+        <translation>Inserir linha</translation>
     </message>
     <message>
         <source>Enter column</source>
-        <translation type="obsolete">Inserir coluna</translation>
+        <translation>Inserir coluna</translation>
     </message>
     <message>
         <source>You need at least two columns for this operation!</source>
@@ -4259,7 +3880,7 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
     </message>
     <message>
         <source>You need to define a e column first!</source>
-        <translation type="obsolete">É necessário definir uma coluna e primeiro!</translation>
+        <translation>É necessário definir uma coluna e primeiro!</translation>
     </message>
     <message>
         <source>New Aspect</source>
@@ -4355,11 +3976,11 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
     </message>
     <message>
         <source>Enter rows number</source>
-        <translation type="obsolete">Introduza o número de linhas</translation>
+        <translation>Introduza o número de linhas</translation>
     </message>
     <message>
         <source>Enter columns number</source>
-        <translation type="obsolete">Introduza o número de colunas</translation>
+        <translation>Introduza o número de colunas</translation>
     </message>
     <message>
         <source>Column selection error</source>
@@ -4403,7 +4024,7 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
     </message>
     <message>
         <source>Help Profile Not Found!</source>
-        <translation type="obsolete">Não foi encontrado o perfil de ajuda!</translation>
+        <translation>Não foi encontrado o perfil de ajuda!</translation>
     </message>
     <message>
         <source>Edit function</source>
@@ -4423,7 +4044,7 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
     </message>
     <message>
         <source>File backup error</source>
-        <translation type="obsolete">Erro na cópia de segurança</translation>
+        <translation>Erro na cópia de segurança</translation>
     </message>
     <message>
         <source>File save error</source>
@@ -4464,7 +4085,7 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
     </message>
     <message>
         <source>No updates available. Your are already running the latest version.</source>
-        <translation type="obsolete">Não existem atualizações disponíveis. Sua versão atual é a última versão disponível.</translation>
+        <translation>Não existem atualizações disponíveis. Sua versão atual é a última versão disponível.</translation>
     </message>
     <message>
         <source>Invalid version file</source>
@@ -4516,7 +4137,7 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
     </message>
     <message>
         <source>SciDAVis currently does not support Origin import. If you are interested in reviving an maintaining an Origin import filter, contact the developers.</source>
-        <translation type="obsolete">Atualmente o SciDAVis não oferece suporte à importação do Origin. Se você tem interesse em reavivar e manter um filtro de importação do Origin contate os desenvolvedores.</translation>
+        <translation>Atualmente o SciDAVis não oferece suporte à importação do Origin. Se você tem interesse em reavivar e manter um filtro de importação do Origin contate os desenvolvedores.</translation>
     </message>
     <message>
         <source>zlib can&apos;t open %1.</source>
@@ -4544,7 +4165,7 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
     </message>
     <message>
         <source>F</source>
-        <translation type="obsolete">F</translation>
+        <translation>F</translation>
     </message>
     <message>
         <source>Error importing image</source>
@@ -4568,7 +4189,7 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
     </message>
     <message>
         <source>Cannot make a backup copy of &lt;b&gt;%1&lt;/b&gt; (to %2).&lt;br&gt;If you ignore this, you run the risk of &lt;b&gt;data loss&lt;/b&gt;.</source>
-        <translation type="obsolete">Não foi possível fazer uma cópia de segurança de &lt;b&gt;%1&lt;/b&gt; (para %2).&lt;br&gt;Se vocè ignorar isto, correrá o risco de &lt;b&gt;perder os dados&lt;/b&gt;.</translation>
+        <translation>Não foi possível fazer uma cópia de segurança de &lt;b&gt;%1&lt;/b&gt; (para %2).&lt;br&gt;Se vocè ignorar isto, correrá o risco de &lt;b&gt;perder os dados&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>You need to define a Y column first!</source>
@@ -4612,15 +4233,11 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
     <name>AsciiTableImportFilter</name>
     <message>
         <source>Table</source>
-        <translation type="obsolete">Tabela</translation>
+        <translation>Tabela</translation>
     </message>
 </context>
 <context>
     <name>AssociationsDialog</name>
-    <message>
-        <source>QtiPlot - Plot Associations</source>
-        <translation type="obsolete">QtiPlot - Associações de gráficos</translation>
-    </message>
     <message>
         <source>Spreadsheet: </source>
         <translation>Planilha: </translation>
@@ -4682,10 +4299,6 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
 </context>
 <context>
     <name>AxesDialog</name>
-    <message>
-        <source>QtiPlot - General Plot Options</source>
-        <translation type="obsolete">QtiPlot - Opções gerais de gráfico</translation>
-    </message>
     <message>
         <source>&amp;Apply</source>
         <translation>&amp;Aplicar</translation>
@@ -4916,23 +4529,23 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
     </message>
     <message>
         <source>Background</source>
-        <translation type="obsolete">Fundo</translation>
+        <translation>Fundo</translation>
     </message>
     <message>
         <source>Opacity</source>
-        <translation type="obsolete">Opacidade</translation>
+        <translation>Opacidade</translation>
     </message>
     <message>
         <source>Canvas Color</source>
-        <translation type="obsolete">Cor de fundo</translation>
+        <translation>Cor de fundo</translation>
     </message>
     <message>
         <source>Border Width</source>
-        <translation type="obsolete">Largura da borda</translation>
+        <translation>Largura da borda</translation>
     </message>
     <message>
         <source>Border Color</source>
-        <translation type="obsolete">Cor da borda</translation>
+        <translation>Cor da borda</translation>
     </message>
     <message>
         <source>Draw backbones</source>
@@ -4952,7 +4565,7 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
     </message>
     <message>
         <source>Apply to all layers</source>
-        <translation type="obsolete">Aplicar a todas as camadas</translation>
+        <translation>Aplicar a todas as camadas</translation>
     </message>
     <message>
         <source>General</source>
@@ -4975,24 +4588,8 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
         <translation>Científico: 10^2</translation>
     </message>
     <message>
-        <source>QtiPlot - Start limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite inicial</translation>
-    </message>
-    <message>
-        <source>QtiPlot - End limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite final</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Step input error</source>
-        <translation type="obsolete">QtiPlot - Erro ao inserir passo</translation>
-    </message>
-    <message>
         <source>Please enter a positive step value!</source>
         <translation>Por favor, forneça um valor de passo positivo!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Formula input error</source>
-        <translation type="obsolete">QtiPlot - Erro ao inserir fórmula</translation>
     </message>
     <message>
         <source>Valid variables are &apos;x&apos; for Top/Bottom axes and &apos;y&apos; for Left/Right axes!</source>
@@ -5066,7 +4663,7 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
     </message>
     <message>
         <source>verde</source>
-        <translation type="obsolete">verde</translation>
+        <translation>verde</translation>
     </message>
     <message>
         <source>blue</source>
@@ -5180,10 +4777,6 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
         <translation>E&amp;scalar Cores</translation>
     </message>
     <message>
-        <source>QtiPlot - Input Error</source>
-        <translation type="obsolete">QtiPlot - Erro de entrada</translation>
-    </message>
-    <message>
         <source>Sorry, you cannot edit this value!</source>
         <translation>Lamento, você não pode editar este valor!</translation>
     </message>
@@ -5200,58 +4793,58 @@ Aviso: esta operação irá reorganizar as camadas existentes!</translation>
     <name>Column</name>
     <message>
         <source>column type missing</source>
-        <translation type="obsolete">falta o tipo de coluna</translation>
+        <translation>falta o tipo de coluna</translation>
     </message>
     <message>
         <source>column type invalid</source>
-        <translation type="obsolete">tipo de coluna inválido</translation>
+        <translation>tipo de coluna inválido</translation>
     </message>
     <message>
         <source>column mode missing</source>
-        <translation type="obsolete">falta modo de coluna</translation>
+        <translation>falta modo de coluna</translation>
     </message>
     <message>
         <source>column mode invalid</source>
-        <translation type="obsolete">modo invállido para a coluna</translation>
+        <translation>modo invállido para a coluna</translation>
     </message>
     <message>
         <source>column type or mode invalid</source>
-        <translation type="obsolete">tipo ou modo de coluna inválido</translation>
+        <translation>tipo ou modo de coluna inválido</translation>
     </message>
     <message>
         <source>column plot designation invalid</source>
-        <translation type="obsolete">coluna inválida para o gráfico designado</translation>
+        <translation>coluna inválida para o gráfico designado</translation>
     </message>
     <message>
         <source>unknown element &apos;%1&apos;</source>
-        <translation type="obsolete">elemento &apos;%1&apos; desconhecido</translation>
+        <translation>elemento &apos;%1&apos; desconhecido</translation>
     </message>
     <message>
         <source>no column element found</source>
-        <translation type="obsolete">nenhum elemento de coluna encontrado</translation>
+        <translation>nenhum elemento de coluna encontrado</translation>
     </message>
     <message>
         <source>invalid or missing start or end row</source>
-        <translation type="obsolete">início ou fim de linha inválido ou faltando</translation>
+        <translation>início ou fim de linha inválido ou faltando</translation>
     </message>
     <message>
         <source>invalid or missing row type</source>
-        <translation type="obsolete">tipo de linha inválido ou faltando</translation>
+        <translation>tipo de linha inválido ou faltando</translation>
     </message>
     <message>
         <source>invalid or missing row index</source>
-        <translation type="obsolete">índice de linha inválido ou faltando</translation>
+        <translation>índice de linha inválido ou faltando</translation>
     </message>
     <message>
         <source>invalid row value</source>
-        <translation type="obsolete">valor inválido de linha</translation>
+        <translation>valor inválido de linha</translation>
     </message>
 </context>
 <context>
     <name>ColumnStringIO</name>
     <message>
         <source>as string</source>
-        <translation type="obsolete">como cadeia de caracteres</translation>
+        <translation>como cadeia de caracteres</translation>
     </message>
 </context>
 <context>
@@ -5271,10 +4864,6 @@ Os seguintes códigos podem ser usados:
 0-9eE.+-</source>
         <translation>O separador não pode conter os seguintes caracteres: 
 0-9eE.+-</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Choose default settings</source>
-        <translation type="obsolete">QtiPlot - Escolher configurações padão</translation>
     </message>
     <message>
         <source>General</source>
@@ -5681,10 +5270,6 @@ Os seguintes códigos podem ser usados:
         <translation>Cor dos picos</translation>
     </message>
     <message>
-        <source>QtiPlot - Import options error</source>
-        <translation type="obsolete">QtiPlot - Erro nas opções de importação</translation>
-    </message>
-    <message>
         <source>The separator must not contain the following characters: 0-9eE.+-</source>
         <translation>O separador não pode conter os seguintes caracteres: 0-9eE.+-</translation>
     </message>
@@ -5706,7 +5291,7 @@ Os seguintes códigos podem ser usados:
     </message>
     <message>
         <source>Update separators in Tables/Matrices</source>
-        <translation type="obsolete">Atualizar os separadores nas tabelas/matrizes</translation>
+        <translation>Atualizar os separadores nas tabelas/matrizes</translation>
     </message>
     <message>
         <source>Use group separator</source>
@@ -5716,7 +5301,7 @@ Os seguintes códigos podem ser usados:
     </message>
     <message>
         <source>Number of Decimal Digits</source>
-        <translation type="obsolete">Número de digitos decimais</translation>
+        <translation>Número de digitos decimais</translation>
     </message>
     <message>
         <source>default</source>
@@ -5789,124 +5374,124 @@ Os seguintes códigos podem ser usados:
     <name>ControlTabs</name>
     <message>
         <source>Control Tabs</source>
-        <translation type="obsolete">Abas de controle</translation>
+        <translation>Abas de controle</translation>
     </message>
     <message>
         <source>Description</source>
-        <translation type="obsolete">Descrição</translation>
+        <translation>Descrição</translation>
     </message>
     <message>
         <source>go to previous column</source>
-        <translation type="obsolete">ir para a coluna anterior</translation>
+        <translation>ir para a coluna anterior</translation>
     </message>
     <message>
         <source>...</source>
-        <translation type="obsolete">...</translation>
+        <translation>...</translation>
     </message>
     <message>
         <source>go to next column</source>
-        <translation type="obsolete">ir para a próxima coluna</translation>
+        <translation>ir para a próxima coluna</translation>
     </message>
     <message>
         <source>Appl&amp;y</source>
-        <translation type="obsolete">Apl&amp;icar</translation>
+        <translation>Apl&amp;icar</translation>
     </message>
     <message>
         <source>Name:</source>
-        <translation type="obsolete">Nome:</translation>
+        <translation>Nome:</translation>
     </message>
     <message>
         <source>Comment:</source>
-        <translation type="obsolete">Comentário:</translation>
+        <translation>Comentário:</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="obsolete">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Apply new type and format to all selected columns&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Aplicar novo tipo e formato para todas as colunas selecionadas&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Type:</source>
-        <translation type="obsolete">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Select the column type&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Selecione o tipo de coluna&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Format:</source>
-        <translation type="obsolete">Formato:</translation>
+        <translation>Formato:</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Choose the display format&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Escolha o formato a ser mostrado&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Decimal Digits:</source>
-        <translation type="obsolete">Casas decimais</translation>
+        <translation>Casas decimais</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Enter the number of displayed decimal digits&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Insira o número de casas decimais que devem ser mostradas&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Numbers are</source>
-        <translation type="obsolete">Números são</translation>
+        <translation>Números são</translation>
     </message>
     <message>
         <source>since</source>
-        <translation type="obsolete">desde</translation>
+        <translation>desde</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Information about the selected type and format&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Informações sobre tipo e formato selecionado&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Formula</source>
-        <translation type="obsolete">Fórmula</translation>
+        <translation>Fórmula</translation>
     </message>
     <message>
         <source>Formula:</source>
-        <translation type="obsolete">Fórmula</translation>
+        <translation>Fórmula</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Apply the formula to all selected cells&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Aplicar fórmula em todas as células selecionadas&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
@@ -5916,7 +5501,7 @@ p, li { white-space: pre-wrap; }
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Select a column reference to insert into the formula&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Selecione uma coluna de referência para inserir na fórmula&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
@@ -5926,21 +5511,21 @@ p, li { white-space: pre-wrap; }
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Insert the column reference into the formula&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Insira a coluna de referência na fórmula&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Add</source>
-        <translation type="obsolete">Adicionar</translation>
+        <translation>Adicionar</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Select a function to insert into the formula&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Selecione uma função para inserir na fórmula&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
@@ -5951,7 +5536,7 @@ p, li { white-space: pre-wrap; }
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Bitstream Vera Sans&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Sans Serif&apos;;&quot;&gt;Insert the function into the formula&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Bitstream Vera Sans&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -5963,10 +5548,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Convolution</source>
         <translation>Convolução</translation>
-    </message>
-    <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
     </message>
     <message>
         <source>Error</source>
@@ -6010,10 +5591,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Correlation</source>
         <translation>Correlação</translation>
-    </message>
-    <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
     </message>
     <message>
         <source>Error</source>
@@ -6073,10 +5650,6 @@ p, li { white-space: pre-wrap; }
 </context>
 <context>
     <name>CurvesDialog</name>
-    <message>
-        <source>QtiPlot - Add/Remove curves</source>
-        <translation type="obsolete">QtiPlot - Adicionar/Remover curvas</translation>
-    </message>
     <message>
         <source>New curves style</source>
         <translation>Novo estilo de curvas</translation>
@@ -6205,24 +5778,12 @@ p, li { white-space: pre-wrap; }
         <translation>Selecione um ponto e dê um duplo clique para removê-lo!</translation>
     </message>
     <message>
-        <source>QtiPlot - Remove point error</source>
-        <translation type="obsolete">QtiPlot - Remover erro do  ponto</translation>
-    </message>
-    <message>
         <source>Sorry, but removing points of a function is not possible.</source>
         <translation>Desculpe, mas não é possível remover pontos de uma função.</translation>
     </message>
     <message>
-        <source>QtiPlot - Move point error</source>
-        <translation type="obsolete">QtiPlot - Erro ao mover ponto</translation>
-    </message>
-    <message>
         <source>Sorry, but moving points of a function is not possible.</source>
         <translation>Desculpe, mas não é possível mover pontos de uma função. </translation>
-    </message>
-    <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
     </message>
     <message>
         <source>This operation cannot be performed on curves plotted from columns having a non-numerical format.</source>
@@ -6294,57 +5855,53 @@ p, li { white-space: pre-wrap; }
     <name>DimensionsDialog</name>
     <message>
         <source>Dialog</source>
-        <translation type="obsolete">Diálogo</translation>
+        <translation>Diálogo</translation>
     </message>
     <message>
         <source>Rows</source>
-        <translation type="obsolete">Linhas</translation>
+        <translation>Linhas</translation>
     </message>
     <message>
         <source>Columns</source>
-        <translation type="obsolete">Colunas</translation>
+        <translation>Colunas</translation>
     </message>
 </context>
 <context>
     <name>Double2StringFilter</name>
     <message>
         <source>missing or invalid format attribute(s)</source>
-        <translation type="obsolete">falta(m) atributo(s) ou estão em formato inválido</translation>
+        <translation>falta(m) atributo(s) ou estão em formato inválido</translation>
     </message>
 </context>
 <context>
     <name>EpsExportDialog</name>
     <message>
         <source>Orientation</source>
-        <translation type="obsolete">Orientação</translation>
+        <translation>Orientação</translation>
     </message>
     <message>
         <source>Page Size</source>
-        <translation type="obsolete">Tamanho da página</translation>
+        <translation>Tamanho da página</translation>
     </message>
     <message>
         <source>&amp;Print in color if available</source>
-        <translation type="obsolete">Im&amp;primir colorido se possível</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Export options</source>
-        <translation type="obsolete">QtiPlot - Opções de exportação</translation>
+        <translation>Im&amp;primir colorido se possível</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Landscape</source>
-        <translation type="obsolete">Paisagen</translation>
+        <translation>Paisagen</translation>
     </message>
     <message>
         <source>Portrait</source>
-        <translation type="obsolete">Retrato</translation>
+        <translation>Retrato</translation>
     </message>
 </context>
 <context>
@@ -6352,10 +5909,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Source of errors</source>
         <translation>Fonte de erros</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Error Bars</source>
-        <translation type="obsolete">QtiPlot - Barras de erro</translation>
     </message>
     <message>
         <source>&amp;X Error Bars</source>
@@ -6396,10 +5949,6 @@ p, li { white-space: pre-wrap; }
 </context>
 <context>
     <name>ExpDecayDialog</name>
-    <message>
-        <source>QtiPlot - Verify initial guesses</source>
-        <translation type="obsolete">QtiPlot - Verificar estimativas iniciais</translation>
-    </message>
     <message>
         <source>Exponential Fit of</source>
         <translation>Ajuste exponencial de</translation>
@@ -6457,10 +6006,6 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Fechar</translation>
     </message>
     <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
-    </message>
-    <message>
         <source>The curve &lt;b&gt; %1 &lt;/b&gt; doesn&apos;t exist anymore! Operation aborted!</source>
         <translation>A curva &lt;b&gt;%1&lt;/b&gt; não existe mais! Operação abortada!</translation>
     </message>
@@ -6502,10 +6047,6 @@ p, li { white-space: pre-wrap; }
 </context>
 <context>
     <name>ExportDialog</name>
-    <message>
-        <source>QtiPlot - Export ASCII</source>
-        <translation type="obsolete">QtiPlot - Exportar para ASCII</translation>
-    </message>
     <message>
         <source>Table</source>
         <translation>Tabela</translation>
@@ -6559,14 +6100,6 @@ p, li { white-space: pre-wrap; }
         <translation>A&amp;juda</translation>
     </message>
     <message>
-        <source>QtiPlot - Help</source>
-        <translation type="obsolete">QtiPlot - Ajuda</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Import options error</source>
-        <translation type="obsolete">QtiPlot - Erro nas opções de importação</translation>
-    </message>
-    <message>
         <source>Export ASCII</source>
         <translation>Exportar para ASCII</translation>
     </message>
@@ -6591,10 +6124,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>FFT</source>
         <translation>FFT</translation>
-    </message>
-    <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
     </message>
     <message>
         <source>Error</source>
@@ -6656,10 +6185,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FFTDialog</name>
     <message>
-        <source>QtiPlot - FFT Options</source>
-        <translation type="obsolete">QtiPlot- Opções FFT</translation>
-    </message>
-    <message>
         <source>Curve</source>
         <translation>Curva</translation>
     </message>
@@ -6704,28 +6229,20 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Fechar</translation>
     </message>
     <message>
-        <source>QtiPlot - Sampling value error</source>
-        <translation type="obsolete">QtiPlot - Erro no valor da amostra</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
-    </message>
-    <message>
         <source>Please choose a column for the real part of the data!</source>
         <translation>Por favor, escolha uma coluna para a parte real dos dados!</translation>
     </message>
     <message>
         <source>Frequency</source>
-        <translation type="obsolete">Frequência</translation>
+        <translation>Frequência</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="obsolete">Tempo</translation>
+        <translation>Tempo</translation>
     </message>
     <message>
         <source>Amplitude</source>
-        <translation type="obsolete">Amplitude</translation>
+        <translation>Amplitude</translation>
     </message>
     <message>
         <source>FFT Options</source>
@@ -6749,10 +6266,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Filtered</source>
         <translation>Filtrado</translation>
-    </message>
-    <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
     </message>
     <message>
         <source>Error</source>
@@ -6798,10 +6311,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>Filter</name>
     <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
-    </message>
-    <message>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
@@ -6811,7 +6320,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Several data points have the same x value causing divisions by zero, operation aborted!</source>
-        <translation type="obsolete">Vários pontos tem o mesmo valor de x causando divisões por zero, integração abortada!</translation>
+        <translation>Vários pontos tem o mesmo valor de x causando divisões por zero, integração abortada!</translation>
     </message>
     <message>
         <source>You need at least %1 points in order to perform this operation!</source>
@@ -6827,7 +6336,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>You didn&apos;t specify a valid data set for this operation!</source>
-        <translation type="obsolete">Não foi especificado um conjunto de dados válido para esta operação!</translation>
+        <translation>Não foi especificado um conjunto de dados válido para esta operação!</translation>
     </message>
     <message>
         <source>of</source>
@@ -6858,10 +6367,6 @@ p, li { white-space: pre-wrap; }
 </context>
 <context>
     <name>FilterDialog</name>
-    <message>
-        <source>QtiPlot - Filter options</source>
-        <translation type="obsolete">QtiPlot - Opções de filtro</translation>
-    </message>
     <message>
         <source>Filter curve: </source>
         <translation>Filtrar curva: </translation>
@@ -6903,16 +6408,8 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Fechar</translation>
     </message>
     <message>
-        <source>QtiPlot - Frequency input error</source>
-        <translation type="obsolete">QtiPlot - Erro na frequência fornecida</translation>
-    </message>
-    <message>
         <source>Please enter positive frequency values!</source>
         <translation>Por favor, forneça valores positivos de frequências!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - High Frequency input error</source>
-        <translation type="obsolete">QtiPlot - Erro na frequência alta fornecida</translation>
     </message>
     <message>
         <source>Please enter frequency limits that satisfy: Low &lt; High !</source>
@@ -6933,10 +6430,6 @@ p, li { white-space: pre-wrap; }
 </context>
 <context>
     <name>FindDialog</name>
-    <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
-    </message>
     <message>
         <source>Find</source>
         <translation>Procurar</translation>
@@ -6993,16 +6486,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>Fit</name>
     <message>
-        <source>QtiPlot - Fit Error</source>
-        <translation type="obsolete">QtiPlot - Erro ao ajustar</translation>
-    </message>
-    <message>
         <source>No curve assigned to the fitter! Please assign a curve first!</source>
-        <translation type="obsolete">Não foi indicada uma curva para ajustar! Por favor, indique uma curva primeiro!</translation>
+        <translation>Não foi indicada uma curva para ajustar! Por favor, indique uma curva primeiro!</translation>
     </message>
     <message>
         <source>Please enter a valid curve name!</source>
-        <translation type="obsolete">Por favor, forneça um nome de curva válido!</translation>
+        <translation>Por favor, forneça um nome de curva válido!</translation>
     </message>
     <message>
         <source>Plot</source>
@@ -7018,23 +6507,23 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Weighting Method</source>
-        <translation type="obsolete">Método de ponderação</translation>
+        <translation>Método de ponderação</translation>
     </message>
     <message>
         <source>No weighting</source>
-        <translation type="obsolete">Sem ponderação</translation>
+        <translation>Sem ponderação</translation>
     </message>
     <message>
         <source>Instrumental</source>
-        <translation type="obsolete">Instrumental</translation>
+        <translation>Instrumental</translation>
     </message>
     <message>
         <source>using error bars dataset</source>
-        <translation type="obsolete">usando barras de erro</translation>
+        <translation>usando barras de erro</translation>
     </message>
     <message>
         <source>Statistical</source>
-        <translation type="obsolete">Estatístico</translation>
+        <translation>Estatístico</translation>
     </message>
     <message>
         <source>Arbitrary Dataset</source>
@@ -7090,7 +6579,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>The curve %1 has no associated e error bars. You cannot use instrumental weighting method.</source>
-        <translation type="obsolete">A curva %1 não possui barras de erro e associadas. Não é possível utilizar o método de ponderação instrumental.</translation>
+        <translation>A curva %1 não possui barras de erro e associadas. Não é possível utilizar o método de ponderação instrumental.</translation>
     </message>
     <message>
         <source>Parameter</source>
@@ -7102,7 +6591,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>You didn&apos;t specify a data set for this fit operation. Operation aborted!</source>
-        <translation type="obsolete">Não foi especificado um conjunto de dados para esta operação. Operação abortada!</translation>
+        <translation>Não foi especificado um conjunto de dados para esta operação. Operação abortada!</translation>
     </message>
     <message>
         <source>There are no parameters specified for this fit operation. Operation aborted!</source>
@@ -7118,15 +6607,11 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source> of </source>
-        <translation type="obsolete"> de </translation>
-    </message>
-    <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
+        <translation> de </translation>
     </message>
     <message>
         <source>You need at least %1 points to perform this operation! Operation aborted!</source>
-        <translation type="obsolete">São necessários pelo menos %1 pontos para realizar esta operação! Operação abortada!</translation>
+        <translation>São necessários pelo menos %1 pontos para realizar esta operação! Operação abortada!</translation>
     </message>
     <message>
         <source>The column %1 has less points than the fitted data set. Please choose another column!.</source>
@@ -7233,19 +6718,19 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Weighting Method</source>
-        <translation type="obsolete">Método de ponderação</translation>
+        <translation>Método de ponderação</translation>
     </message>
     <message>
         <source>No weighting</source>
-        <translation type="obsolete">Sem ponderação</translation>
+        <translation>Sem ponderação</translation>
     </message>
     <message>
         <source>Instrumental</source>
-        <translation type="obsolete">Instrumental</translation>
+        <translation>Instrumental</translation>
     </message>
     <message>
         <source>Statistical</source>
-        <translation type="obsolete">Estatístico</translation>
+        <translation>Estatístico</translation>
     </message>
     <message>
         <source>Arbitrary Dataset</source>
@@ -7408,10 +6893,6 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Aplicar</translation>
     </message>
     <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
-    </message>
-    <message>
         <source>Please enter a valid name for the parameters table.</source>
         <translation>Por favor, forneça um nome válido para a tabela de parâmetros.</translation>
     </message>
@@ -7424,10 +6905,6 @@ p, li { white-space: pre-wrap; }
         <translation>Por favor, forneça um nome válido para a matriz de covariância.</translation>
     </message>
     <message>
-        <source>QtiPlot - Input function error</source>
-        <translation type="obsolete">QtiPlot - Erro na função fornecida</translation>
-    </message>
-    <message>
         <source>Please enter a valid function!</source>
         <translation>Por favor, forneça uma função válida!</translation>
     </message>
@@ -7438,10 +6915,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Please enter at least one parameter name!</source>
         <translation>Por favor, forneça pelo menos um nome para o parâmetro!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Error: function name</source>
-        <translation type="obsolete">QtiPlot - Erro: nome da função</translation>
     </message>
     <message>
         <source> is a built-in function name&lt;p&gt;You must choose another name for your function!</source>
@@ -7469,7 +6942,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Gauss</source>
-        <translation type="obsolete">Gauss</translation>
+        <translation>Gauss</translation>
     </message>
     <message>
         <source>Peaks</source>
@@ -7477,39 +6950,19 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Lorentz</source>
-        <translation type="obsolete">Lorentz</translation>
+        <translation>Lorentz</translation>
     </message>
     <message>
         <source>Polynomial</source>
-        <translation type="obsolete">Polinomial</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
+        <translation>Polinomial</translation>
     </message>
     <message>
         <source>The curve &lt;b&gt; %1 &lt;/b&gt; doesn&apos;t exist anymore! Operation aborted!</source>
         <translation>A curva &lt;b&gt;%1&lt;/b&gt; não existe mais! Operação abortada!</translation>
     </message>
     <message>
-        <source>QtiPlot - Start limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite inicial</translation>
-    </message>
-    <message>
-        <source>QtiPlot - End limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite final</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input error</source>
-        <translation type="obsolete">QtiPlot - Erro de entrada</translation>
-    </message>
-    <message>
         <source>Please enter x limits that satisfy: from &lt; end!</source>
         <translation>Por favor, forneça limites em x tais que: início &lt; fim!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Tolerance input error</source>
-        <translation type="obsolete">QtiPlot - Erro na tolerância</translation>
     </message>
     <message>
         <source>The tolerance value must be positive and less than 1!</source>
@@ -7517,7 +6970,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Please verify that you have initialized all the parameters!</source>
-        <translation type="obsolete">Por favor, certifique-se de que todos os parâmetros tenham sido inicializados!</translation>
+        <translation>Por favor, certifique-se de que todos os parâmetros tenham sido inicializados!</translation>
     </message>
     <message>
         <source>MultiPeak</source>
@@ -7533,7 +6986,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>You have to use a dot as decimal separator in formulas.</source>
-        <translation type="obsolete">Deve usar um ponto como separador decimal nas fórmulas.</translation>
+        <translation>Deve usar um ponto como separador decimal nas fórmulas.</translation>
     </message>
     <message>
         <source>Fit Wizard</source>
@@ -7592,31 +7045,31 @@ p, li { white-space: pre-wrap; }
     <name>Folder</name>
     <message>
         <source>kB</source>
-        <translation type="obsolete">kB</translation>
+        <translation>kB</translation>
     </message>
     <message>
         <source>bytes</source>
-        <translation type="obsolete">bytes</translation>
+        <translation>bytes</translation>
     </message>
     <message>
         <source>no folder element found</source>
-        <translation type="obsolete">sem elemento de pasta</translation>
+        <translation>sem elemento de pasta</translation>
     </message>
     <message>
         <source>Folder %1</source>
-        <translation type="obsolete">Pasta %1</translation>
+        <translation>Pasta %1</translation>
     </message>
     <message>
         <source>Column %1</source>
-        <translation type="obsolete">Coluna %1</translation>
+        <translation>Coluna %1</translation>
     </message>
     <message>
         <source>creation of aspect from element &apos;%1&apos; failed</source>
-        <translation type="obsolete">A criação de aspecto a partir do elemento &apos;%1&apos; falhou</translation>
+        <translation>A criação de aspecto a partir do elemento &apos;%1&apos; falhou</translation>
     </message>
     <message>
         <source>no plugin to load element &apos;%1&apos; found</source>
-        <translation type="obsolete">Nenhum plugin para carregar o elemento &apos;%1&apos; foi encontrado</translation>
+        <translation>Nenhum plugin para carregar o elemento &apos;%1&apos; foi encontrado</translation>
     </message>
 </context>
 <context>
@@ -7635,10 +7088,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Clear Function</source>
         <translation>Remover função</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Add function curve</source>
-        <translation type="obsolete">QtiPlot - Adicionar curva de função</translation>
     </message>
     <message>
         <source>Curve type </source>
@@ -7713,24 +7162,8 @@ p, li { white-space: pre-wrap; }
         <translation>Ok</translation>
     </message>
     <message>
-        <source>QtiPlot - Start limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite inicial</translation>
-    </message>
-    <message>
-        <source>QtiPlot - End limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite final</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input error</source>
-        <translation type="obsolete">QtiPlot - Erro de entrada</translation>
-    </message>
-    <message>
         <source>Please enter x limits that satisfy: from &lt; end!</source>
         <translation>Por favor, forneça limites em x tais que: início &lt; fim!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input function error</source>
-        <translation type="obsolete">QtiPlot - Erro na fórmula fornecida</translation>
     </message>
     <message>
         <source>Please enter parameter limits that satisfy: from &lt; end!</source>
@@ -7754,7 +7187,6 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Input function error</source>
-        <translation type="obsolete">QtiPlot - Erro na função fornecida</translation>
     </message>
 </context>
 <context>
@@ -7777,7 +7209,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>GaussAmp</source>
-        <translation type="obsolete">GaussAmp</translation>
+        <translation>GaussAmp</translation>
     </message>
     <message>
         <source>GaussAmp Fit</source>
@@ -7810,20 +7242,8 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>Graph</name>
     <message>
-        <source>QtiPlot - File open error</source>
-        <translation type="obsolete">QtiPlot - Erro na abertura do arquivo</translation>
-    </message>
-    <message>
-        <source>Error - QtiPlot</source>
-        <translation type="obsolete">Erro - QtiPlot</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Pixel selection warning</source>
-        <translation type="obsolete">QtiPlot - Atenção à seleção de pixel</translation>
-    </message>
-    <message>
         <source>Curve selected! Move cursor and click to choose a point and double-click/press &apos;Enter&apos; to finish!</source>
-        <translation type="obsolete">Curva selecionada! Mova o cursor e clique para escolher um ponto e dê um duplo clique/&apos;enter&apos; para finalisar</translation>
+        <translation>Curva selecionada! Mova o cursor e clique para escolher um ponto e dê um duplo clique/&apos;enter&apos; para finalisar</translation>
     </message>
     <message>
         <source>&amp;Cut</source>
@@ -7847,7 +7267,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Ctrl+R</source>
-        <translation type="obsolete">Ctrl+R</translation>
+        <translation>Ctrl+R</translation>
     </message>
     <message>
         <source>&amp;Hide axis</source>
@@ -7863,137 +7283,121 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Your data is not valid. You need at least two different points for a histogram!</source>
-        <translation type="obsolete">Seus dados não são válidos. São necessários pelo menos dois pontos diferentes para um  histograma!</translation>
+        <translation>Seus dados não são válidos. São necessários pelo menos dois pontos diferentes para um  histograma!</translation>
     </message>
     <message>
         <source>Histogram and Probabilities for</source>
-        <translation type="obsolete">Histograma e Probabilidades para</translation>
+        <translation>Histograma e Probabilidades para</translation>
     </message>
     <message>
         <source>Mean</source>
-        <translation type="obsolete">Média</translation>
+        <translation>Média</translation>
     </message>
     <message>
         <source>Standard Deviation</source>
-        <translation type="obsolete">Desvio padrão</translation>
+        <translation>Desvio padrão</translation>
     </message>
     <message>
         <source>Minimum</source>
-        <translation type="obsolete">Mínimo</translation>
+        <translation>Mínimo</translation>
     </message>
     <message>
         <source>Maximum</source>
-        <translation type="obsolete">Máximo</translation>
+        <translation>Máximo</translation>
     </message>
     <message>
         <source>Bins</source>
-        <translation type="obsolete">Bins</translation>
+        <translation>Bins</translation>
     </message>
     <message>
         <source>Could not allocate memory, operation aborted!</source>
-        <translation type="obsolete">Não foi possível reservar memória, operação abortada!</translation>
+        <translation>Não foi possível reservar memória, operação abortada!</translation>
     </message>
     <message>
         <source>Frequency</source>
-        <translation type="obsolete">Frequência</translation>
+        <translation>Frequência</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="obsolete">Tempo</translation>
+        <translation>Tempo</translation>
     </message>
     <message>
         <source>Real</source>
-        <translation type="obsolete">Real</translation>
+        <translation>Real</translation>
     </message>
     <message>
         <source>Imaginary</source>
-        <translation type="obsolete">Imaginário</translation>
+        <translation>Imaginário</translation>
     </message>
     <message>
         <source>Amplitude</source>
-        <translation type="obsolete">Amplitude</translation>
+        <translation>Amplitude</translation>
     </message>
     <message>
         <source>Angle</source>
-        <translation type="obsolete">Ângulo</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Integration error</source>
-        <translation type="obsolete">QtiPlot - Erro na integração</translation>
+        <translation>Ângulo</translation>
     </message>
     <message>
         <source>You need at least 2 points to integrate! Integration aborted!</source>
-        <translation type="obsolete">São necessários pelo menos 2 pontos para integrar! Operação abortada!</translation>
+        <translation>São necessários pelo menos 2 pontos para integrar! Operação abortada!</translation>
     </message>
     <message>
         <source>Several points have the same x value causing divisions by zero, integration aborted!</source>
-        <translation type="obsolete">Vários pontos tem o mesmo valor de x causando divisão por zero, integração abortada!</translation>
+        <translation>Vários pontos tem o mesmo valor de x causando divisão por zero, integração abortada!</translation>
     </message>
     <message>
         <source>Linear regresion of </source>
-        <translation type="obsolete">Regressão linear de </translation>
-    </message>
-    <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
+        <translation>Regressão linear de </translation>
     </message>
     <message>
         <source>You need at least %1 points to perform this operation! Operation aborted!</source>
-        <translation type="obsolete">São necessários pelo menos %1 pontos para realizar esta operação! Operação abortada!</translation>
+        <translation>São necessários pelo menos %1 pontos para realizar esta operação! Operação abortada!</translation>
     </message>
     <message>
         <source>Order</source>
-        <translation type="obsolete">Ordem</translation>
+        <translation>Ordem</translation>
     </message>
     <message>
         <source>Polynomial fit of </source>
-        <translation type="obsolete">Ajuste polinomial de </translation>
-    </message>
-    <message>
-        <source>QtiPlot - File not found</source>
-        <translation type="obsolete">QtiPlot - arquivo não encontrado</translation>
+        <translation>Ajuste polinomial de </translation>
     </message>
     <message>
         <source>Plugin file: &lt;p&gt;&lt;b&gt; %1 &lt;/b&gt; &lt;p&gt;not found. Operation aborted!</source>
-        <translation type="obsolete">Plugin: &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;p&gt;não encontrado. Operação abortada!</translation>
+        <translation>Plugin: &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;p&gt;não encontrado. Operação abortada!</translation>
     </message>
     <message>
         <source>Error when loading plugin!
 </source>
-        <translation type="obsolete">Erro ao carregar plugin!
+        <translation>Erro ao carregar plugin!
 </translation>
     </message>
     <message>
         <source>You need at least %1 points to perform the fit! Operation aborted!</source>
-        <translation type="obsolete">São necessários pelo menos %1 pontos para fazer o ajuste! Operação abortada!</translation>
+        <translation>São necessários pelo menos %1 pontos para fazer o ajuste! Operação abortada!</translation>
     </message>
     <message>
         <source>Error when loading plugin!</source>
-        <translation type="obsolete">Erro ao carregar plugin!</translation>
+        <translation>Erro ao carregar plugin!</translation>
     </message>
     <message>
         <source>Low Pass FFT Filter of </source>
-        <translation type="obsolete">Filtro FFT passa baixa de </translation>
+        <translation>Filtro FFT passa baixa de </translation>
     </message>
     <message>
         <source>High Pass FFT Filter of </source>
-        <translation type="obsolete">Filtro FFT passa alta de </translation>
+        <translation>Filtro FFT passa alta de </translation>
     </message>
     <message>
         <source>Band Pass FFT Filter of </source>
-        <translation type="obsolete">Filtro FFT passa banda de </translation>
+        <translation>Filtro FFT passa banda de </translation>
     </message>
     <message>
         <source>Band Block FFT Filter of </source>
-        <translation type="obsolete">Filtro FFT bloqueia banda de </translation>
+        <translation>Filtro FFT bloqueia banda de </translation>
     </message>
     <message>
         <source>There are no curves available on this plot!</source>
         <translation>Não existem curvas disponíveis neste gráfico!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
     </message>
     <message>
         <source>There are no curves with more than two points on this plot. Operation aborted!</source>
@@ -8001,143 +7405,143 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>All the curves on this plot are empty!</source>
-        <translation type="obsolete">Todas as curvas neste gráfico estão vazias!</translation>
+        <translation>Todas as curvas neste gráfico estão vazias!</translation>
     </message>
     <message>
         <source>Peak %1 selected! Click to select a point and double-click/press &apos;Enter&apos; to set the position of the next peak!</source>
-        <translation type="obsolete">Pico %1 selecionado! Clique para selecionar um ponto e dê um duplo clique/&apos;enter&apos; para fixar a posição do pico seguinte!</translation>
+        <translation>Pico %1 selecionado! Clique para selecionar um ponto e dê um duplo clique/&apos;enter&apos; para fixar a posição do pico seguinte!</translation>
     </message>
     <message>
         <source>y0 (offset)</source>
-        <translation type="obsolete">y0 (offset)</translation>
+        <translation>y0 (offset)</translation>
     </message>
     <message>
         <source>Lorentz</source>
-        <translation type="obsolete">Lorentz</translation>
+        <translation>Lorentz</translation>
     </message>
     <message>
         <source>Gauss</source>
-        <translation type="obsolete">Gauss</translation>
+        <translation>Gauss</translation>
     </message>
     <message>
         <source>multi-peak</source>
-        <translation type="obsolete">multiplos picos</translation>
+        <translation>multiplos picos</translation>
     </message>
     <message>
         <source>Non-linear fit of </source>
-        <translation type="obsolete">Ajuste não linear de </translation>
+        <translation>Ajuste não linear de </translation>
     </message>
     <message>
         <source>Non-linear</source>
-        <translation type="obsolete">Não linear</translation>
+        <translation>Não linear</translation>
     </message>
     <message>
         <source>Peak</source>
-        <translation type="obsolete">Pico</translation>
+        <translation>Pico</translation>
     </message>
     <message>
         <source>Height</source>
-        <translation type="obsolete">Altura</translation>
+        <translation>Altura</translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="obsolete">área</translation>
+        <translation>área</translation>
     </message>
     <message>
         <source>Center</source>
-        <translation type="obsolete">Centro</translation>
+        <translation>Centro</translation>
     </message>
     <message>
         <source>Width</source>
-        <translation type="obsolete">Largura</translation>
+        <translation>Largura</translation>
     </message>
     <message>
         <source>fit of</source>
-        <translation type="obsolete">ajuste de</translation>
+        <translation>ajuste de</translation>
     </message>
     <message>
         <source>Exponential decay fit of </source>
-        <translation type="obsolete">Ajuste por decaimento exponencial de </translation>
+        <translation>Ajuste por decaimento exponencial de </translation>
     </message>
     <message>
         <source>ExpDecay2 fit of </source>
-        <translation type="obsolete">Ajuste ExpDecaim2 de </translation>
+        <translation>Ajuste ExpDecaim2 de </translation>
     </message>
     <message>
         <source>ExpDecay3 fit of </source>
-        <translation type="obsolete">Ajuste ExpDecaim3 de </translation>
+        <translation>Ajuste ExpDecaim3 de </translation>
     </message>
     <message>
         <source>Exponential growth fit of </source>
-        <translation type="obsolete">Ajuste por crescimento exponencial de </translation>
+        <translation>Ajuste por crescimento exponencial de </translation>
     </message>
     <message>
         <source>Gauss fit of </source>
-        <translation type="obsolete">Ajuste gaussiano de </translation>
+        <translation>Ajuste gaussiano de </translation>
     </message>
     <message>
         <source>Lorentz fit of </source>
-        <translation type="obsolete">Ajuste lorentziano de </translation>
+        <translation>Ajuste lorentziano de </translation>
     </message>
     <message>
         <source>using function</source>
-        <translation type="obsolete">usando função </translation>
+        <translation>usando função </translation>
     </message>
     <message>
         <source>Unscaled Levenberg-Marquardt</source>
-        <translation type="obsolete">Levenberg-Marquardt não escalado</translation>
+        <translation>Levenberg-Marquardt não escalado</translation>
     </message>
     <message>
         <source>Scaled Levenberg-Marquardt</source>
-        <translation type="obsolete">Levenberg-Marquardt escalado</translation>
+        <translation>Levenberg-Marquardt escalado</translation>
     </message>
     <message>
         <source> algorithm with tolerance = </source>
-        <translation type="obsolete"> algoritmo com tolerância = </translation>
+        <translation> algoritmo com tolerância = </translation>
     </message>
     <message>
         <source>From x=</source>
-        <translation type="obsolete">A partir de x=</translation>
+        <translation>A partir de x=</translation>
     </message>
     <message>
         <source> to x=</source>
-        <translation type="obsolete"> até x = </translation>
+        <translation> até x = </translation>
     </message>
     <message>
         <source>Iterations = </source>
-        <translation type="obsolete">Interações = </translation>
+        <translation>Interações = </translation>
     </message>
     <message>
         <source>Nelder-Mead Simplex</source>
-        <translation type="obsolete">Nelder-Mead Simplex</translation>
+        <translation>Nelder-Mead Simplex</translation>
     </message>
     <message>
         <source>Savitzky-Golay smoothing of </source>
-        <translation type="obsolete">Suavização de Savitzky-Golay de </translation>
+        <translation>Suavização de Savitzky-Golay de </translation>
     </message>
     <message>
         <source>A1 (init value)</source>
-        <translation type="obsolete">A1 (valor inicial)</translation>
+        <translation>A1 (valor inicial)</translation>
     </message>
     <message>
         <source>A2 (final value)</source>
-        <translation type="obsolete">A2 (valor final)</translation>
+        <translation>A2 (valor final)</translation>
     </message>
     <message>
         <source>x0 (center)</source>
-        <translation type="obsolete">x0 (centro)</translation>
+        <translation>x0 (centro)</translation>
     </message>
     <message>
         <source>dx (time constant)</source>
-        <translation type="obsolete">dx (constante de Tempo)</translation>
+        <translation>dx (constante de Tempo)</translation>
     </message>
     <message>
         <source>Boltzmann (Sigmoidal)</source>
-        <translation type="obsolete">Boltzmann (Sigmoidal)</translation>
+        <translation>Boltzmann (Sigmoidal)</translation>
     </message>
     <message>
         <source>Boltzmann (Sigmoidal) fit of </source>
-        <translation type="obsolete">Boltzmann (Sigmoidal) ajuste de </translation>
+        <translation>Boltzmann (Sigmoidal) ajuste de </translation>
     </message>
     <message>
         <source>The columns</source>
@@ -8157,51 +7561,39 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Derivative of</source>
-        <translation type="obsolete">Derivada de</translation>
+        <translation>Derivada de</translation>
     </message>
     <message>
         <source>Left</source>
-        <translation type="obsolete">Esquerda</translation>
+        <translation>Esquerda</translation>
     </message>
     <message>
         <source>Right</source>
-        <translation type="obsolete">Direita</translation>
+        <translation>Direita</translation>
     </message>
     <message>
         <source>Title</source>
         <translation>Título</translation>
     </message>
     <message>
-        <source>QtiPlot - Remove point error</source>
-        <translation type="obsolete">QtiPlot - Remover erro do ponto</translation>
-    </message>
-    <message>
         <source>This function is not available for function curves!</source>
-        <translation type="obsolete">Esta função não está disponível para curvas de função!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Move point error</source>
-        <translation type="obsolete">QtiPlot - Erro ao mover ponto</translation>
+        <translation>Esta função não está disponível para curvas de função!</translation>
     </message>
     <message>
         <source>There is no curve called &apos;%1&apos; on this layer.</source>
-        <translation type="obsolete">Não existe nenhuma curva chamada &apos;%1&apos; nesta camada.</translation>
+        <translation>Não existe nenhuma curva chamada &apos;%1&apos; nesta camada.</translation>
     </message>
     <message>
         <source>There is no curve with index %1 on this layer.</source>
-        <translation type="obsolete">Não existe nenhuma curva com índice %1 nesta camada.</translation>
+        <translation>Não existe nenhuma curva com índice %1 nesta camada.</translation>
     </message>
     <message>
         <source>Valid indexes must have values between 0 and %1</source>
-        <translation type="obsolete">Os índices válidos devem ter valores entre 0 e %1</translation>
+        <translation>Os índices válidos devem ter valores entre 0 e %1</translation>
     </message>
     <message>
         <source>Image file: &lt;p&gt;&lt;b&gt; %1 &lt;/b&gt;&lt;p&gt;does not exist anymore!</source>
         <translation>O arquivo de imagem: &lt;p&gt;&lt;b&gt; %1 &lt;/b&gt;&lt;p&gt; não existe mais!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input function error</source>
-        <translation type="obsolete">QtiPlot - Erro na fórmula introduzida</translation>
     </message>
     <message>
         <source>Ctrl+Shift+R</source>
@@ -8209,59 +7601,59 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Fit</source>
-        <translation type="obsolete">Ajustar</translation>
+        <translation>Ajustar</translation>
     </message>
     <message>
         <source>Quantity</source>
-        <translation type="obsolete">Quantidade</translation>
+        <translation>Quantidade</translation>
     </message>
     <message>
         <source>Sum</source>
-        <translation type="obsolete">Soma</translation>
+        <translation>Soma</translation>
     </message>
     <message>
         <source>Percent</source>
-        <translation type="obsolete">Porcentagem</translation>
+        <translation>Porcentagem</translation>
     </message>
     <message>
         <source>Linear interpolation of </source>
-        <translation type="obsolete">Interpolação linear de </translation>
+        <translation>Interpolação linear de </translation>
     </message>
     <message>
         <source>Cubic interpolation of </source>
-        <translation type="obsolete">Interpolação cúbica de </translation>
+        <translation>Interpolação cúbica de </translation>
     </message>
     <message>
         <source>Akima interpolation of </source>
-        <translation type="obsolete">Interpolação de Akima de </translation>
+        <translation>Interpolação de Akima de </translation>
     </message>
     <message>
         <source>The curve %1 doesn&apos;t exist! Operation aborted!</source>
-        <translation type="obsolete">A curva %1 não existe! Operação abortada!</translation>
+        <translation>A curva %1 não existe! Operação abortada!</translation>
     </message>
     <message>
         <source>Please select the start line point inside the image rectangle!</source>
-        <translation type="obsolete">Por favor, selecione o ponto de início de linha na imagem do retângulo!</translation>
+        <translation>Por favor, selecione o ponto de início de linha na imagem do retângulo!</translation>
     </message>
     <message>
         <source>Please select the end line point inside the image rectangle!</source>
-        <translation type="obsolete">Por favor, selecione o ponto de fim de linha na imagem do retângulo!</translation>
+        <translation>Por favor, selecione o ponto de fim de linha na imagem do retângulo!</translation>
     </message>
     <message>
         <source>Smoothed</source>
-        <translation type="obsolete">Suavizado</translation>
+        <translation>Suavizado</translation>
     </message>
     <message>
         <source>points</source>
-        <translation type="obsolete">pontos</translation>
+        <translation>pontos</translation>
     </message>
     <message>
         <source>FFT Smoothing of</source>
-        <translation type="obsolete">Suavizar FFT de</translation>
+        <translation>Suavizar FFT de</translation>
     </message>
     <message>
         <source>average mmoothing of</source>
-        <translation type="obsolete">suavizar média de</translation>
+        <translation>suavizar média de</translation>
     </message>
     <message>
         <source>Please provide a valid file name!</source>
@@ -8277,11 +7669,11 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Table</source>
-        <translation type="obsolete">Tabela</translation>
+        <translation>Tabela</translation>
     </message>
     <message>
         <source>F</source>
-        <translation type="obsolete">F</translation>
+        <translation>F</translation>
     </message>
     <message>
         <source>Error</source>
@@ -8325,36 +7717,20 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>Graph3D</name>
     <message>
-        <source>QtiPlot - IO Error</source>
-        <translation type="obsolete">QtiPlot - Erro de entrada/saída</translation>
-    </message>
-    <message>
         <source>Choose a filename to save under</source>
-        <translation type="obsolete">Escolha um nome de arquivo para salvar</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Overwrite File?</source>
-        <translation type="obsolete">QtiPlot - Sobrescrever arquivo?</translation>
+        <translation>Escolha um nome de arquivo para salvar</translation>
     </message>
     <message>
         <source>A file called: &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;p&gt;already exists. Do you want to overwrite it?</source>
-        <translation type="obsolete">Um arquivo chamado &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;p&gt; já existe. Deseja sobreescrvê-lo?</translation>
+        <translation>Um arquivo chamado &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;p&gt; já existe. Deseja sobreescrvê-lo?</translation>
     </message>
     <message>
         <source>&amp;Yes</source>
-        <translation type="obsolete">&amp;Sim</translation>
+        <translation>&amp;Sim</translation>
     </message>
     <message>
         <source>&amp;No</source>
-        <translation type="obsolete">&amp;Não</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Export Error</source>
-        <translation type="obsolete">QtiPlot - Erro na exportação</translation>
-    </message>
-    <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
+        <translation>&amp;Não</translation>
     </message>
     <message>
         <source>X axis</source>
@@ -8371,10 +7747,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Could not print: &lt;h4&gt;</source>
         <translation>Não foi possível imprimir: &lt;h4&gt;</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
     </message>
     <message>
         <source>Please provide a valid file name!</source>
@@ -8395,10 +7767,6 @@ p, li { white-space: pre-wrap; }
 </context>
 <context>
     <name>ImageDialog</name>
-    <message>
-        <source>QtiPlot - Image Geometry</source>
-        <translation type="obsolete">QtiPlot - Geometria da Imagem</translation>
-    </message>
     <message>
         <source>Origin</source>
         <translation>Origem</translation>
@@ -8451,12 +7819,8 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ImageExportDialog</name>
     <message>
-        <source>QtiPlot - Choose a filename to save under</source>
-        <translation type="obsolete">QtiPlot - Escolha o nome do arquivo para salvar</translation>
-    </message>
-    <message>
         <source>Show export &amp;options</source>
-        <translation type="obsolete">Mostrar &amp;opções de exportação</translation>
+        <translation>Mostrar &amp;opções de exportação</translation>
     </message>
     <message>
         <source>Resolution (DPI)</source>
@@ -8476,7 +7840,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Save transparency</source>
-        <translation type="obsolete">Salvar transparência</translation>
+        <translation>Salvar transparência</translation>
     </message>
     <message>
         <source>Choose a filename to save under</source>
@@ -8628,24 +7992,20 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ImageExportOptionsDialog</name>
     <message>
-        <source>QtiPlot - Export options</source>
-        <translation type="obsolete">QtiPlot - Opções de exportação</translation>
-    </message>
-    <message>
         <source>Image format</source>
-        <translation type="obsolete">Formato da imagem</translation>
+        <translation>Formato da imagem</translation>
     </message>
     <message>
         <source>Image quality</source>
-        <translation type="obsolete">Qualidade da imagem</translation>
+        <translation>Qualidade da imagem</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
 </context>
 <context>
@@ -8790,7 +8150,7 @@ tiverem o mesmo número de linhas.</translation>
     </message>
     <message>
         <source>Use custom &amp;decimal separator</source>
-        <translation type="obsolete">Usar separador &amp;decimal personalizado</translation>
+        <translation>Usar separador &amp;decimal personalizado</translation>
     </message>
     <message>
         <source>Re&amp;member the above options</source>
@@ -8856,170 +8216,146 @@ tiverem o mesmo número de linhas.</translation>
 <context>
     <name>ImportDialog</name>
     <message>
-        <source>QtiPlot - ASCII Import Options</source>
-        <translation type="obsolete">QtiPlot - Opções de importação ASCII</translation>
-    </message>
-    <message>
         <source>Separator</source>
-        <translation type="obsolete">Separador</translation>
+        <translation>Separador</translation>
     </message>
     <message>
         <source>TAB</source>
-        <translation type="obsolete">TAB</translation>
+        <translation>TAB</translation>
     </message>
     <message>
         <source>SPACE</source>
-        <translation type="obsolete">ESPAÇO</translation>
+        <translation>ESPAÇO</translation>
     </message>
     <message>
         <source>Ignore first</source>
-        <translation type="obsolete">Ignorar primeiras</translation>
+        <translation>Ignorar primeiras</translation>
     </message>
     <message>
         <source>lines</source>
-        <translation type="obsolete">linhas</translation>
+        <translation>linhas</translation>
     </message>
     <message>
         <source>Use first row to &amp;name columns</source>
-        <translation type="obsolete">Usar primeira linha para &amp;nomear colunas</translation>
+        <translation>Usar primeira linha para &amp;nomear colunas</translation>
     </message>
     <message>
         <source>&amp;Remove white spaces from line ends</source>
-        <translation type="obsolete">Remove&amp;r espaços em branco dos finais de linha</translation>
+        <translation>Remove&amp;r espaços em branco dos finais de linha</translation>
     </message>
     <message>
         <source>&amp;Simplify white spaces</source>
-        <translation type="obsolete">&amp;Simplificar espaços em branco</translation>
+        <translation>&amp;Simplificar espaços em branco</translation>
     </message>
     <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>&amp;Close</source>
-        <translation type="obsolete">&amp;Fechar</translation>
+        <translation>&amp;Fechar</translation>
     </message>
     <message>
         <source>The separator must not contain the following characters: 0-9eE.+-</source>
-        <translation type="obsolete">O separador não pode conter os seguintes caracteres: 0-9eE.+-</translation>
+        <translation>O separador não pode conter os seguintes caracteres: 0-9eE.+-</translation>
     </message>
     <message>
         <source>Remove white spaces from line ends</source>
-        <translation type="obsolete">Remover espaços em branco dos finais de linha</translation>
+        <translation>Remover espaços em branco dos finais de linha</translation>
     </message>
     <message>
         <source>By checking this option all white spaces will be removed from the beginning and the end of the lines in the ASCII file.</source>
-        <translation type="obsolete">Marcando esta opção todos os espaços em branco serão removidos do principio e do final das linhas no arquivo ASCII.</translation>
+        <translation>Marcando esta opção todos os espaços em branco serão removidos do principio e do final das linhas no arquivo ASCII.</translation>
     </message>
     <message>
         <source>Simplify white spaces</source>
-        <translation type="obsolete">Simplificar espaços em branco</translation>
+        <translation>Simplificar espaços em branco</translation>
     </message>
     <message>
         <source>By checking this option each sequence of internal whitespaces (including the TAB character) will be replaced with a single space.</source>
-        <translation type="obsolete">Marcando esta opção cada sequência de espaços em branco internos (incluindo o caractere TAB) será substituída por um  único espaço.</translation>
+        <translation>Marcando esta opção cada sequência de espaços em branco internos (incluindo o caractere TAB) será substituída por um  único espaço.</translation>
     </message>
     <message>
         <source>By checking this option all white spaces will be removed from the beginning and the end of the lines and each sequence of internal whitespaces (including the TAB character) will be replaced with a single space.</source>
-        <translation type="obsolete">Marcando esta opção todos os espaços em branco serão removidos do início e do final das linhas e cada sequência de espaços internos (incluindo o caractere TAB) será substituída por um único espaço em branco.</translation>
+        <translation>Marcando esta opção todos os espaços em branco serão removidos do início e do final das linhas e cada sequência de espaços internos (incluindo o caractere TAB) será substituída por um único espaço em branco.</translation>
     </message>
     <message>
         <source>Warning: using these two last options leads to column overlaping if the columns in the ASCII file don&apos;t have the same number of rows.</source>
-        <translation type="obsolete">Aviso: o uso destas duas últimas opções conduz à superposição de colunas se as colunas do arquivo ASCII não tiverem o mesmo número de linhas.</translation>
+        <translation>Aviso: o uso destas duas últimas opções conduz à superposição de colunas se as colunas do arquivo ASCII não tiverem o mesmo número de linhas.</translation>
     </message>
     <message>
         <source>To avoid this problem you should precisely define the column separator using TAB and SPACE characters.</source>
-        <translation type="obsolete">Para evitar este problema é necessário definir exatamente o separador de colunas usando os caracteres TAB ou ESPAÇO.</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Help</source>
-        <translation type="obsolete">QtiPlot - Ajuda</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Import options error</source>
-        <translation type="obsolete">QtiPlot - Erro nas opções de importação</translation>
-    </message>
-    <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
+        <translation>Para evitar este problema é necessário definir exatamente o separador de colunas usando os caracteres TAB ou ESPAÇO.</translation>
     </message>
     <message>
         <source>Do you want to save the modifications to the ASCII import options before closing?</source>
-        <translation type="obsolete">Gostaria de salvar as modificações nas opções de importação ASCII antes de fechar?</translation>
+        <translation>Gostaria de salvar as modificações nas opções de importação ASCII antes de fechar?</translation>
     </message>
     <message>
         <source>Yes</source>
-        <translation type="obsolete">Sim</translation>
+        <translation>Sim</translation>
     </message>
     <message>
         <source>No</source>
-        <translation type="obsolete">Não</translation>
+        <translation>Não</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">Cancelar</translation>
+        <translation>Cancelar</translation>
     </message>
 </context>
 <context>
     <name>ImportFilesDialog</name>
     <message>
-        <source>QtiPlot - Import Multiple ASCII Files</source>
-        <translation type="obsolete">QtiPlot - Importar vários arquivos ASCII</translation>
-    </message>
-    <message>
         <source>New Table</source>
-        <translation type="obsolete">Nova tabela</translation>
+        <translation>Nova tabela</translation>
     </message>
     <message>
         <source>New Columns</source>
-        <translation type="obsolete">Novas colunas</translation>
+        <translation>Novas colunas</translation>
     </message>
     <message>
         <source>New Rows</source>
-        <translation type="obsolete">Novas linhas</translation>
+        <translation>Novas linhas</translation>
     </message>
     <message>
         <source>All files</source>
-        <translation type="obsolete">Todos os arquivos</translation>
+        <translation>Todos os arquivos</translation>
     </message>
     <message>
         <source>Text</source>
-        <translation type="obsolete">Texto</translation>
+        <translation>Texto</translation>
     </message>
     <message>
         <source>Data</source>
-        <translation type="obsolete">Dados</translation>
+        <translation>Dados</translation>
     </message>
     <message>
         <source>Comma Separated Values</source>
-        <translation type="obsolete">Valores separados por vírgula</translation>
+        <translation>Valores separados por vírgula</translation>
     </message>
     <message>
         <source>Import each file as</source>
-        <translation type="obsolete">Importar cada arquivo como</translation>
+        <translation>Importar cada arquivo como</translation>
     </message>
 </context>
 <context>
     <name>IntDialog</name>
-    <message>
-        <source>QtiPlot - Integration Options</source>
-        <translation type="obsolete">QtiPlot - Opções de integração</translation>
-    </message>
     <message>
         <source>Integration of</source>
         <translation>Integração de</translation>
     </message>
     <message>
         <source>Order (1 - 5, 1 = Trapezoid Rule)</source>
-        <translation type="obsolete">Ordem (1 - 5, 1 = Regra do trapézio)</translation>
+        <translation>Ordem (1 - 5, 1 = Regra do trapézio)</translation>
     </message>
     <message>
         <source>Number of iterations (Max=40)</source>
-        <translation type="obsolete">Número de interações (Max=40)</translation>
+        <translation>Número de interações (Max=40)</translation>
     </message>
     <message>
         <source>Tolerance</source>
-        <translation type="obsolete">Tolerância</translation>
+        <translation>Tolerância</translation>
     </message>
     <message>
         <source>Interpolation</source>
@@ -9058,24 +8394,12 @@ tiverem o mesmo número de linhas.</translation>
         <translation>&amp;Fechar</translation>
     </message>
     <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
-    </message>
-    <message>
         <source>Warning</source>
         <translation>Atenção</translation>
     </message>
     <message>
         <source>The curve &lt;b&gt; %1 &lt;/b&gt; doesn&apos;t exist anymore! Operation aborted!</source>
         <translation>A curva &lt;b&gt;%1&lt;/b&gt; não existe mais! Operação abortada!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Tolerance value error</source>
-        <translation type="obsolete">QtiPlot - Erro na tolerância</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input error</source>
-        <translation type="obsolete">QtiPlot - Erro de entrada</translation>
     </message>
     <message>
         <source>Please give a number larger or equal to the minimum value of X, for the lower limit.
@@ -9090,22 +8414,10 @@ Se você não conhece este valor, escreva min na caixa.</translation>
 Se você não conhece este valor, escreva max na caixa.</translation>
     </message>
     <message>
-        <source>QtiPlot - Start limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite inicial</translation>
-    </message>
-    <message>
         <source>Please give a number larger or equal to the minimum value of X, for the upper limit.
  If you do not know that value, type min in the box.</source>
         <translation>Por favor, forneça um número maior o igual ao valor mínimo de X para o limite superior.
 Se não conhece este valor, escreva min na caixa.</translation>
-    </message>
-    <message>
-        <source>QtiPlot - End limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite final</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Help for Integration</source>
-        <translation type="obsolete">QtiPlot - Ajuda para a integração</translation>
     </message>
     <message>
         <source>The integration of a curve consists of the following five steps:
@@ -9139,7 +8451,7 @@ Os limites devem estar dentro do intervalo de x; se não conhece o valor máximo
     </message>
     <message>
         <source>Tolerance value error</source>
-        <translation type="obsolete">Erro no valor da tolerância</translation>
+        <translation>Erro no valor da tolerância</translation>
     </message>
     <message>
         <source>Input error</source>
@@ -9206,19 +8518,19 @@ Os limites devem estar dentro do intervalo de x; se não conhece o valor máximo
     </message>
     <message>
         <source>using a %1 order method</source>
-        <translation type="obsolete">usando um método de %1 orden</translation>
+        <translation>usando um método de %1 orden</translation>
     </message>
     <message>
         <source>Iterations</source>
-        <translation type="obsolete">Interações</translation>
+        <translation>Interações</translation>
     </message>
     <message>
         <source>Tolerance</source>
-        <translation type="obsolete">Tolerância</translation>
+        <translation>Tolerância</translation>
     </message>
     <message>
         <source>max</source>
-        <translation type="obsolete">max</translation>
+        <translation>max</translation>
     </message>
     <message>
         <source>Points</source>
@@ -9241,12 +8553,8 @@ Os limites devem estar dentro do intervalo de x; se não conhece o valor máximo
         <translation>área</translation>
     </message>
     <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
-    </message>
-    <message>
         <source>Unknown integration method. Valid values must be in the range: 1 (Trapezoidal Method) to 5.</source>
-        <translation type="obsolete">Método de integração desconhecido. Os valores válidos devem estar no intervalo: 1 (Método do Trapézio) a 5.</translation>
+        <translation>Método de integração desconhecido. Os valores válidos devem estar no intervalo: 1 (Método do Trapézio) a 5.</translation>
     </message>
     <message>
         <source>Error</source>
@@ -9259,10 +8567,6 @@ Os limites devem estar dentro do intervalo de x; se não conhece o valor máximo
 </context>
 <context>
     <name>Interpolation</name>
-    <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
-    </message>
     <message>
         <source>Error</source>
         <translation>Erro</translation>
@@ -9296,10 +8600,6 @@ Os limites devem estar dentro do intervalo de x; se não conhece o valor máximo
         <translation>Vários pontos tem o mesmo valor de x causando divisões por zero, operação abortada!</translation>
     </message>
     <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
-    </message>
-    <message>
         <source>Unknown interpolation method, valid values are: 0 - Linear, 1 - Cubic, 2 - Akima.</source>
         <translation>Método de Interpolação desconhecido. Os valores válidos são: 0 - Linear, 1 - Cúbico, 2 - Akima.</translation>
     </message>
@@ -9314,10 +8614,6 @@ Os limites devem estar dentro do intervalo de x; se não conhece o valor máximo
 </context>
 <context>
     <name>InterpolationDialog</name>
-    <message>
-        <source>QtiPlot - Interpolation Options</source>
-        <translation type="obsolete">QtiPlot - Opções de interpolação</translation>
-    </message>
     <message>
         <source>Make curve from</source>
         <translation>Traçar curva a partir de</translation>
@@ -9367,24 +8663,8 @@ Os limites devem estar dentro do intervalo de x; se não conhece o valor máximo
         <translation>&amp;Fechar</translation>
     </message>
     <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
-    </message>
-    <message>
         <source>The curve &lt;b&gt; %1 &lt;/b&gt; doesn&apos;t exist anymore! Operation aborted!</source>
         <translation>A curva &lt;b&gt;%1&lt;/b&gt; não existe mais! Operação abortada!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Start limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite inicial</translation>
-    </message>
-    <message>
-        <source>QtiPlot - End limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite final</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input error</source>
-        <translation type="obsolete">QtiPlot - Erro de entrada</translation>
     </message>
     <message>
         <source>Please enter x limits that satisfy: from &lt; to!</source>
@@ -9414,12 +8694,8 @@ Os limites devem estar dentro do intervalo de x; se não conhece o valor máximo
 <context>
     <name>LayerDialog</name>
     <message>
-        <source>QtiPlot - Arrange Layers</source>
-        <translation type="obsolete">QtiPlot - Organizar camadas</translation>
-    </message>
-    <message>
         <source>Number of Layers</source>
-        <translation type="obsolete">Número de camadas</translation>
+        <translation>Número de camadas</translation>
     </message>
     <message>
         <source>Automatic &amp;layout</source>
@@ -9515,19 +8791,19 @@ Os limites devem estar dentro do intervalo de x; se não conhece o valor máximo
     </message>
     <message>
         <source>Layout</source>
-        <translation type="obsolete">Disposição</translation>
+        <translation>Disposição</translation>
     </message>
     <message>
         <source>Titles</source>
-        <translation type="obsolete">Títulos</translation>
+        <translation>Títulos</translation>
     </message>
     <message>
         <source>Legends</source>
-        <translation type="obsolete">Legendas</translation>
+        <translation>Legendas</translation>
     </message>
     <message>
         <source>Fonts</source>
-        <translation type="obsolete">Fontes</translation>
+        <translation>Fontes</translation>
     </message>
     <message>
         <source>&amp;Apply</source>
@@ -9542,10 +8818,6 @@ Os limites devem estar dentro do intervalo de x; se não conhece o valor máximo
         <translation>&amp;Cancelar</translation>
     </message>
     <message>
-        <source>QtiPlot - Delete Layers?</source>
-        <translation type="obsolete">QtiPlot - Remover camadas?</translation>
-    </message>
-    <message>
         <source>You are about to delete %1 existing layers.</source>
         <translation>Você está prestes a remover %1 camadas existentes.</translation>
     </message>
@@ -9558,16 +8830,8 @@ Os limites devem estar dentro do intervalo de x; se não conhece o valor máximo
         <translation>&amp;Continuar</translation>
     </message>
     <message>
-        <source>QtiPlot - Columns input error</source>
-        <translation type="obsolete">QtiPlot - Erro ao inserir colunas</translation>
-    </message>
-    <message>
         <source>The number of columns you&apos;ve entered is greater than the number of graphs (%1)!</source>
         <translation>O número de colunas fornecido é maior que o número de gráficos (%1)!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Rows input error</source>
-        <translation type="obsolete">QtiPlot - Erro ao inserir linhas</translation>
     </message>
     <message>
         <source>The number of rows you&apos;ve entered is greater than the number of graphs (%1)!</source>
@@ -9600,10 +8864,6 @@ Os limites devem estar dentro do intervalo de x; se não conhece o valor máximo
 </context>
 <context>
     <name>LineDialog</name>
-    <message>
-        <source>QtiPlot - Line options</source>
-        <translation type="obsolete">QtiPlot- Opções de linha</translation>
-    </message>
     <message>
         <source>Color</source>
         <translation>Cor</translation>
@@ -9702,7 +8962,7 @@ Os limites devem estar dentro do intervalo de x; se não conhece o valor máximo
     </message>
     <message>
         <source>To</source>
-        <translation type="obsolete">A</translation>
+        <translation>A</translation>
     </message>
     <message>
         <source>End Point</source>
@@ -9729,7 +8989,7 @@ Os limites devem estar dentro do intervalo de x; se não conhece o valor máximo
     </message>
     <message>
         <source>Table</source>
-        <translation type="obsolete">Tabela</translation>
+        <translation>Tabela</translation>
     </message>
     <message>
         <source>Pixel selection warning</source>
@@ -9767,10 +9027,6 @@ Os limites devem estar dentro do intervalo de x; se não conhece o valor máximo
         <translation>Linear</translation>
     </message>
     <message>
-        <source>QtiPlot - Fit Error</source>
-        <translation type="obsolete">QtiPlot - Erro de ajuste</translation>
-    </message>
-    <message>
         <source>You need at least %1 data points for this fit operation. Operation aborted!</source>
         <translation>São necessários pelo menos %1 pontos para esta operação de ajuste. Operação abortada!</translation>
     </message>
@@ -9805,20 +9061,12 @@ Os limites devem estar dentro do intervalo de x; se não conhece o valor máximo
 <context>
     <name>Matrix</name>
     <message>
-        <source>QtiPlot - Input error</source>
-        <translation type="obsolete">QtiPlot - Erro de entrada</translation>
-    </message>
-    <message>
         <source>Yes</source>
-        <translation type="obsolete">Sim</translation>
+        <translation>Sim</translation>
     </message>
     <message>
         <source>Cancel</source>
         <translation>Cancelar</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
     </message>
     <message>
         <source>Calculation failed, the matrix is not square!</source>
@@ -9830,32 +9078,28 @@ Os limites devem estar dentro do intervalo de x; se não conhece o valor máximo
     </message>
     <message>
         <source>No</source>
-        <translation type="obsolete">No</translation>
-    </message>
-    <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
+        <translation>No</translation>
     </message>
     <message>
         <source>The text in the clipboard is larger than your current selection!	        
 Do you want to insert cells?</source>
-        <translation type="obsolete">O texto na área de transferência é maior que a seleção!	        
+        <translation>O texto na área de transferência é maior que a seleção!	        
 Gostaria de inserir células?</translation>
     </message>
     <message>
         <source>Ctrl+A</source>
         <comment>Matriz: selecionar tudo</comment>
-        <translation type="obsolete">Ctrl+A</translation>
+        <translation>Ctrl+A</translation>
     </message>
     <message>
         <source>Deleting rows/columns from the matrix!</source>
         <comment>set matrix dimensions</comment>
-        <translation type="obsolete">Apagando linhas/colunas desta matriz!</translation>
+        <translation>Apagando linhas/colunas desta matriz!</translation>
     </message>
     <message>
         <source>&lt;p&gt;Do you really want to continue?</source>
         <comment>set matrix dimensions</comment>
-        <translation type="obsolete">&lt;p&gt;Deseja realmente continuar?</translation>
+        <translation>&lt;p&gt;Deseja realmente continuar?</translation>
     </message>
     <message>
         <source>SciDAVis</source>
@@ -9887,284 +9131,284 @@ Gostaria de inserir células?</translation>
     </message>
     <message>
         <source>%1: cut selected cell(s)</source>
-        <translation type="obsolete">%1: cortar célula(s) selecionada(s)</translation>
+        <translation>%1: cortar célula(s) selecionada(s)</translation>
     </message>
     <message>
         <source>%1: paste from clipboard</source>
-        <translation type="obsolete">%1: colar da área de trabalho</translation>
+        <translation>%1: colar da área de trabalho</translation>
     </message>
     <message>
         <source>%1: clear selected cell(s)</source>
-        <translation type="obsolete">%1: limpar célula(s) selecionada(s)</translation>
+        <translation>%1: limpar célula(s) selecionada(s)</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
-        <translation type="obsolete">C&amp;opiar</translation>
+        <translation>C&amp;opiar</translation>
     </message>
     <message>
         <source>Past&amp;e</source>
-        <translation type="obsolete">Co&amp;lar</translation>
+        <translation>Co&amp;lar</translation>
     </message>
     <message>
         <source>Clea&amp;r</source>
         <comment>clear selection</comment>
-        <translation type="obsolete">Limpa&amp;r</translation>
+        <translation>Limpa&amp;r</translation>
     </message>
     <message>
         <source>Alt+Q</source>
-        <translation type="obsolete">Alt+Q</translation>
+        <translation>Alt+Q</translation>
     </message>
     <message>
         <source>Recalculate</source>
-        <translation type="obsolete">Recalcular</translation>
+        <translation>Recalcular</translation>
     </message>
     <message>
         <source>F12</source>
-        <translation type="obsolete">F12</translation>
+        <translation>F12</translation>
     </message>
     <message>
         <source>Select All</source>
-        <translation type="obsolete">Selecionar tudo</translation>
+        <translation>Selecionar tudo</translation>
     </message>
     <message>
         <source>Clear Matrix</source>
-        <translation type="obsolete">Limpar matriz</translation>
+        <translation>Limpar matriz</translation>
     </message>
     <message>
         <source>&amp;Go to Cell</source>
-        <translation type="obsolete">Ir para célula</translation>
+        <translation>Ir para célula</translation>
     </message>
     <message>
         <source>Ctrl+Alt+G</source>
-        <translation type="obsolete">Ctrl+Alt+G</translation>
+        <translation>Ctrl+Alt+G</translation>
     </message>
     <message>
         <source>&amp;Transpose</source>
-        <translation type="obsolete">&amp;Transpor</translation>
+        <translation>&amp;Transpor</translation>
     </message>
     <message>
         <source>Mirror &amp;Horizontally</source>
-        <translation type="obsolete">Espelhar horizontalmente</translation>
+        <translation>Espelhar horizontalmente</translation>
     </message>
     <message>
         <source>Mirror &amp;Vertically</source>
-        <translation type="obsolete">Espelhar verticalmente</translation>
+        <translation>Espelhar verticalmente</translation>
     </message>
     <message>
         <source>&amp;Import Image</source>
         <comment>import image as matrix</comment>
-        <translation type="obsolete">Importar imagem</translation>
+        <translation>Importar imagem</translation>
     </message>
     <message>
         <source>&amp;Duplicate</source>
         <comment>duplicate matrix</comment>
-        <translation type="obsolete">&amp;Duplicar</translation>
+        <translation>&amp;Duplicar</translation>
     </message>
     <message>
         <source>Set &amp;Coordinates</source>
-        <translation type="obsolete">Coordenadas</translation>
+        <translation>Coordenadas</translation>
     </message>
     <message>
         <source>Set Display &amp;Format</source>
-        <translation type="obsolete">Definir formato do mostrador</translation>
+        <translation>Definir formato do mostrador</translation>
     </message>
     <message>
         <source>&amp;Insert Empty Columns</source>
-        <translation type="obsolete">Inserir coluna vazia</translation>
+        <translation>Inserir coluna vazia</translation>
     </message>
     <message>
         <source>Remo&amp;ve Columns</source>
-        <translation type="obsolete">Remover colunas</translation>
+        <translation>Remover colunas</translation>
     </message>
     <message>
         <source>Clea&amp;r Columns</source>
-        <translation type="obsolete">Limpar colunas</translation>
+        <translation>Limpar colunas</translation>
     </message>
     <message>
         <source>&amp;Add Columns</source>
-        <translation type="obsolete">Adicionar colunas</translation>
+        <translation>Adicionar colunas</translation>
     </message>
     <message>
         <source>&amp;Insert Empty Rows</source>
-        <translation type="obsolete">Inserir linhas vazias</translation>
+        <translation>Inserir linhas vazias</translation>
     </message>
     <message>
         <source>Remo&amp;ve Rows</source>
-        <translation type="obsolete">Remover linhas</translation>
+        <translation>Remover linhas</translation>
     </message>
     <message>
         <source>Clea&amp;r Rows</source>
-        <translation type="obsolete">Lim&amp;par linhas</translation>
+        <translation>Lim&amp;par linhas</translation>
     </message>
     <message>
         <source>&amp;Add Rows</source>
-        <translation type="obsolete">Adicionar linhas</translation>
+        <translation>Adicionar linhas</translation>
     </message>
     <message>
         <source>&amp;Matrix</source>
-        <translation type="obsolete">&amp;Matriz</translation>
+        <translation>&amp;Matriz</translation>
     </message>
     <message>
         <source>Go to Cell</source>
-        <translation type="obsolete">Ir para a célula</translation>
+        <translation>Ir para a célula</translation>
     </message>
     <message>
         <source>Enter column</source>
-        <translation type="obsolete">Inserir coluna</translation>
+        <translation>Inserir coluna</translation>
     </message>
     <message>
         <source>Enter row</source>
-        <translation type="obsolete">Inserir linha</translation>
+        <translation>Inserir linha</translation>
     </message>
     <message>
         <source>Set Matrix Dimensions</source>
-        <translation type="obsolete">Definir dimensões da matriz</translation>
+        <translation>Definir dimensões da matriz</translation>
     </message>
     <message>
         <source>Enter number of columns</source>
-        <translation type="obsolete">Número de colunas</translation>
+        <translation>Número de colunas</translation>
     </message>
     <message>
         <source>Enter number of rows</source>
-        <translation type="obsolete">Número de linhas</translation>
+        <translation>Número de linhas</translation>
     </message>
     <message>
         <source>Error importing image</source>
-        <translation type="obsolete">Erro ao importar imagem</translation>
+        <translation>Erro ao importar imagem</translation>
     </message>
     <message>
         <source>Import of image &apos;%1&apos; failed</source>
-        <translation type="obsolete">A importação da imagem &apos;%1&apos; falhou</translation>
+        <translation>A importação da imagem &apos;%1&apos; falhou</translation>
     </message>
     <message>
         <source>invalid row or column count</source>
-        <translation type="obsolete">Contagem de linhas ou colunas inválidas</translation>
+        <translation>Contagem de linhas ou colunas inválidas</translation>
     </message>
     <message>
         <source>no matrix element found</source>
-        <translation type="obsolete">Nenhum elemento de matriz encontrado</translation>
+        <translation>Nenhum elemento de matriz encontrado</translation>
     </message>
     <message>
         <source>invalid or missing numeric format</source>
-        <translation type="obsolete">Formato numérico inválido ou ausente</translation>
+        <translation>Formato numérico inválido ou ausente</translation>
     </message>
     <message>
         <source>invalid or missing number of displayed digits</source>
-        <translation type="obsolete">O número de dígitos mostrados não é válido</translation>
+        <translation>O número de dígitos mostrados não é válido</translation>
     </message>
     <message>
         <source>invalid x start value</source>
-        <translation type="obsolete">O valor inicial de x não é válido</translation>
+        <translation>O valor inicial de x não é válido</translation>
     </message>
     <message>
         <source>invalid x end value</source>
-        <translation type="obsolete">O valor final de x não é válido</translation>
+        <translation>O valor final de x não é válido</translation>
     </message>
     <message>
         <source>invalid y start value</source>
-        <translation type="obsolete">valor inicial de y inválido</translation>
+        <translation>valor inicial de y inválido</translation>
     </message>
     <message>
         <source>invalid y end value</source>
-        <translation type="obsolete">valor final de y inválido</translation>
+        <translation>valor final de y inválido</translation>
     </message>
     <message>
         <source>invalid row height</source>
-        <translation type="obsolete">altura de linha inválida</translation>
+        <translation>altura de linha inválida</translation>
     </message>
     <message>
         <source>invalid or missing column index</source>
-        <translation type="obsolete">índice de colunas inválido ou inexistente</translation>
+        <translation>índice de colunas inválido ou inexistente</translation>
     </message>
     <message>
         <source>invalid column width</source>
-        <translation type="obsolete">largura de coluna inválida</translation>
+        <translation>largura de coluna inválida</translation>
     </message>
     <message>
         <source>invalid cell value</source>
-        <translation type="obsolete">valor da célula inválido</translation>
+        <translation>valor da célula inválido</translation>
     </message>
     <message>
         <source>Hide Controls</source>
-        <translation type="obsolete">Ocultar controles</translation>
+        <translation>Ocultar controles</translation>
     </message>
     <message>
         <source>Show Controls</source>
-        <translation type="obsolete">Mostrar controles</translation>
+        <translation>Mostrar controles</translation>
     </message>
     <message>
         <source>Matrix</source>
-        <translation type="obsolete">Matriz</translation>
+        <translation>Matriz</translation>
     </message>
     <message>
         <source>Import image...</source>
-        <translation type="obsolete">Importar imagem...</translation>
+        <translation>Importar imagem...</translation>
     </message>
 </context>
 <context>
     <name>MatrixControlTabs</name>
     <message>
         <source>Control Tabs</source>
-        <translation type="obsolete">Abas de controle</translation>
+        <translation>Abas de controle</translation>
     </message>
     <message>
         <source>Coordinates</source>
-        <translation type="obsolete">Coordenadas</translation>
+        <translation>Coordenadas</translation>
     </message>
     <message>
         <source>Appl&amp;y</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>First column X =</source>
-        <translation type="obsolete">Primeira coluna X =</translation>
+        <translation>Primeira coluna X =</translation>
     </message>
     <message>
         <source>Last column X =</source>
-        <translation type="obsolete">Última coluna X =</translation>
+        <translation>Última coluna X =</translation>
     </message>
     <message>
         <source>First row Y =</source>
-        <translation type="obsolete">Primeira linha Y =</translation>
+        <translation>Primeira linha Y =</translation>
     </message>
     <message>
         <source>Format</source>
-        <translation type="obsolete">Formato</translation>
+        <translation>Formato</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Apply new type and format to all selected columns&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Aplicar novo tipo e formato em todas as colunas selecionadas&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Format:</source>
-        <translation type="obsolete">Formato:</translation>
+        <translation>Formato:</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Choose the display format&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Escolha o formato a ser mostrado&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Decimal Digits:</source>
-        <translation type="obsolete">Casas decimais</translation>
+        <translation>Casas decimais</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Enter the number of displayed decimal digits&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Insira o número de casas decimais a serem mostradas&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
@@ -10174,25 +9418,25 @@ p, li { white-space: pre-wrap; }
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Information about the selected type and format&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Informação sobre o tipo e formato selecionado&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Formula</source>
-        <translation type="obsolete">Fórmula</translation>
+        <translation>Fórmula</translation>
     </message>
     <message>
         <source>Formula:</source>
-        <translation type="obsolete">Fórmula:</translation>
+        <translation>Fórmula:</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Apply the formula to all selected cells&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Aplicar fórmula em todas as células selecionadas&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
@@ -10202,7 +9446,7 @@ p, li { white-space: pre-wrap; }
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Select a column reference to insert into the formula&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Selecione uma coluna de referência para inserir na fórmula&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
@@ -10212,21 +9456,21 @@ p, li { white-space: pre-wrap; }
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Insert the column reference into the formula&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Insira a coluna de referência na fórmula&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Add</source>
-        <translation type="obsolete">Adicionar</translation>
+        <translation>Adicionar</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Select a function to insert into the formula&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Selecione uma função para inserir na fórmula&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
@@ -10236,175 +9480,159 @@ p, li { white-space: pre-wrap; }
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Inset the function into the formula&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="obsolete">&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Insira a função na fórmula&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Last row Y =</source>
-        <translation type="obsolete">Última linha Y =</translation>
+        <translation>Última linha Y =</translation>
     </message>
 </context>
 <context>
     <name>MatrixDialog</name>
     <message>
         <source>Cell Width</source>
-        <translation type="obsolete">Largura de célula</translation>
+        <translation>Largura de célula</translation>
     </message>
     <message>
         <source>Data Format</source>
-        <translation type="obsolete">Formato dos dados</translation>
+        <translation>Formato dos dados</translation>
     </message>
     <message>
         <source>Numeric Display</source>
-        <translation type="obsolete">Mostrador numérico</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Matrix Properties</source>
-        <translation type="obsolete">QtiPlot - Propriedades da matriz</translation>
+        <translation>Mostrador numérico</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>Decimal: 1000</source>
-        <translation type="obsolete">Decimal: 1000</translation>
+        <translation>Decimal: 1000</translation>
     </message>
     <message>
         <source>Scientific: 1E3</source>
-        <translation type="obsolete">Científico: 1E3</translation>
+        <translation>Científico: 1E3</translation>
     </message>
     <message>
         <source>Default Decimal Digits</source>
-        <translation type="obsolete">Casas decimais padrão</translation>
+        <translation>Casas decimais padrão</translation>
     </message>
     <message>
         <source>Significant Digits=</source>
-        <translation type="obsolete">Algarismos significativos=</translation>
+        <translation>Algarismos significativos=</translation>
     </message>
     <message>
         <source>Matrix Properties</source>
-        <translation type="obsolete">Propriedades da matriz</translation>
+        <translation>Propriedades da matriz</translation>
     </message>
     <message>
         <source>Decimal digits</source>
-        <translation type="obsolete">Digitos decimais</translation>
+        <translation>Digitos decimais</translation>
     </message>
 </context>
 <context>
     <name>MatrixSizeDialog</name>
     <message>
         <source>Dimensions</source>
-        <translation type="obsolete">Dimensões</translation>
+        <translation>Dimensões</translation>
     </message>
     <message>
         <source>Coordinates</source>
-        <translation type="obsolete">Coordenadas</translation>
+        <translation>Coordenadas</translation>
     </message>
     <message>
         <source>Rows</source>
-        <translation type="obsolete">Linhas</translation>
+        <translation>Linhas</translation>
     </message>
     <message>
         <source>Columns</source>
-        <translation type="obsolete">Colunas</translation>
+        <translation>Colunas</translation>
     </message>
     <message>
         <source>X (Columns)</source>
-        <translation type="obsolete">X (Colunas)</translation>
+        <translation>X (Colunas)</translation>
     </message>
     <message>
         <source>Y (Rows)</source>
-        <translation type="obsolete">Y (Linhas)</translation>
+        <translation>Y (Linhas)</translation>
     </message>
     <message>
         <source>First</source>
-        <translation type="obsolete">Primeiro</translation>
+        <translation>Primeiro</translation>
     </message>
     <message>
         <source>Last</source>
-        <translation type="obsolete">�ltimo</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Matrix Dimensions</source>
-        <translation type="obsolete">QtiPlot - Dimensões da matriz</translation>
+        <translation>�ltimo</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input error</source>
-        <translation type="obsolete">QtiPlot - Erro de entrada</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Matrix Dimensions</source>
-        <translation type="obsolete">Dimensões da matriz</translation>
+        <translation>Dimensões da matriz</translation>
     </message>
     <message>
         <source>Input error</source>
-        <translation type="obsolete">Erro de entrada</translation>
+        <translation>Erro de entrada</translation>
     </message>
 </context>
 <context>
     <name>MatrixValuesDialog</name>
     <message>
-        <source>QtiPlot - Set Matrix Values</source>
-        <translation type="obsolete">QtiPlot - DEfinir valores da matriz</translation>
-    </message>
-    <message>
         <source>For row (i)</source>
-        <translation type="obsolete">Para a linha (i)</translation>
+        <translation>Para a linha (i)</translation>
     </message>
     <message>
         <source>to</source>
-        <translation type="obsolete">a</translation>
+        <translation>a</translation>
     </message>
     <message>
         <source>For col (j)</source>
-        <translation type="obsolete">Para col (j)</translation>
+        <translation>Para col (j)</translation>
     </message>
     <message>
         <source>Add function</source>
-        <translation type="obsolete">Adicionar função</translation>
+        <translation>Adicionar função</translation>
     </message>
     <message>
         <source>Add Cell</source>
-        <translation type="obsolete">Adicionar célula</translation>
+        <translation>Adicionar célula</translation>
     </message>
     <message>
         <source>Cell(i,j)=</source>
-        <translation type="obsolete">Célula(i,j)=</translation>
+        <translation>Célula(i,j)=</translation>
     </message>
     <message>
         <source>OK</source>
-        <translation type="obsolete">OK</translation>
+        <translation>OK</translation>
     </message>
     <message>
         <source>Apply</source>
-        <translation type="obsolete">Aplicar</translation>
+        <translation>Aplicar</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">Cancelar</translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
         <source>Set Matrix Values</source>
-        <translation type="obsolete">Definir valores da matriz</translation>
+        <translation>Definir valores da matriz</translation>
     </message>
 </context>
 <context>
@@ -10412,35 +9640,35 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Ctrl+A</source>
         <comment>Matrix: select all</comment>
-        <translation type="obsolete">Ctrl+A</translation>
+        <translation>Ctrl+A</translation>
     </message>
     <message>
         <source>Show/hide control tabs</source>
-        <translation type="obsolete">Mostrar/esconder abas de controle</translation>
+        <translation>Mostrar/esconder abas de controle</translation>
     </message>
     <message>
         <source>Decimal</source>
-        <translation type="obsolete">Decimal</translation>
+        <translation>Decimal</translation>
     </message>
     <message>
         <source>Scientific (e)</source>
-        <translation type="obsolete">Científico (e)</translation>
+        <translation>Científico (e)</translation>
     </message>
     <message>
         <source>Scientific (E)</source>
-        <translation type="obsolete">Científico (E)</translation>
+        <translation>Científico (E)</translation>
     </message>
     <message>
         <source>Example: %1</source>
-        <translation type="obsolete">Exemplo: %1</translation>
+        <translation>Exemplo: %1</translation>
     </message>
     <message>
         <source>Automatic (e)</source>
-        <translation type="obsolete">Automático (e)</translation>
+        <translation>Automático (e)</translation>
     </message>
     <message>
         <source>Automatic (E)</source>
-        <translation type="obsolete">Automático (E)</translation>
+        <translation>Automático (E)</translation>
     </message>
 </context>
 <context>
@@ -10792,18 +10020,6 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
 <context>
     <name>MultiLayer</name>
     <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Guess best origin for the new layer?</source>
-        <translation type="obsolete">QtiPlot - Procurar melhor origem para a nova camada?</translation>
-    </message>
-    <message>
-        <source>Do you want QtiPlot to rearrange the remaining layers?</source>
-        <translation type="obsolete">Você quer que o QtiPlot reorganize as camadas restantes?</translation>
-    </message>
-    <message>
         <source>&amp;Yes</source>
         <translation>&amp;Sim</translation>
     </message>
@@ -10816,24 +10032,12 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
         <translation>&amp;Cancelar</translation>
     </message>
     <message>
-        <source>QtiPlot - Error: arranging layers failed!</source>
-        <translation type="obsolete">QtiPlot - Erro: a organização de camadas falhou!</translation>
-    </message>
-    <message>
         <source>There is not enaugh space available in this window.&lt;p&gt;You could try to maximize it first and to rearrange the layers using the automatic option!&lt;/p&gt;</source>
-        <translation type="obsolete">Não há espaço suficiente disponível nesta janela.&lt;p&gt;Você pode tentar primeiro reorganizar as camadas usando a opção automática!&lt;/p&gt;</translation>
+        <translation>Não há espaço suficiente disponível nesta janela.&lt;p&gt;Você pode tentar primeiro reorganizar as camadas usando a opção automática!&lt;/p&gt;</translation>
     </message>
     <message>
         <source>enter your text here</source>
         <translation>digite seu texto aqui</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Guess best layout?</source>
-        <translation type="obsolete">QtiPlot - Buscar melhor organização?</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
     </message>
     <message>
         <source>Please provide a valid file name!</source>
@@ -10864,11 +10068,11 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
     </message>
     <message>
         <source>Gauss</source>
-        <translation type="obsolete">Gauss</translation>
+        <translation>Gauss</translation>
     </message>
     <message>
         <source>Lorentz</source>
-        <translation type="obsolete">Lorentz</translation>
+        <translation>Lorentz</translation>
     </message>
     <message>
         <source>multi-peak</source>
@@ -10877,10 +10081,6 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
     <message>
         <source>Peak</source>
         <translation>Pico</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Fit Error</source>
-        <translation type="obsolete">QtiPlot - Erro de ajuste</translation>
     </message>
     <message>
         <source>Could not allocate enough memory for the fit curves!</source>
@@ -10983,10 +10183,6 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
 <context>
     <name>MyWidget</name>
     <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
-    </message>
-    <message>
         <source>Do you want to hide or delete</source>
         <translation>Você quer ocultar ou excluir</translation>
     </message>
@@ -11020,7 +10216,7 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
     </message>
     <message>
         <source>kB</source>
-        <translation type="obsolete">kB</translation>
+        <translation>kB</translation>
     </message>
     <message>
         <source>SciDAVis</source>
@@ -11038,24 +10234,16 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
         <translation>Não linear</translation>
     </message>
     <message>
-        <source>QtiPlot - Input function error</source>
-        <translation type="obsolete">QtiPlot - Erro na fórmula fornecida</translation>
-    </message>
-    <message>
         <source>Please enter a valid non-empty expression! Operation aborted!</source>
-        <translation type="obsolete">Por favor, forneça uma expressão válida não vazia! Operação abortada!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Fit Error</source>
-        <translation type="obsolete">QtiPlot - Erro ao ajuste</translation>
+        <translation>Por favor, forneça uma expressão válida não vazia! Operação abortada!</translation>
     </message>
     <message>
         <source>There are no parameters specified for this fit operation. Please define a list of parameters first!</source>
-        <translation type="obsolete">Não foram especificados os parâmetros para esta operação de ajuste. Por favor, defina uma lista de parâmetros primeiro!</translation>
+        <translation>Não foram especificados os parâmetros para esta operação de ajuste. Por favor, defina uma lista de parâmetros primeiro!</translation>
     </message>
     <message>
         <source>You must provide a list containing at least 2 parameters for this type of fit. Operation aborted!</source>
-        <translation type="obsolete">Você deve fornecer uma lista contendo pelo menos 2 parâmetros para este tipo de ajuste. Operação abortada!</translation>
+        <translation>Você deve fornecer uma lista contendo pelo menos 2 parâmetros para este tipo de ajuste. Operação abortada!</translation>
     </message>
     <message>
         <source>You must provide a list containing at least one parameter for this type of fit. Operation aborted!</source>
@@ -11063,7 +10251,7 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
     </message>
     <message>
         <source>Input function error</source>
-        <translation type="obsolete">Erro na função fornecida</translation>
+        <translation>Erro na função fornecida</translation>
     </message>
     <message>
         <source>Fit Error</source>
@@ -11073,20 +10261,16 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
 <context>
     <name>Note</name>
     <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
-    </message>
-    <message>
         <source>Delete</source>
-        <translation type="obsolete">Apagar</translation>
+        <translation>Apagar</translation>
     </message>
     <message>
         <source>Hide</source>
-        <translation type="obsolete">Ocultar</translation>
+        <translation>Ocultar</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">Cancelar</translation>
+        <translation>Cancelar</translation>
     </message>
 </context>
 <context>
@@ -11214,88 +10398,84 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
 <context>
     <name>PieDialog</name>
     <message>
-        <source>QtiPlot - Pie Options</source>
-        <translation type="obsolete">QtiPlot - Opções de Pizza</translation>
-    </message>
-    <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="obsolete">Cor</translation>
+        <translation>Cor</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="obsolete">Estilo</translation>
+        <translation>Estilo</translation>
     </message>
     <message>
         <source>Width</source>
-        <translation type="obsolete">Largura</translation>
+        <translation>Largura</translation>
     </message>
     <message>
         <source>Border</source>
-        <translation type="obsolete">Borda</translation>
+        <translation>Borda</translation>
     </message>
     <message>
         <source>First color</source>
-        <translation type="obsolete">Primeira cor</translation>
+        <translation>Primeira cor</translation>
     </message>
     <message>
         <source>Pattern</source>
-        <translation type="obsolete">Modelo</translation>
+        <translation>Modelo</translation>
     </message>
     <message>
         <source>Pie radius</source>
-        <translation type="obsolete">Raio da pizza</translation>
+        <translation>Raio da pizza</translation>
     </message>
     <message>
         <source>Fill</source>
-        <translation type="obsolete">Preenchimento</translation>
+        <translation>Preenchimento</translation>
     </message>
     <message>
         <source>Pie</source>
-        <translation type="obsolete">Pizza</translation>
+        <translation>Pizza</translation>
     </message>
     <message>
         <source>Opacity</source>
-        <translation type="obsolete">Opacidade</translation>
+        <translation>Opacidade</translation>
     </message>
     <message>
         <source>Canvas Color</source>
-        <translation type="obsolete">Cor de fundo</translation>
+        <translation>Cor de fundo</translation>
     </message>
     <message>
         <source>Border Width</source>
-        <translation type="obsolete">Largura da borda</translation>
+        <translation>Largura da borda</translation>
     </message>
     <message>
         <source>Border Color</source>
-        <translation type="obsolete">Cor da borda</translation>
+        <translation>Cor da borda</translation>
     </message>
     <message>
         <source>Background</source>
-        <translation type="obsolete">Fundo</translation>
+        <translation>Fundo</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="obsolete">Opções</translation>
+        <translation>Opções</translation>
     </message>
     <message>
         <source>Apply to all layers</source>
-        <translation type="obsolete">Aplicar a todas as camadas</translation>
+        <translation>Aplicar a todas as camadas</translation>
     </message>
     <message>
         <source>General</source>
-        <translation type="obsolete">Geral</translation>
+        <translation>Geral</translation>
     </message>
 </context>
 <context>
@@ -11311,10 +10491,6 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
 </context>
 <context>
     <name>Plot3DDialog</name>
-    <message>
-        <source>QtiPlot - Surface Plot Options</source>
-        <translation type="obsolete">QtiPlot - Opções de gráfico de superfície</translation>
-    </message>
     <message>
         <source>&amp;Apply</source>
         <translation>&amp;Aplicar</translation>
@@ -11564,18 +10740,6 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
         <translation>Arquivos de mapa de cores</translation>
     </message>
     <message>
-        <source>QtiPlot - Start limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite inicial</translation>
-    </message>
-    <message>
-        <source>QtiPlot - End limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite final</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input error</source>
-        <translation type="obsolete">QtiPlot - Erro de entrada</translation>
-    </message>
-    <message>
         <source>Please enter scale limits that satisfy: from &lt; to!</source>
         <translation>Por favor, forneça limites de escala que satisfaçam: inicio &lt; fim!</translation>
     </message>
@@ -11604,7 +10768,7 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
     </message>
     <message>
         <source>&amp;Edit Function...</source>
-        <translation type="obsolete">&amp;Editar função...</translation>
+        <translation>&amp;Editar função...</translation>
     </message>
     <message>
         <source>Plot type</source>
@@ -12139,10 +11303,6 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
         <translation>Linha + Símbolo</translation>
     </message>
     <message>
-        <source>QtiPlot - Input error</source>
-        <translation type="obsolete">QtiPlot - Erro de entrada</translation>
-    </message>
-    <message>
         <source>Please enter a valid start limit!</source>
         <translation>Por favor, forneça um limite inicial válido!</translation>
     </message>
@@ -12155,20 +11315,8 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
         <translation>Por favor, forneça um  valor de bin válido!</translation>
     </message>
     <message>
-        <source>QtiPlot - Start limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite inicial</translation>
-    </message>
-    <message>
-        <source>QtiPlot - End limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite final</translation>
-    </message>
-    <message>
         <source>Please enter limits that satisfy: begin &lt; end!</source>
         <translation>Por favor, forneça limites que satisfaçam: início &lt; fim!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Bin size input error</source>
-        <translation type="obsolete">QtiPlot - Erro no tamanho do bin</translation>
     </message>
     <message>
         <source>Please enter a positive bin size value!</source>
@@ -12294,10 +11442,6 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
 <context>
     <name>PlotWizard</name>
     <message>
-        <source>QtiPlot - Select Columns to Plot</source>
-        <translation type="obsolete">QtiPlot - Selecione colunas para o gráfico</translation>
-    </message>
-    <message>
         <source>&amp;X</source>
         <translation>&amp;X</translation>
     </message>
@@ -12338,12 +11482,8 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
         <translation>&amp;Fechar</translation>
     </message>
     <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
-    </message>
-    <message>
         <source>Please define a e column for the following curve</source>
-        <translation type="obsolete">Por favor defina uma e coluna para a seguinte curva</translation>
+        <translation>Por favor defina uma e coluna para a seguinte curva</translation>
     </message>
     <message>
         <source>You have already defined a X column!</source>
@@ -12355,11 +11495,7 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
     </message>
     <message>
         <source>You have already defined a e column!</source>
-        <translation type="obsolete">Já foi definida uma coluna Y!</translation>
-    </message>
-    <message>
-        <source>This kind of curve is not handled by QtiPlot!</source>
-        <translation type="obsolete">Este tipo de gráfico não é manipulada pelo QtiPlot!</translation>
+        <translation>Já foi definida uma coluna Y!</translation>
     </message>
     <message>
         <source>You have already defined a Z column!</source>
@@ -12367,7 +11503,7 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
     </message>
     <message>
         <source>You must define a e column first!</source>
-        <translation type="obsolete">� necessário definir uma coluna e primeiro!</translation>
+        <translation>É necessário definir uma coluna e primeiro!</translation>
     </message>
     <message>
         <source>You have already defined an error-bars column!</source>
@@ -12406,19 +11542,11 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
     <name>PluginFit</name>
     <message>
         <source>Plugin</source>
-        <translation type="obsolete">Plugin</translation>
-    </message>
-    <message>
-        <source>QtiPlot - File not found</source>
-        <translation type="obsolete">QtiPlot - Arquivo não encontrado</translation>
+        <translation>Plugin</translation>
     </message>
     <message>
         <source>Plugin file: &lt;p&gt;&lt;b&gt; %1 &lt;/b&gt; &lt;p&gt;not found. Operation aborted!</source>
         <translation>Arquivo de plugin: &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;p&gt;não encontrado. Operação abortada!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Plugin Error</source>
-        <translation type="obsolete">QtiPlot - Erro de Plugin</translation>
     </message>
     <message>
         <source>The plugin does not implement a %1 method necessary for simplex fitting.</source>
@@ -12444,10 +11572,6 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
 <context>
     <name>PolynomFitDialog</name>
     <message>
-        <source>QtiPlot - Polynomial Fit Options</source>
-        <translation type="obsolete">QtiPlot - Opções de ajuste polinomial</translation>
-    </message>
-    <message>
         <source>Polynomial Fit of</source>
         <translation>Ajuste polinomial de </translation>
     </message>
@@ -12457,11 +11581,11 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
     </message>
     <message>
         <source>Fit curve # pts</source>
-        <translation type="obsolete"># pts da curva</translation>
+        <translation># pts da curva</translation>
     </message>
     <message>
         <source>Not enough points</source>
-        <translation type="obsolete">Não existem pontos suficientes</translation>
+        <translation>Não existem pontos suficientes</translation>
     </message>
     <message>
         <source>Fit curve Xmin</source>
@@ -12492,10 +11616,6 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
         <translation>&amp;Fechar</translation>
     </message>
     <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
-    </message>
-    <message>
         <source>The curve &lt;b&gt; %1 &lt;/b&gt; doesn&apos;t exist anymore! Operation aborted!</source>
         <translation>A curva &lt;b&gt;%1&lt;/b&gt; não existe mais! Operação abortada!</translation>
     </message>
@@ -12519,10 +11639,6 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
         <translation>Polinomial</translation>
     </message>
     <message>
-        <source>QtiPlot - Fit Error</source>
-        <translation type="obsolete">QtiPlot - Erro ao ajustar</translation>
-    </message>
-    <message>
         <source>You need at least %1 data points for this fit operation. Operation aborted!</source>
         <translation>São necessários pelo menos %1 pontos para este ajuste. Operação abortada!</translation>
     </message>
@@ -12535,46 +11651,46 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
     <name>Project</name>
     <message>
         <source>Unnamed</source>
-        <translation type="obsolete">Sem nome</translation>
+        <translation>Sem nome</translation>
     </message>
     <message>
         <source>invalid or missing project version</source>
-        <translation type="obsolete">versão do projeto inválida ou faltando</translation>
+        <translation>versão do projeto inválida ou faltando</translation>
     </message>
     <message>
         <source>unknown element &apos;%1&apos;</source>
-        <translation type="obsolete">o elemento &apos;%1&apos; é desconhecido</translation>
+        <translation>o elemento &apos;%1&apos; é desconhecido</translation>
     </message>
     <message>
         <source>no scidavis_project element found</source>
-        <translation type="obsolete">nenhum elemento do scidavis encontrado</translation>
+        <translation>nenhum elemento do scidavis encontrado</translation>
     </message>
     <message>
         <source>no valid XML document found</source>
-        <translation type="obsolete">nenhum documento XML válido foi encontrado</translation>
+        <translation>nenhum documento XML válido foi encontrado</translation>
     </message>
 </context>
 <context>
     <name>ProjectConfigPage</name>
     <message>
         <source>Form</source>
-        <translation type="obsolete">A partir de</translation>
+        <translation>A partir de</translation>
     </message>
     <message>
         <source>By default, show the subwindows ...</source>
-        <translation type="obsolete">Mostrar subjanelas por padrão...</translation>
+        <translation>Mostrar subjanelas por padrão...</translation>
     </message>
     <message>
         <source>in the current folder</source>
-        <translation type="obsolete">na pasta atual</translation>
+        <translation>na pasta atual</translation>
     </message>
     <message>
         <source>in the current folder and its subfolders</source>
-        <translation type="obsolete">na pasta atual e em suas subpastas</translation>
+        <translation>na pasta atual e em suas subpastas</translation>
     </message>
     <message>
         <source>all subwindows in the project</source>
-        <translation type="obsolete">para todas as subjanelas no projeto</translation>
+        <translation>para todas as subjanelas no projeto</translation>
     </message>
 </context>
 <context>
@@ -12596,282 +11712,282 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
     </message>
     <message>
         <source>&amp;Remove</source>
-        <translation type="obsolete">&amp;Remover</translation>
+        <translation>&amp;Remover</translation>
     </message>
     <message>
         <source>In%1</source>
-        <translation type="obsolete">Em%1</translation>
+        <translation>Em%1</translation>
     </message>
     <message>
         <source>General</source>
-        <translation type="obsolete">Geral</translation>
+        <translation>Geral</translation>
     </message>
     <message>
         <source>%1: rename to %2</source>
-        <translation type="obsolete">%1: renomear para %2</translation>
+        <translation>%1: renomear para %2</translation>
     </message>
     <message>
         <source>%1: change comment</source>
-        <translation type="obsolete">%1: mudar comentário</translation>
+        <translation>%1: mudar comentário</translation>
     </message>
     <message>
         <source>%1: change caption</source>
-        <translation type="obsolete">%1: mudar legenda</translation>
+        <translation>%1: mudar legenda</translation>
     </message>
     <message>
         <source>%1: set creation time</source>
-        <translation type="obsolete">%1: definir hora de criação</translation>
+        <translation>%1: definir hora de criação</translation>
     </message>
     <message>
         <source>%1: remove %2</source>
-        <translation type="obsolete">%1: remover %2</translation>
+        <translation>%1: remover %2</translation>
     </message>
     <message>
         <source>%1: add %2</source>
-        <translation type="obsolete">%1: adicionar %2</translation>
+        <translation>%1: adicionar %2</translation>
     </message>
     <message>
         <source>%1: move child from position %2 to %3.</source>
-        <translation type="obsolete">%1: mover filho da posição %2 para %3.</translation>
+        <translation>%1: mover filho da posição %2 para %3.</translation>
     </message>
     <message>
         <source>%1: move %2 to %3.</source>
-        <translation type="obsolete">%1: mover %2 para %3.</translation>
+        <translation>%1: mover %2 para %3.</translation>
     </message>
     <message>
         <source>%1: change column type</source>
-        <translation type="obsolete">%1: alterar tipo da coluna</translation>
+        <translation>%1: alterar tipo da coluna</translation>
     </message>
     <message>
         <source>%1: change cell value(s)</source>
-        <translation type="obsolete">%1: alterar valor(es) da(s) célula(s)</translation>
+        <translation>%1: alterar valor(es) da(s) célula(s)</translation>
     </message>
     <message>
         <source>%1: insert %2 row(s)</source>
-        <translation type="obsolete">%1: inserir %2 linha(s)</translation>
+        <translation>%1: inserir %2 linha(s)</translation>
     </message>
     <message>
         <source>%1: remove %2 row(s)</source>
-        <translation type="obsolete">%1: remover %2 linha(s)</translation>
+        <translation>%1: remover %2 linha(s)</translation>
     </message>
     <message>
         <source>%1: set plot designation</source>
-        <translation type="obsolete">%1: definir designação do gráfico</translation>
+        <translation>%1: definir designação do gráfico</translation>
     </message>
     <message>
         <source>%1: clear column</source>
-        <translation type="obsolete">%1: limpar coluna</translation>
+        <translation>%1: limpar coluna</translation>
     </message>
     <message>
         <source>%1: mark all cells valid</source>
-        <translation type="obsolete">%1: marcar todas as células como válidas</translation>
+        <translation>%1: marcar todas as células como válidas</translation>
     </message>
     <message>
         <source>%1: clear masks</source>
-        <translation type="obsolete">%1: limpar máscaras</translation>
+        <translation>%1: limpar máscaras</translation>
     </message>
     <message>
         <source>%1: mark cells invalid</source>
-        <translation type="obsolete">%1: marcar células como inválidas</translation>
+        <translation>%1: marcar células como inválidas</translation>
     </message>
     <message>
         <source>%1: mark cells valid</source>
-        <translation type="obsolete">%1: marcar células como válidas</translation>
+        <translation>%1: marcar células como válidas</translation>
     </message>
     <message>
         <source>%1: mask cells</source>
-        <translation type="obsolete">%1: mascarar células</translation>
+        <translation>%1: mascarar células</translation>
     </message>
     <message>
         <source>%1: unmask cells</source>
-        <translation type="obsolete">%1: remover máscaras das células</translation>
+        <translation>%1: remover máscaras das células</translation>
     </message>
     <message>
         <source>%1: set cell formula</source>
-        <translation type="obsolete">%1: definir fórmula para a célula</translation>
+        <translation>%1: definir fórmula para a célula</translation>
     </message>
     <message>
         <source>%1: clear all formulas</source>
-        <translation type="obsolete">%1: limpar todas as fórmulas</translation>
+        <translation>%1: limpar todas as fórmulas</translation>
     </message>
     <message>
         <source>%1: set text for row %2</source>
-        <translation type="obsolete">%1: definir texto para linha %2</translation>
+        <translation>%1: definir texto para linha %2</translation>
     </message>
     <message>
         <source>%1: set value for row %2</source>
-        <translation type="obsolete">%1: definir valor para linha %2</translation>
+        <translation>%1: definir valor para linha %2</translation>
     </message>
     <message>
         <source>%1: replace the texts for rows %2 to %3</source>
-        <translation type="obsolete">%1: substituir texto para linhas %2 a %3</translation>
+        <translation>%1: substituir texto para linhas %2 a %3</translation>
     </message>
     <message>
         <source>%1: replace the values for rows %2 to %3</source>
-        <translation type="obsolete">%1: substituir valores para linhas %2 a %3</translation>
+        <translation>%1: substituir valores para linhas %2 a %3</translation>
     </message>
     <message>
         <source>%1: set date-time format to %2</source>
-        <translation type="obsolete">%1: definir formato de data e hora para %2</translation>
+        <translation>%1: definir formato de data e hora para %2</translation>
     </message>
     <message>
         <source>set date-time format to %1</source>
-        <translation type="obsolete">definir formato de data e hora para %1</translation>
+        <translation>definir formato de data e hora para %1</translation>
     </message>
     <message>
         <source>%1: set numeric format to &apos;%2&apos;</source>
-        <translation type="obsolete">%1: definir formato numérico para &apos;%2&apos;</translation>
+        <translation>%1: definir formato numérico para &apos;%2&apos;</translation>
     </message>
     <message>
         <source>set numeric format to &apos;%1&apos;</source>
-        <translation type="obsolete">definir formato numérico para &apos;%1&apos;</translation>
+        <translation>definir formato numérico para &apos;%1&apos;</translation>
     </message>
     <message>
         <source>%1: set decimal digits to %2</source>
-        <translation type="obsolete">%1: definir casas decimais para %2</translation>
+        <translation>%1: definir casas decimais para %2</translation>
     </message>
     <message>
         <source>set decimal digits to %1</source>
-        <translation type="obsolete">definir casas decimais para %1</translation>
+        <translation>definir casas decimais para %1</translation>
     </message>
     <message>
         <source>XML reader error: </source>
         <comment>prefix for XML error messages</comment>
-        <translation type="obsolete">Erro no leitor de XML:</translation>
+        <translation>Erro no leitor de XML:</translation>
     </message>
     <message>
         <source> (loading failed)</source>
         <comment>postfix for XML error messages</comment>
-        <translation type="obsolete">(o carregamento falhou)</translation>
+        <translation>(o carregamento falhou)</translation>
     </message>
     <message>
         <source>XML reader warning: </source>
         <comment>prefix for XML warning messages</comment>
-        <translation type="obsolete">Aviso do leitor de XML:</translation>
+        <translation>Aviso do leitor de XML:</translation>
     </message>
     <message>
         <source>line %1, column %2: </source>
-        <translation type="obsolete">linha %1, coluna %2:</translation>
+        <translation>linha %1, coluna %2:</translation>
     </message>
     <message>
         <source>unexpected end of document</source>
-        <translation type="obsolete">final inesperado de documento</translation>
+        <translation>final inesperado de documento</translation>
     </message>
     <message>
         <source>%1: insert %2 column(s)</source>
-        <translation type="obsolete">%1: inserir %2 coluna(s)</translation>
+        <translation>%1: inserir %2 coluna(s)</translation>
     </message>
     <message>
         <source>%1: remove %2 column(s)</source>
-        <translation type="obsolete">%1: remover %2 coluna(s)</translation>
+        <translation>%1: remover %2 coluna(s)</translation>
     </message>
     <message>
         <source>%1: set matrix size to %2x%3</source>
-        <translation type="obsolete">%1: definir tamanho da matriz para %2x%3</translation>
+        <translation>%1: definir tamanho da matriz para %2x%3</translation>
     </message>
     <message>
         <source>%1: clear</source>
-        <translation type="obsolete">%1: limpar</translation>
+        <translation>%1: limpar</translation>
     </message>
     <message>
         <source>%1: insert empty column(s)</source>
-        <translation type="obsolete">%1: inserir coluna(s) em branco</translation>
+        <translation>%1: inserir coluna(s) em branco</translation>
     </message>
     <message>
         <source>%1: remove selected column(s)</source>
-        <translation type="obsolete">%1: remover coluna(s) selecionada(s)</translation>
+        <translation>%1: remover coluna(s) selecionada(s)</translation>
     </message>
     <message>
         <source>%1: clear selected column(s)</source>
-        <translation type="obsolete">%1: limpar coluna(s) selecionada(s)</translation>
+        <translation>%1: limpar coluna(s) selecionada(s)</translation>
     </message>
     <message>
         <source>%1: insert empty rows(s)</source>
-        <translation type="obsolete">%1: inserir linha(s) em branco</translation>
+        <translation>%1: inserir linha(s) em branco</translation>
     </message>
     <message>
         <source>%1: remove selected rows(s)</source>
-        <translation type="obsolete">%1: remover lilnha(s) selecionada(s)</translation>
+        <translation>%1: remover lilnha(s) selecionada(s)</translation>
     </message>
     <message>
         <source>%1: clear selected rows(s)</source>
-        <translation type="obsolete">%1: limpar linha(s) selecionada(s)</translation>
+        <translation>%1: limpar linha(s) selecionada(s)</translation>
     </message>
     <message>
         <source>%1: copy %2</source>
-        <translation type="obsolete">%1: copiar %2</translation>
+        <translation>%1: copiar %2</translation>
     </message>
     <message>
         <source>%1: add %2 rows(s)</source>
-        <translation type="obsolete">%1: adicionar %2 linha(s)</translation>
+        <translation>%1: adicionar %2 linha(s)</translation>
     </message>
     <message>
         <source>%1: add %2 column(s)</source>
-        <translation type="obsolete">%1: adicionar %2 coluna(s)</translation>
+        <translation>%1: adicionar %2 coluna(s)</translation>
     </message>
     <message>
         <source>%1: clear column %2</source>
-        <translation type="obsolete">%1: limpar coluna %2</translation>
+        <translation>%1: limpar coluna %2</translation>
     </message>
     <message>
         <source>%1: set cell value</source>
-        <translation type="obsolete">%1: definir valor da célula</translation>
+        <translation>%1: definir valor da célula</translation>
     </message>
     <message>
         <source>%1: set matrix coordinates</source>
-        <translation type="obsolete">%1: definir coordenadas da matriz</translation>
+        <translation>%1: definir coordenadas da matriz</translation>
     </message>
     <message>
         <source>%1: set formula</source>
-        <translation type="obsolete">%1: definir fórmula</translation>
+        <translation>%1: definir fórmula</translation>
     </message>
     <message>
         <source>%1: set cell values</source>
-        <translation type="obsolete">%1: definir valores das células</translation>
+        <translation>%1: definir valores das células</translation>
     </message>
     <message>
         <source>%1: transpose</source>
-        <translation type="obsolete">%1: transpor</translation>
+        <translation>%1: transpor</translation>
     </message>
     <message>
         <source>%1: mirror horizontally</source>
-        <translation type="obsolete">%1: espelhar horizontalmente</translation>
+        <translation>%1: espelhar horizontalmente</translation>
     </message>
     <message>
         <source>%1: mirror vertically</source>
-        <translation type="obsolete">%1: espelhar verticalmente</translation>
+        <translation>%1: espelhar verticalmente</translation>
     </message>
     <message>
         <source>ASCII table</source>
-        <translation type="obsolete">Tabela ASCII</translation>
+        <translation>Tabela ASCII</translation>
     </message>
     <message>
         <source>%1: set the number of rows to %2</source>
-        <translation type="obsolete">%1: definir o número de linhas para %2</translation>
+        <translation>%1: definir o número de linhas para %2</translation>
     </message>
     <message>
         <source>%1: clear all masks</source>
-        <translation type="obsolete">%1: remover todas as máscaras</translation>
+        <translation>%1: remover todas as máscaras</translation>
     </message>
     <message>
         <source>%1: add column</source>
-        <translation type="obsolete">%1: adicionar coluna</translation>
+        <translation>%1: adicionar coluna</translation>
     </message>
     <message>
         <source>%1: set plot designation(s)</source>
-        <translation type="obsolete">%1: definir designação do(s) gráfico(s)</translation>
+        <translation>%1: definir designação do(s) gráfico(s)</translation>
     </message>
     <message>
         <source>%1: normalize column(s)</source>
-        <translation type="obsolete">%1: normalizar coluna(s)</translation>
+        <translation>%1: normalizar coluna(s)</translation>
     </message>
     <message>
         <source>%1: normalize selection</source>
-        <translation type="obsolete">%1: normalizar seleção</translation>
+        <translation>%1: normalizar seleção</translation>
     </message>
     <message>
         <source>%1: move column %2 from position %3 to %4</source>
-        <translation type="obsolete">%1: mover coluna %2 da posição %3 para a %4</translation>
+        <translation>%1: mover coluna %2 da posição %3 para a %4</translation>
     </message>
     <message>
         <source>About SciDAVis</source>
@@ -12879,15 +11995,11 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
     </message>
     <message>
         <source>%1: clear selected cell(s)</source>
-        <translation type="obsolete">%1: limpar célula(s) selecionada(s)</translation>
+        <translation>%1: limpar célula(s) selecionada(s)</translation>
     </message>
 </context>
 <context>
     <name>RangeSelectorTool</name>
-    <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
-    </message>
     <message>
         <source>All the curves on this plot are empty!</source>
         <translation>Todas as curvas neste gráfico estão vazias!</translation>
@@ -12928,20 +12040,12 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
         <translation>Nom&amp;e e rótulo</translation>
     </message>
     <message>
-        <source>QtiPlot - Rename Window</source>
-        <translation type="obsolete">QtiPlot - Renomear janela</translation>
-    </message>
-    <message>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
     </message>
     <message>
         <source>For internal consistency reasons the underscore character is replaced with a minus sign.</source>
@@ -12960,19 +12064,19 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
     <name>SciDAVisAbout</name>
     <message>
         <source>Dialog</source>
-        <translation type="obsolete">Diálogo</translation>
+        <translation>Diálogo</translation>
     </message>
     <message>
         <source>SciDAVis XX.XX.XX-betaXX</source>
-        <translation type="obsolete">SciDAVis XX.XX.XX-betaXX</translation>
+        <translation>SciDAVis XX.XX.XX-betaXX</translation>
     </message>
     <message>
         <source>Released XXXX-XX-XX</source>
-        <translation type="obsolete">Atualizado em XXXX-XX-XX</translation>
+        <translation>Atualizado em XXXX-XX-XX</translation>
     </message>
     <message>
         <source>Close</source>
-        <translation type="obsolete">Fechar</translation>
+        <translation>Fechar</translation>
     </message>
 </context>
 <context>
@@ -12998,19 +12102,11 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
     </message>
     <message>
         <source>Python Source</source>
-        <translation type="obsolete">Código Python</translation>
+        <translation>Código Python</translation>
     </message>
     <message>
         <source>All Files</source>
         <translation>Todos os arquivos</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Import Text From File</source>
-        <translation type="obsolete">QtiPlot - Importar texto a partir do arquivo</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Error Opening File</source>
-        <translation type="obsolete">QtiPlot - Erro ao abrir arquivo</translation>
     </message>
     <message>
         <source>Could not open file &quot;%1&quot; for reading.</source>
@@ -13021,26 +12117,18 @@ s-ésimo zero positivo x_s da função regular cilíndrica de Bessel de ordem n,
         <translation>Salvar texto no arquivo</translation>
     </message>
     <message>
-        <source>QtiPlot -- Overwrite File? </source>
-        <translation type="obsolete">QtiPlot -- Sobrescrever arquivo?</translation>
-    </message>
-    <message>
         <source>A file called: &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;p&gt;already exists.
 Do you want to overwrite it?</source>
-        <translation type="obsolete">Um arquivo chamado &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;p&gt;já existe.
+        <translation>Um arquivo chamado &lt;p&gt;&lt;b&gt;%1&lt;/b&gt;&lt;p&gt;já existe.
 Deseja sobreescrevê-lo?</translation>
     </message>
     <message>
         <source>&amp;Yes</source>
-        <translation type="obsolete">&amp;Sim</translation>
+        <translation>&amp;Sim</translation>
     </message>
     <message>
         <source>&amp;No</source>
-        <translation type="obsolete">&amp;Não</translation>
-    </message>
-    <message>
-        <source>QtiPlot - File Save Error</source>
-        <translation type="obsolete">QtiPlot - Erro ao salvar arquivo</translation>
+        <translation>&amp;Não</translation>
     </message>
     <message>
         <source>Could not write to file: &lt;br&gt;&lt;h4&gt; %1 &lt;/h4&gt;&lt;p&gt;Please verify that you have the right to write to this location!</source>
@@ -13098,140 +12186,128 @@ Deseja sobreescrevê-lo?</translation>
 <context>
     <name>ScriptWindow</name>
     <message>
-        <source>QtiPlot - Python Script Window</source>
-        <translation type="obsolete">QtiPlot - Janela de programação em Python</translation>
-    </message>
-    <message>
         <source>&amp;File</source>
-        <translation type="obsolete">&amp;Arquivo</translation>
+        <translation>&amp;Arquivo</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation type="obsolete">&amp;Editar</translation>
+        <translation>&amp;Editar</translation>
     </message>
     <message>
         <source>E&amp;xecute</source>
-        <translation type="obsolete">Executar</translation>
+        <translation>Executar</translation>
     </message>
     <message>
         <source>&amp;Hide</source>
-        <translation type="obsolete">Ocultar</translation>
+        <translation>Ocultar</translation>
     </message>
     <message>
         <source>Ctrl+N</source>
-        <translation type="obsolete">Ctrl+N</translation>
+        <translation>Ctrl+N</translation>
     </message>
     <message>
         <source>Ctrl+O</source>
-        <translation type="obsolete">Ctrl+O</translation>
+        <translation>Ctrl+O</translation>
     </message>
     <message>
         <source>Ctrl+S</source>
-        <translation type="obsolete">Ctrl+S</translation>
+        <translation>Ctrl+S</translation>
     </message>
     <message>
         <source>Ctrl+P</source>
-        <translation type="obsolete">Ctrl+P</translation>
+        <translation>Ctrl+P</translation>
     </message>
     <message>
         <source>Ctrl+Z</source>
-        <translation type="obsolete">Ctrl+Z</translation>
+        <translation>Ctrl+Z</translation>
     </message>
     <message>
         <source>Ctrl+Y</source>
-        <translation type="obsolete">Ctrl+Y</translation>
+        <translation>Ctrl+Y</translation>
     </message>
     <message>
         <source>Ctrl+x</source>
-        <translation type="obsolete">Ctrl+x</translation>
+        <translation>Ctrl+x</translation>
     </message>
     <message>
         <source>Ctrl+C</source>
-        <translation type="obsolete">Ctrl+C</translation>
+        <translation>Ctrl+C</translation>
     </message>
     <message>
         <source>Ctrl+V</source>
-        <translation type="obsolete">Ctrl+V</translation>
+        <translation>Ctrl+V</translation>
     </message>
     <message>
         <source>Del</source>
-        <translation type="obsolete">Del</translation>
+        <translation>Del</translation>
     </message>
     <message>
         <source>CTRL+J</source>
-        <translation type="obsolete">CTRL+J</translation>
+        <translation>CTRL+J</translation>
     </message>
     <message>
         <source>CTRL+SHIFT+J</source>
-        <translation type="obsolete">CTRL+SHIFT+J</translation>
+        <translation>CTRL+SHIFT+J</translation>
     </message>
     <message>
         <source>CTRL+Return</source>
-        <translation type="obsolete">CTRL+Return</translation>
-    </message>
-    <message>
-        <source>QtiPlot - File Save Error</source>
-        <translation type="obsolete">QtiPlot - Erro ao salvar arquivo</translation>
+        <translation>CTRL+Return</translation>
     </message>
     <message>
         <source>Could not write to file: &lt;br&gt;&lt;h4&gt; %1 &lt;/h4&gt;&lt;p&gt;Please verify that you have the right to write to this location!</source>
-        <translation type="obsolete">Não foi possível escrever no arquivo &lt;br&gt;&lt;h4&gt; %1 &lt;/h4&gt;&lt;p&gt;Por favor, verifique se você possui permissão de escrita no local selecionado!</translation>
+        <translation>Não foi possível escrever no arquivo &lt;br&gt;&lt;h4&gt; %1 &lt;/h4&gt;&lt;p&gt;Por favor, verifique se você possui permissão de escrita no local selecionado!</translation>
     </message>
     <message>
         <source>&amp;New</source>
-        <translation type="obsolete">&amp;Novo</translation>
+        <translation>&amp;Novo</translation>
     </message>
     <message>
         <source>&amp;Open...</source>
-        <translation type="obsolete">&amp;Abrir...</translation>
+        <translation>&amp;Abrir...</translation>
     </message>
     <message>
         <source>&amp;Save</source>
-        <translation type="obsolete">&amp;Salvar</translation>
+        <translation>&amp;Salvar</translation>
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <translation type="obsolete">Salvar &amp;como...</translation>
+        <translation>Salvar &amp;como...</translation>
     </message>
     <message>
         <source>&amp;Print</source>
-        <translation type="obsolete">Im&amp;primir</translation>
+        <translation>Im&amp;primir</translation>
     </message>
     <message>
         <source>&amp;Undo</source>
-        <translation type="obsolete">&amp;Desfazer</translation>
+        <translation>&amp;Desfazer</translation>
     </message>
     <message>
         <source>&amp;Redo</source>
-        <translation type="obsolete">&amp;Refazer</translation>
+        <translation>&amp;Refazer</translation>
     </message>
     <message>
         <source>&amp;Cut</source>
-        <translation type="obsolete">&amp;Cortar</translation>
+        <translation>&amp;Cortar</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
-        <translation type="obsolete">C&amp;opiar</translation>
+        <translation>C&amp;opiar</translation>
     </message>
     <message>
         <source>&amp;Paste</source>
-        <translation type="obsolete">Co&amp;lar</translation>
+        <translation>Co&amp;lar</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation type="obsolete">&amp;Apagar</translation>
+        <translation>&amp;Apagar</translation>
     </message>
     <message>
         <source>Execute &amp;All</source>
-        <translation type="obsolete">Execut&amp;ar tudo</translation>
+        <translation>Execut&amp;ar tudo</translation>
     </message>
     <message>
         <source>&amp;Evaluate Expression</source>
-        <translation type="obsolete">&amp;Resolver expressão</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Script Window</source>
-        <translation type="obsolete">QtiPlot - Janela de script</translation>
+        <translation>&amp;Resolver expressão</translation>
     </message>
 </context>
 <context>
@@ -13244,20 +12320,12 @@ Deseja sobreescrevê-lo?</translation>
 <context>
     <name>ScriptingLangDialog</name>
     <message>
-        <source>QtiPlot - Select scripting language</source>
-        <translation type="obsolete">QtiPlot - Selecionar linguagem de script</translation>
-    </message>
-    <message>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
         <source>Cancel</source>
         <translation>Cancelar</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Scripting Error</source>
-        <translation type="obsolete">QtiPlot - Erro no script</translation>
     </message>
     <message>
         <source>Scripting language &quot;%1&quot; failed to initialize.</source>
@@ -13275,58 +12343,54 @@ Deseja sobreescrevê-lo?</translation>
 <context>
     <name>SetColValuesDialog</name>
     <message>
-        <source>QtiPlot - Set column values</source>
-        <translation type="obsolete">QtiPlot - Definir valores da coluna</translation>
-    </message>
-    <message>
         <source>For row (i)</source>
-        <translation type="obsolete">Da linha (i)</translation>
+        <translation>Da linha (i)</translation>
     </message>
     <message>
         <source>to</source>
-        <translation type="obsolete">à</translation>
+        <translation>à</translation>
     </message>
     <message>
         <source>Add function</source>
-        <translation type="obsolete">Adicionar função</translation>
+        <translation>Adicionar função</translation>
     </message>
     <message>
         <source>Add column</source>
-        <translation type="obsolete">Adicionar coluna</translation>
+        <translation>Adicionar coluna</translation>
     </message>
     <message>
         <source>Add cell</source>
-        <translation type="obsolete">Adicionar célula</translation>
+        <translation>Adicionar célula</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">Cancelar</translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
         <source>&amp;&lt;&lt; Prev.</source>
         <comment>previous column</comment>
-        <translation type="obsolete">&amp;&lt;&lt; Prev.</translation>
+        <translation>&amp;&lt;&lt; Prev.</translation>
     </message>
     <message>
         <source>Next &amp;&gt;&gt;</source>
         <comment>next column</comment>
-        <translation type="obsolete"> Próxima &amp;&gt;&gt;</translation>
+        <translation> Próxima &amp;&gt;&gt;</translation>
     </message>
     <message>
         <source>Set column values</source>
-        <translation type="obsolete">Definir valores da coluna</translation>
+        <translation>Definir valores da coluna</translation>
     </message>
     <message>
         <source>&amp;Close</source>
-        <translation type="obsolete">&amp;Fechar</translation>
+        <translation>&amp;Fechar</translation>
     </message>
 </context>
 <context>
@@ -13349,7 +12413,7 @@ Deseja sobreescrevê-lo?</translation>
     </message>
     <message>
         <source>Boltzmann (Sigmoidal)</source>
-        <translation type="obsolete">Boltzmann (Sigmoidal)</translation>
+        <translation>Boltzmann (Sigmoidal)</translation>
     </message>
     <message>
         <source>Boltzmann (Sigmoidal) Fit</source>
@@ -13358,10 +12422,6 @@ Deseja sobreescrevê-lo?</translation>
 </context>
 <context>
     <name>SmoothCurveDialog</name>
-    <message>
-        <source>QtiPlot - Smoothing Options</source>
-        <translation type="obsolete">QtiPlot - Opções de suavização</translation>
-    </message>
     <message>
         <source>Curve</source>
         <translation>Curva</translation>
@@ -13404,10 +12464,6 @@ Deseja sobreescrevê-lo?</translation>
     <message>
         <source>Smoothed</source>
         <translation>Suavizado</translation>
-    </message>
-    <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
     </message>
     <message>
         <source>Error</source>
@@ -13474,56 +12530,48 @@ Deseja sobreescrevê-lo?</translation>
 <context>
     <name>SortDialog</name>
     <message>
-        <source>QtiPlot - Sorting Options</source>
-        <translation type="obsolete">QtiPlot - Opções de ordenação</translation>
-    </message>
-    <message>
         <source>Sort columns</source>
-        <translation type="obsolete">Ordemar colunas</translation>
+        <translation>Ordemar colunas</translation>
     </message>
     <message>
         <source>Order</source>
-        <translation type="obsolete">Ordem</translation>
+        <translation>Ordem</translation>
     </message>
     <message>
         <source>Leading column</source>
-        <translation type="obsolete">Coluna principal</translation>
+        <translation>Coluna principal</translation>
     </message>
     <message>
         <source>&amp;Sort</source>
-        <translation type="obsolete">&amp;Ordemar</translation>
+        <translation>&amp;Ordemar</translation>
     </message>
     <message>
         <source>&amp;Close</source>
-        <translation type="obsolete">&amp;Fechar</translation>
+        <translation>&amp;Fechar</translation>
     </message>
     <message>
         <source>Separately</source>
-        <translation type="obsolete">Separadamente</translation>
+        <translation>Separadamente</translation>
     </message>
     <message>
         <source>Together</source>
-        <translation type="obsolete">Juntas</translation>
+        <translation>Juntas</translation>
     </message>
     <message>
         <source>Ascending</source>
-        <translation type="obsolete">Ascendente</translation>
+        <translation>Ascendente</translation>
     </message>
     <message>
         <source>Descending</source>
-        <translation type="obsolete">Descendente</translation>
+        <translation>Descendente</translation>
     </message>
     <message>
         <source>Sorting Options</source>
-        <translation type="obsolete">Opções de ordenamento</translation>
+        <translation>Opções de ordenamento</translation>
     </message>
 </context>
 <context>
     <name>SurfaceDialog</name>
-    <message>
-        <source>QtiPlot - Define surface plot</source>
-        <translation type="obsolete">QtiPlot - Definir gráfico de superfície</translation>
-    </message>
     <message>
         <source>f(x,y)=</source>
         <translation>f(x,y)=</translation>
@@ -13569,40 +12617,8 @@ Deseja sobreescrevê-lo?</translation>
         <translation>&amp;Fechar</translation>
     </message>
     <message>
-        <source>QtiPlot - X Start limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite X inicial</translation>
-    </message>
-    <message>
-        <source>QtiPlot - X End limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite X final</translation>
-    </message>
-    <message>
-        <source>QtiPlot - e Start limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite Y inicial</translation>
-    </message>
-    <message>
-        <source>QtiPlot - e End limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite Y final</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Z Start limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite Z inicial</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Z End limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite Z final</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input error</source>
-        <translation type="obsolete">QtiPlot - Erro de entrada</translation>
-    </message>
-    <message>
         <source>Please enter limits that satisfy: from &lt; end!</source>
         <translation>Por favor, forneça limites tais que: início &lt; fim!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input function error</source>
-        <translation type="obsolete">QtiPlot - Erro na fórmula forecida</translation>
     </message>
     <message>
         <source>Define surface plot</source>
@@ -13715,10 +12731,6 @@ Deseja sobreescrevê-lo?</translation>
         <translation>&amp;Fechar</translation>
     </message>
     <message>
-        <source>QtiPlot - Choose Symbol</source>
-        <translation type="obsolete">QtiPlot - Escolher símbolo</translation>
-    </message>
-    <message>
         <source>Choose Symbol</source>
         <translation>Escolher símbolo</translation>
     </message>
@@ -13726,16 +12738,12 @@ Deseja sobreescrevê-lo?</translation>
 <context>
     <name>Table</name>
     <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
-    </message>
-    <message>
         <source>Yes</source>
-        <translation type="obsolete">Sim</translation>
+        <translation>Sim</translation>
     </message>
     <message>
         <source>No</source>
-        <translation type="obsolete">Não</translation>
+        <translation>Não</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -13743,131 +12751,119 @@ Deseja sobreescrevê-lo?</translation>
     </message>
     <message>
         <source>Please select two columns for this operation!</source>
-        <translation type="obsolete">Por favor, selecione duas colunas para esta operação!</translation>
+        <translation>Por favor, selecione duas colunas para esta operação!</translation>
     </message>
     <message>
         <source>Could not allocate memory, operation aborted!</source>
-        <translation type="obsolete">Não foi possível alocar memória, operação abortada!</translation>
+        <translation>Não foi possível alocar memória, operação abortada!</translation>
     </message>
     <message>
         <source>Error in GSL forward FFT operation!</source>
-        <translation type="obsolete">Erro na operação de FFT direta com GSL!</translation>
+        <translation>Erro na operação de FFT direta com GSL!</translation>
     </message>
     <message>
         <source>Please set a default X column for this table, first!</source>
-        <translation type="obsolete">Por favor, defina primeiro uma coluna X para esta tabela!</translation>
+        <translation>Por favor, defina primeiro uma coluna X para esta tabela!</translation>
     </message>
     <message>
         <source>Please select a column to plot!</source>
-        <translation type="obsolete">Por favor, selecione uma coluna para o gráfico!</translation>
+        <translation>Por favor, selecione uma coluna para o gráfico!</translation>
     </message>
     <message>
         <source>Please select four columns for this operation!</source>
-        <translation type="obsolete">Por favor, selecione quatro colunas para esta operação!</translation>
+        <translation>Por favor, selecione quatro colunas para esta operação!</translation>
     </message>
     <message>
         <source>You need at least two columns for this operation!</source>
-        <translation type="obsolete">É necessário pelo menos duas colunas para esta operação!</translation>
+        <translation>É necessário pelo menos duas colunas para esta operação!</translation>
     </message>
     <message>
         <source>Please select a Z column for this operation!</source>
-        <translation type="obsolete">Por favor, selecione uma coluna Z para esta operação!</translation>
+        <translation>Por favor, selecione uma coluna Z para esta operação!</translation>
     </message>
     <message>
         <source>You need to define a X column first!</source>
-        <translation type="obsolete">É necessário definir uma coluna X primeiro!</translation>
+        <translation>É necessário definir uma coluna X primeiro!</translation>
     </message>
     <message>
         <source>You need to define a e column first!</source>
-        <translation type="obsolete">É necessário definir uma coluna X primeiro!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - ASCII Export Error</source>
-        <translation type="obsolete">QtiPlot - Erro na exportação para ASCII</translation>
-    </message>
-    <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
+        <translation>É necessário definir uma coluna X primeiro!</translation>
     </message>
     <message>
         <source>Columns will be deleted from the table!</source>
-        <translation type="obsolete">As colunas serão excluídas da tabela!</translation>
+        <translation>As colunas serão excluídas da tabela!</translation>
     </message>
     <message>
         <source>Do you really want to continue?</source>
-        <translation type="obsolete">Deseja realmente continuar?</translation>
+        <translation>Deseja realmente continuar?</translation>
     </message>
     <message>
         <source>Please select two columns for this operation:
  the first represents the signal and the second the response function!</source>
-        <translation type="obsolete">Por favor, selecione duas colunas para esta operação: 
+        <translation>Por favor, selecione duas colunas para esta operação: 
 A primeira representa o sinal e a segunda a função resposta!</translation>
     </message>
     <message>
         <source>The response dataset &apos;%1&apos; must be less then half the size of the signal dataset &apos;%2&apos;!</source>
-        <translation type="obsolete">O conjunto resposta &apos;%1&apos; deve ser menor que a metade do Tamanho do conjunto sinal &apos;%2&apos;!</translation>
+        <translation>O conjunto resposta &apos;%1&apos; deve ser menor que a metade do Tamanho do conjunto sinal &apos;%2&apos;!</translation>
     </message>
     <message>
         <source>The response dataset &apos;%1&apos; must contain an odd number of points!</source>
-        <translation type="obsolete">O conjunto resposta &apos;%1&apos; deve conter um número ímpar de pontos!</translation>
+        <translation>O conjunto resposta &apos;%1&apos; deve conter um número ímpar de pontos!</translation>
     </message>
     <message>
         <source>Frequency</source>
-        <translation type="obsolete">Frequência</translation>
+        <translation>Frequência</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="obsolete">Tempo</translation>
+        <translation>Tempo</translation>
     </message>
     <message>
         <source>Real</source>
-        <translation type="obsolete">Real</translation>
+        <translation>Real</translation>
     </message>
     <message>
         <source>Imaginary</source>
-        <translation type="obsolete">Imaginário</translation>
+        <translation>Imaginário</translation>
     </message>
     <message>
         <source>Amplitude</source>
-        <translation type="obsolete">Amplitude</translation>
+        <translation>Amplitude</translation>
     </message>
     <message>
         <source>Angle</source>
-        <translation type="obsolete">Ângulo</translation>
+        <translation>Ângulo</translation>
     </message>
     <message>
         <source>The text in the clipboard is larger than your current selection!	        
 Do you want to insert cells?</source>
-        <translation type="obsolete">O texto na área de transferência é maior que a seleção!	        
+        <translation>O texto na área de transferência é maior que a seleção!	        
 Gostaria de inserir células?</translation>
     </message>
     <message>
         <source>Rows will be deleted from the table!</source>
-        <translation type="obsolete">As linhas serão excluídas da tabela!</translation>
-    </message>
-    <message>
-        <source>Qtiplot - Reading file...</source>
-        <translation type="obsolete">QtiPlot - Lendo arquivo...</translation>
+        <translation>As linhas serão excluídas da tabela!</translation>
     </message>
     <message>
         <source>The column name must be different from the table name : &lt;b&gt;</source>
-        <translation type="obsolete">O nome da coluna deve ser diferente do nome da tabela: &lt;b&gt;</translation>
+        <translation>O nome da coluna deve ser diferente do nome da tabela: &lt;b&gt;</translation>
     </message>
     <message>
         <source>There is already a column called : &lt;b&gt;</source>
-        <translation type="obsolete">Já existe uma coluna chamada: &lt;b&gt;</translation>
+        <translation>Já existe uma coluna chamada: &lt;b&gt;</translation>
     </message>
     <message>
         <source>Please indicate the name of the leading column!</source>
-        <translation type="obsolete">Por favor, indique o nome da colunma principal!</translation>
+        <translation>Por favor, indique o nome da colunma principal!</translation>
     </message>
     <message>
         <source>The leading column has the type set to &apos;Text&apos;! Operation aborted!</source>
-        <translation type="obsolete">A coluna principal é do tipo &apos;Texto&apos;! Operação abortada!</translation>
+        <translation>A coluna principal é do tipo &apos;Texto&apos;! Operação abortada!</translation>
     </message>
     <message>
         <source>The leading column is empty! Operation aborted!</source>
-        <translation type="obsolete">A coluna principal esta vazia! Operação abortada!</translation>
+        <translation>A coluna principal esta vazia! Operação abortada!</translation>
     </message>
     <message>
         <source>Could not write to file: &lt;br&gt;&lt;h4&gt;</source>
@@ -13879,7 +12875,7 @@ Gostaria de inserir células?</translation>
     </message>
     <message>
         <source>Error</source>
-        <translation type="obsolete">Erro</translation>
+        <translation>Erro</translation>
     </message>
     <message>
         <source>ASCII Export Error</source>
@@ -13903,549 +12899,537 @@ Gostaria de inserir células?</translation>
     </message>
     <message>
         <source>%1: cut selected cell(s)</source>
-        <translation type="obsolete">%1: cortar célula(s) selecionada(s)</translation>
+        <translation>%1: cortar célula(s) selecionada(s)</translation>
     </message>
     <message>
         <source>%1: paste from clipboard</source>
-        <translation type="obsolete">%1: colar da área de trabalho</translation>
+        <translation>%1: colar da área de trabalho</translation>
     </message>
     <message>
         <source>%1: mask selected cell(s)</source>
-        <translation type="obsolete">%1: mascarar células(s) selecionada(s)</translation>
+        <translation>%1: mascarar células(s) selecionada(s)</translation>
     </message>
     <message>
         <source>%1: unmask selected cell(s)</source>
-        <translation type="obsolete">%1: remover máscara(s) de célula(s) selecionada(s)</translation>
+        <translation>%1: remover máscara(s) de célula(s) selecionada(s)</translation>
     </message>
     <message>
         <source>%1: apply formula to selection</source>
-        <translation type="obsolete">%1: aplicar fórmula à seleção</translation>
+        <translation>%1: aplicar fórmula à seleção</translation>
     </message>
     <message>
         <source>%1: fill cells with row numbers</source>
-        <translation type="obsolete">%1: preencher células com números das linhas</translation>
+        <translation>%1: preencher células com números das linhas</translation>
     </message>
     <message>
         <source>%1: fill cells with random values</source>
-        <translation type="obsolete">%1: preencher células com valores aleatórios</translation>
+        <translation>%1: preencher células com valores aleatórios</translation>
     </message>
     <message>
         <source>&amp;Table</source>
-        <translation type="obsolete">&amp;Tabela</translation>
+        <translation>&amp;Tabela</translation>
     </message>
     <message>
         <source>S&amp;et Column(s) As</source>
-        <translation type="obsolete">Definir coluna(s) como</translation>
+        <translation>Definir coluna(s) como</translation>
     </message>
     <message>
         <source>Fi&amp;ll Selection with</source>
-        <translation type="obsolete">&amp;Preencher seleção com</translation>
+        <translation>&amp;Preencher seleção com</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
-        <translation type="obsolete">C&amp;opiar</translation>
+        <translation>C&amp;opiar</translation>
     </message>
     <message>
         <source>Past&amp;e</source>
-        <translation type="obsolete">Co&amp;lar</translation>
+        <translation>Co&amp;lar</translation>
     </message>
     <message>
         <source>&amp;Mask</source>
         <comment>mask selection</comment>
-        <translation type="obsolete">Mascarar</translation>
+        <translation>Mascarar</translation>
     </message>
     <message>
         <source>&amp;Unmask</source>
         <comment>unmask selection</comment>
-        <translation type="obsolete">Desmascarar</translation>
+        <translation>Desmascarar</translation>
     </message>
     <message>
         <source>Alt+Q</source>
-        <translation type="obsolete">Alt+Q</translation>
+        <translation>Alt+Q</translation>
     </message>
     <message>
         <source>Clea&amp;r</source>
         <comment>clear selection</comment>
-        <translation type="obsolete">Limpa&amp;r</translation>
+        <translation>Limpa&amp;r</translation>
     </message>
     <message>
         <source>Recalculate</source>
-        <translation type="obsolete">Recalcular</translation>
+        <translation>Recalcular</translation>
     </message>
     <message>
         <source>Row Numbers</source>
-        <translation type="obsolete">Números das linhas</translation>
+        <translation>Números das linhas</translation>
     </message>
     <message>
         <source>Random Values</source>
-        <translation type="obsolete">Valores aleatórios</translation>
+        <translation>Valores aleatórios</translation>
     </message>
     <message>
         <source>F12</source>
-        <translation type="obsolete">F12</translation>
+        <translation>F12</translation>
     </message>
     <message>
         <source>Formula Edit Mode</source>
-        <translation type="obsolete">Modo de edição de fórmula</translation>
+        <translation>Modo de edição de fórmula</translation>
     </message>
     <message>
         <source>Select All</source>
-        <translation type="obsolete">Selecionar tudo</translation>
+        <translation>Selecionar tudo</translation>
     </message>
     <message>
         <source>&amp;Add Column</source>
-        <translation type="obsolete">Adicio&amp;nar coluna</translation>
+        <translation>Adicio&amp;nar coluna</translation>
     </message>
     <message>
         <source>append a new column to the table</source>
-        <translation type="obsolete">adicionar nova coluna à tabela</translation>
+        <translation>adicionar nova coluna à tabela</translation>
     </message>
     <message>
         <source>Clear Table</source>
-        <translation type="obsolete">Limpar tabela</translation>
+        <translation>Limpar tabela</translation>
     </message>
     <message>
         <source>Export to TeX...</source>
-        <translation type="obsolete">Exportar para Tex...</translation>
+        <translation>Exportar para Tex...</translation>
     </message>
     <message>
         <source>Clear Masks</source>
-        <translation type="obsolete">Limpar máscaras</translation>
+        <translation>Limpar máscaras</translation>
     </message>
     <message>
         <source>&amp;Sort Table</source>
-        <translation type="obsolete">Ordemar tabela</translation>
+        <translation>Ordemar tabela</translation>
     </message>
     <message>
         <source>&amp;Go to Cell</source>
-        <translation type="obsolete">Ir para célula</translation>
+        <translation>Ir para célula</translation>
     </message>
     <message>
         <source>Ctrl+Alt+G</source>
-        <translation type="obsolete">Ctrl+Alt+G</translation>
+        <translation>Ctrl+Alt+G</translation>
     </message>
     <message>
         <source>change the table size</source>
-        <translation type="obsolete">Modificar dimensões da tabela</translation>
+        <translation>Modificar dimensões da tabela</translation>
     </message>
     <message>
         <source>&amp;Insert Empty Columns</source>
-        <translation type="obsolete">Inserir coluna vazia</translation>
+        <translation>Inserir coluna vazia</translation>
     </message>
     <message>
         <source>Remo&amp;ve Columns</source>
-        <translation type="obsolete">Remover colunas</translation>
+        <translation>Remover colunas</translation>
     </message>
     <message>
         <source>Clea&amp;r Columns</source>
-        <translation type="obsolete">Limpar colunas</translation>
+        <translation>Limpar colunas</translation>
     </message>
     <message>
         <source>&amp;Add Columns</source>
-        <translation type="obsolete">Adicionar colunas</translation>
+        <translation>Adicionar colunas</translation>
     </message>
     <message>
         <source>X</source>
         <comment>plot designation</comment>
-        <translation type="obsolete">X</translation>
+        <translation>X</translation>
     </message>
     <message>
         <source>Y</source>
         <comment>plot designation</comment>
-        <translation type="obsolete">Y</translation>
+        <translation>Y</translation>
     </message>
     <message>
         <source>Z</source>
         <comment>plot designation</comment>
-        <translation type="obsolete">Z</translation>
+        <translation>Z</translation>
     </message>
     <message>
         <source>X Error</source>
         <comment>plot designation</comment>
-        <translation type="obsolete">Erro em X</translation>
+        <translation>Erro em X</translation>
     </message>
     <message>
         <source>Y Error</source>
         <comment>plot designation</comment>
-        <translation type="obsolete">Erro em Y</translation>
+        <translation>Erro em Y</translation>
     </message>
     <message>
         <source>&amp;Normalize Columns</source>
-        <translation type="obsolete">Normalizar colunas</translation>
+        <translation>Normalizar colunas</translation>
     </message>
     <message>
         <source>&amp;Normalize Selection</source>
-        <translation type="obsolete">Normalizar seleção</translation>
+        <translation>Normalizar seleção</translation>
     </message>
     <message>
         <source>&amp;Sort Columns</source>
-        <translation type="obsolete">Ordemar colunas</translation>
+        <translation>Ordemar colunas</translation>
     </message>
     <message>
         <source>Column Statisti&amp;cs</source>
-        <translation type="obsolete">Estatísticas das colunas</translation>
+        <translation>Estatísticas das colunas</translation>
     </message>
     <message>
         <source>statistics on columns</source>
-        <translation type="obsolete">Estatísticas em colunas</translation>
+        <translation>Estatísticas em colunas</translation>
     </message>
     <message>
         <source>Change &amp;Type &amp;&amp; Format</source>
-        <translation type="obsolete">Modificar tipo e formato</translation>
+        <translation>Modificar tipo e formato</translation>
     </message>
     <message>
         <source>Ctrl+Alt+O</source>
-        <translation type="obsolete">Ctrl+Alt+O</translation>
+        <translation>Ctrl+Alt+O</translation>
     </message>
     <message>
         <source>Edit Column &amp;Description</source>
-        <translation type="obsolete">Editar descrição da coluna</translation>
+        <translation>Editar descrição da coluna</translation>
     </message>
     <message>
         <source>&amp;Insert Empty Rows</source>
-        <translation type="obsolete">Inserir linhas vazias</translation>
+        <translation>Inserir linhas vazias</translation>
     </message>
     <message>
         <source>Remo&amp;ve Rows</source>
-        <translation type="obsolete">Remover linhas</translation>
+        <translation>Remover linhas</translation>
     </message>
     <message>
         <source>Clea&amp;r Rows</source>
-        <translation type="obsolete">Lim&amp;par linhas</translation>
+        <translation>Lim&amp;par linhas</translation>
     </message>
     <message>
         <source>&amp;Add Rows</source>
-        <translation type="obsolete">Adicionar linhas</translation>
+        <translation>Adicionar linhas</translation>
     </message>
     <message>
         <source>Row Statisti&amp;cs</source>
-        <translation type="obsolete">Estatísticas das linhas</translation>
+        <translation>Estatísticas das linhas</translation>
     </message>
     <message>
         <source>statistics on rows</source>
-        <translation type="obsolete">Estatísticas em linhas</translation>
+        <translation>Estatísticas em linhas</translation>
     </message>
     <message>
         <source>TeX Export Error</source>
-        <translation type="obsolete">Erro ao exportar para Tex</translation>
+        <translation>Erro ao exportar para Tex</translation>
     </message>
     <message>
         <source>Could not write to file: &lt;br&gt;&lt;h4&gt;%1&lt;/h4&gt;&lt;p&gt;Please verify that you have the right to write to this location!</source>
-        <translation type="obsolete">Não foi possível escrever no arquivo: &lt;br&gt;&lt;h4&gt; %1 &lt;/h4&gt;&lt;p&gt;Por favor, verifique se você tem permissão de escrita no local selecionado!</translation>
+        <translation>Não foi possível escrever no arquivo: &lt;br&gt;&lt;h4&gt; %1 &lt;/h4&gt;&lt;p&gt;Por favor, verifique se você tem permissão de escrita no local selecionado!</translation>
     </message>
     <message>
         <source>Go to Cell</source>
-        <translation type="obsolete">Ir para a célula</translation>
+        <translation>Ir para a célula</translation>
     </message>
     <message>
         <source>Enter column</source>
-        <translation type="obsolete">Inserir coluna</translation>
+        <translation>Inserir coluna</translation>
     </message>
     <message>
         <source>Enter row</source>
-        <translation type="obsolete">Inserir linha</translation>
+        <translation>Inserir linha</translation>
     </message>
     <message>
         <source>Set Table Dimensions</source>
-        <translation type="obsolete">Definir dimensões da tabela</translation>
+        <translation>Definir dimensões da tabela</translation>
     </message>
     <message>
         <source>%1: move column %2 from position %3 to %4.</source>
-        <translation type="obsolete">%1: mover coluna %2 da posição %3 para %4.</translation>
+        <translation>%1: mover coluna %2 da posição %3 para %4.</translation>
     </message>
     <message>
         <source>%1: sort column(s)</source>
-        <translation type="obsolete">%1: ordenar coluna(s)</translation>
+        <translation>%1: ordenar coluna(s)</translation>
     </message>
     <message>
         <source>invalid row or column count</source>
-        <translation type="obsolete">Contagem de linhas ou colunas inválidas</translation>
+        <translation>Contagem de linhas ou colunas inválidas</translation>
     </message>
     <message>
         <source>Column %1</source>
-        <translation type="obsolete">Coluna %1</translation>
+        <translation>Coluna %1</translation>
     </message>
     <message>
         <source>columns attribute and number of read columns do not match</source>
-        <translation type="obsolete">os atributos das colunas e o número de colunas lidas não coincidem</translation>
+        <translation>os atributos das colunas e o número de colunas lidas não coincidem</translation>
     </message>
     <message>
         <source>no table element found</source>
-        <translation type="obsolete">nenhum elemento de tabela encontrado</translation>
+        <translation>nenhum elemento de tabela encontrado</translation>
     </message>
     <message>
         <source>Hide Comments</source>
-        <translation type="obsolete">Ocultar comentários</translation>
+        <translation>Ocultar comentários</translation>
     </message>
     <message>
         <source>Show Comments</source>
-        <translation type="obsolete">Mostrar comentários</translation>
+        <translation>Mostrar comentários</translation>
     </message>
     <message>
         <source>Hide Controls</source>
-        <translation type="obsolete">Ocultar controles</translation>
+        <translation>Ocultar controles</translation>
     </message>
     <message>
         <source>Show Controls</source>
-        <translation type="obsolete">Mostrar controles</translation>
+        <translation>Mostrar controles</translation>
     </message>
     <message>
         <source>invalid or missing column index</source>
-        <translation type="obsolete">índice de colunas inválido ou inexistente</translation>
+        <translation>índice de colunas inválido ou inexistente</translation>
     </message>
     <message>
         <source>invalid column width</source>
-        <translation type="obsolete">largura de coluna inválida</translation>
+        <translation>largura de coluna inválida</translation>
     </message>
     <message>
         <source>Table</source>
-        <translation type="obsolete">Tabela</translation>
+        <translation>Tabela</translation>
     </message>
 </context>
 <context>
     <name>TableDialog</name>
     <message>
-        <source>QtiPlot - Column options</source>
-        <translation type="obsolete">QtiPlot - Opções de coluna</translation>
-    </message>
-    <message>
         <source>Column Name:</source>
-        <translation type="obsolete">Nome da Coluna:</translation>
+        <translation>Nome da Coluna:</translation>
     </message>
     <message>
         <source>Enumerate all to the right</source>
-        <translation type="obsolete">Enumerar todas à direita</translation>
+        <translation>Enumerar todas à direita</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Plot Designation:</source>
-        <translation type="obsolete">Designação do gráfico:</translation>
+        <translation>Designação do gráfico:</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="obsolete">Nenhum</translation>
+        <translation>Nenhum</translation>
     </message>
     <message>
         <source>X (abscissae)</source>
-        <translation type="obsolete">X (abscisas)</translation>
+        <translation>X (abscisas)</translation>
     </message>
     <message>
         <source>Y (ordinates)</source>
-        <translation type="obsolete">Y (ordenadas)</translation>
+        <translation>Y (ordenadas)</translation>
     </message>
     <message>
         <source>Z (height)</source>
-        <translation type="obsolete">Z (altura)</translation>
+        <translation>Z (altura)</translation>
     </message>
     <message>
         <source>X Error</source>
-        <translation type="obsolete">Erro em X</translation>
+        <translation>Erro em X</translation>
     </message>
     <message>
         <source>Y Error</source>
-        <translation type="obsolete">Erro em Y</translation>
+        <translation>Erro em Y</translation>
     </message>
     <message>
         <source>Display</source>
-        <translation type="obsolete">Mostrador</translation>
+        <translation>Mostrador</translation>
     </message>
     <message>
         <source>Numeric</source>
-        <translation type="obsolete">Numérico</translation>
+        <translation>Numérico</translation>
     </message>
     <message>
         <source>Text</source>
-        <translation type="obsolete">Texto</translation>
+        <translation>Texto</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="obsolete">Data</translation>
+        <translation>Data</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="obsolete">Hora</translation>
+        <translation>Hora</translation>
     </message>
     <message>
         <source>Month</source>
-        <translation type="obsolete">Mês</translation>
+        <translation>Mês</translation>
     </message>
     <message>
         <source>Day of Week</source>
-        <translation type="obsolete">Dia da semana</translation>
+        <translation>Dia da semana</translation>
     </message>
     <message>
         <source>Format:</source>
-        <translation type="obsolete">Formato:</translation>
+        <translation>Formato:</translation>
     </message>
     <message>
         <source>Precision:</source>
-        <translation type="obsolete">Precisão:</translation>
+        <translation>Precisão:</translation>
     </message>
     <message>
         <source>Apply to all columns to the right</source>
-        <translation type="obsolete">Aplicar a todas as colunas à direita</translation>
+        <translation>Aplicar a todas as colunas à direita</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="obsolete">Opções</translation>
+        <translation>Opções</translation>
     </message>
     <message>
         <source>Column Width:</source>
-        <translation type="obsolete">Largura da coluna:</translation>
+        <translation>Largura da coluna:</translation>
     </message>
     <message>
         <source>Apply to all</source>
-        <translation type="obsolete">Aplicar a todos</translation>
+        <translation>Aplicar a todos</translation>
     </message>
     <message>
         <source>Comment:</source>
-        <translation type="obsolete">Comentário:</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
+        <translation>Comentário:</translation>
     </message>
     <message>
         <source>For internal consistency reasons the underscore character is replaced with a minus sign.</source>
-        <translation type="obsolete">Por razõe de consistência interna o caracter de sublinha é substituído pelo sinal menos.</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
+        <translation>Por razões de consistência interna o caracter de sublinha é substituído pelo sinal menos.</translation>
     </message>
     <message>
         <source>The column names must only contain letters and digits!</source>
-        <translation type="obsolete">Os nomes das colunas podem conter apenas dígitos e letras!</translation>
+        <translation>Os nomes das colunas podem conter apenas dígitos e letras!</translation>
     </message>
     <message>
         <source>Default</source>
-        <translation type="obsolete">Padrão</translation>
+        <translation>Padrão</translation>
     </message>
     <message>
         <source>Decimal: 1000</source>
-        <translation type="obsolete">Decimal: 1000</translation>
+        <translation>Decimal: 1000</translation>
     </message>
     <message>
         <source>Scientific: 1E3</source>
-        <translation type="obsolete">Científico: 1E3</translation>
+        <translation>Científico: 1E3</translation>
     </message>
     <message>
         <source>yyyy-MM-dd</source>
-        <translation type="obsolete">aaaa-MM-dd</translation>
+        <translation>aaaa-MM-dd</translation>
     </message>
     <message>
         <source>h</source>
-        <translation type="obsolete">h</translation>
+        <translation>h</translation>
     </message>
     <message>
         <source>h ap</source>
-        <translation type="obsolete">h ap</translation>
+        <translation>h ap</translation>
     </message>
     <message>
         <source>h AP</source>
-        <translation type="obsolete">h AP</translation>
+        <translation>h AP</translation>
     </message>
     <message>
         <source>h:mm</source>
-        <translation type="obsolete">h:mm</translation>
+        <translation>h:mm</translation>
     </message>
     <message>
         <source>h:mm ap</source>
-        <translation type="obsolete">h:mm ap</translation>
+        <translation>h:mm ap</translation>
     </message>
     <message>
         <source>hh:mm</source>
-        <translation type="obsolete">hh:mm</translation>
+        <translation>hh:mm</translation>
     </message>
     <message>
         <source>h:mm:ss</source>
-        <translation type="obsolete">h:mm:ss</translation>
+        <translation>h:mm:ss</translation>
     </message>
     <message>
         <source>h:mm:ss.zzz</source>
-        <translation type="obsolete">h:mm:ss.zzz</translation>
+        <translation>h:mm:ss.zzz</translation>
     </message>
     <message>
         <source>mm:ss</source>
-        <translation type="obsolete">mm:ss</translation>
+        <translation>mm:ss</translation>
     </message>
     <message>
         <source>mm:ss.zzz</source>
-        <translation type="obsolete">mm:ss.zzz</translation>
+        <translation>mm:ss.zzz</translation>
     </message>
     <message>
         <source>hmm</source>
-        <translation type="obsolete">hmm</translation>
+        <translation>hmm</translation>
     </message>
     <message>
         <source>hmmss</source>
-        <translation type="obsolete">hmmss</translation>
+        <translation>hmmss</translation>
     </message>
     <message>
         <source>hhmmss</source>
-        <translation type="obsolete">hhmmss</translation>
+        <translation>hhmmss</translation>
     </message>
     <message>
         <source>&amp;&lt;&lt; Prev.</source>
         <comment>previous column</comment>
-        <translation type="obsolete">&amp;&lt;&lt; Ant.</translation>
+        <translation>&amp;&lt;&lt; Ant.</translation>
     </message>
     <message>
         <source>Next &amp;&gt;&gt;</source>
         <comment>next column</comment>
-        <translation type="obsolete">Próx. &amp;&gt;&gt;</translation>
+        <translation>Próx. &amp;&gt;&gt;</translation>
     </message>
     <message>
         <source>&amp;Display Comments in Header</source>
-        <translation type="obsolete">&amp;Mostrar comentários no cabeçalho</translation>
+        <translation>&amp;Mostrar comentários no cabeçalho</translation>
     </message>
     <message>
         <source>Couldn&apos;t guess the source data format, please specify it using the &apos;Format&apos; box!</source>
-        <translation type="obsolete">Não foi possível determminar o formato dos dados, por favor especifique-o usando o quadro &apos;Formato&apos;!</translation>
+        <translation>Não foi possível determminar o formato dos dados, por favor especifique-o usando o quadro &apos;Formato&apos;!</translation>
     </message>
     <message>
         <source>For more information about the supported date/time formats please read the Qt documentation for the QDateTime class!</source>
-        <translation type="obsolete">Para mais informações sobre os formatos de data/hora suportados, leia a documentação do Qt para a clase QDateTime!</translation>
+        <translation>Para mais informações sobre os formatos de data/hora suportados, leia a documentação do Qt para a clase QDateTime!</translation>
     </message>
     <message>
         <source>Column options</source>
-        <translation type="obsolete">Opções de coluna</translation>
+        <translation>Opções de coluna</translation>
     </message>
     <message>
         <source>Warning</source>
-        <translation type="obsolete">Atenção</translation>
+        <translation>Atenção</translation>
     </message>
     <message>
         <source>Error</source>
-        <translation type="obsolete">Erro</translation>
+        <translation>Erro</translation>
     </message>
 </context>
 <context>
     <name>TableModel</name>
     <message>
         <source>(masked)</source>
-        <translation type="obsolete">(mascarado)</translation>
+        <translation>(mascarado)</translation>
     </message>
     <message>
         <source>invalid cell (ignored in all operations)</source>
         <comment>tooltip string for invalid rows</comment>
-        <translation type="obsolete">célula inválida (ignorada em todas as opreações)</translation>
+        <translation>célula inválida (ignorada em todas as opreações)</translation>
     </message>
     <message>
         <source>-</source>
         <comment>string for invalid rows</comment>
-        <translation type="obsolete">cadeia de caracteres para linhas inválidas</translation>
+        <translation>cadeia de caracteres para linhas inválidas</translation>
     </message>
 </context>
 <context>
@@ -14524,163 +13508,163 @@ Gostaria de inserir células?</translation>
     <message>
         <source>Ctrl+A</source>
         <comment>Table: select all</comment>
-        <translation type="obsolete">Ctrl+A</translation>
+        <translation>Ctrl+A</translation>
     </message>
     <message>
         <source>Show/hide control tabs</source>
-        <translation type="obsolete">Mostrar/ocultar abas de controle</translation>
+        <translation>Mostrar/ocultar abas de controle</translation>
     </message>
     <message>
         <source>Numeric</source>
-        <translation type="obsolete">Numérico</translation>
+        <translation>Numérico</translation>
     </message>
     <message>
         <source>Text</source>
-        <translation type="obsolete">Texto</translation>
+        <translation>Texto</translation>
     </message>
     <message>
         <source>Month names</source>
-        <translation type="obsolete">Nomes dos meses</translation>
+        <translation>Nomes dos meses</translation>
     </message>
     <message>
         <source>Day names</source>
-        <translation type="obsolete">Nomes dos dias</translation>
+        <translation>Nomes dos dias</translation>
     </message>
     <message>
         <source>Date and time</source>
-        <translation type="obsolete">Data e hora</translation>
+        <translation>Data e hora</translation>
     </message>
     <message>
         <source>years</source>
-        <translation type="obsolete">anos</translation>
+        <translation>anos</translation>
     </message>
     <message>
         <source>months</source>
-        <translation type="obsolete">meses</translation>
+        <translation>meses</translation>
     </message>
     <message>
         <source>days</source>
-        <translation type="obsolete">dias</translation>
+        <translation>dias</translation>
     </message>
     <message>
         <source>hours</source>
-        <translation type="obsolete">horas</translation>
+        <translation>horas</translation>
     </message>
     <message>
         <source>minutes</source>
-        <translation type="obsolete">minutos</translation>
+        <translation>minutos</translation>
     </message>
     <message>
         <source>seconds</source>
-        <translation type="obsolete">segundos</translation>
+        <translation>segundos</translation>
     </message>
     <message>
         <source>milliseconds</source>
-        <translation type="obsolete">milissegundos</translation>
+        <translation>milissegundos</translation>
     </message>
     <message>
         <source>Current column:
 Name: %1
 Position: %2</source>
-        <translation type="obsolete">Coluna Atual:
+        <translation>Coluna Atual:
 Nome: %1
 Posição: %2</translation>
     </message>
     <message>
         <source>Decimal</source>
-        <translation type="obsolete">Decimal</translation>
+        <translation>Decimal</translation>
     </message>
     <message>
         <source>Scientific (e)</source>
-        <translation type="obsolete">Científico (e)</translation>
+        <translation>Científico (e)</translation>
     </message>
     <message>
         <source>Scientific (E)</source>
-        <translation type="obsolete">Científico (E)</translation>
+        <translation>Científico (E)</translation>
     </message>
     <message>
         <source>Number without leading zero</source>
-        <translation type="obsolete">Número sem o zero principal</translation>
+        <translation>Número sem o zero principal</translation>
     </message>
     <message>
         <source>Number with leading zero</source>
-        <translation type="obsolete">Número com o zero principal</translation>
+        <translation>Número com o zero principal</translation>
     </message>
     <message>
         <source>Abbreviated month name</source>
-        <translation type="obsolete">Nome abreviado do mês</translation>
+        <translation>Nome abreviado do mês</translation>
     </message>
     <message>
         <source>Full month name</source>
-        <translation type="obsolete">Nome completo do mês</translation>
+        <translation>Nome completo do mês</translation>
     </message>
     <message>
         <source>Abbreviated day name</source>
-        <translation type="obsolete">Nome abreviado do dia</translation>
+        <translation>Nome abreviado do dia</translation>
     </message>
     <message>
         <source>Full day name</source>
-        <translation type="obsolete">Nome completo do dia</translation>
+        <translation>Nome completo do dia</translation>
     </message>
     <message>
         <source>Predefined:</source>
-        <translation type="obsolete">Pré-definido(a):</translation>
+        <translation>Pré-definido(a):</translation>
     </message>
     <message>
         <source>Format:</source>
-        <translation type="obsolete">Formato:</translation>
+        <translation>Formato:</translation>
     </message>
     <message>
         <source>Selected column type:
 </source>
-        <translation type="obsolete">Selecione tipo de coluna:
+        <translation>Selecione tipo de coluna:
 </translation>
     </message>
     <message>
         <source>Double precision
 floating point values
 </source>
-        <translation type="obsolete">Precisão dupla (double)
+        <translation>Precisão dupla (double)
 valores de ponto flutuante (float)
 </translation>
     </message>
     <message>
         <source>Text
 </source>
-        <translation type="obsolete">Texto
+        <translation>Texto
 </translation>
     </message>
     <message>
         <source>Month names
 </source>
-        <translation type="obsolete">Momes dos meses</translation>
+        <translation>Momes dos meses</translation>
     </message>
     <message>
         <source>Days of the week
 </source>
-        <translation type="obsolete">Dias da semana</translation>
+        <translation>Dias da semana</translation>
     </message>
     <message>
         <source>Dates and/or times
 </source>
-        <translation type="obsolete">Datas e/ou horas</translation>
+        <translation>Datas e/ou horas</translation>
     </message>
     <message>
         <source>Example: </source>
-        <translation type="obsolete">Exemplo: </translation>
+        <translation>Exemplo: </translation>
     </message>
     <message>
         <source>Hello world!
 </source>
-        <translation type="obsolete">Olá mundo!</translation>
+        <translation>Olá mundo!</translation>
     </message>
     <message>
         <source>Automatic (e)</source>
-        <translation type="obsolete">Automático (e)</translation>
+        <translation>Automático (e)</translation>
     </message>
     <message>
         <source>Automatic (E)</source>
-        <translation type="obsolete">Automático (E)</translation>
+        <translation>Automático (E)</translation>
     </message>
 </context>
 <context>
@@ -14720,16 +13704,12 @@ valores de ponto flutuante (float)
 <context>
     <name>TextDialog</name>
     <message>
-        <source>QtiPlot - Text options</source>
-        <translation type="obsolete">QtiPlot- Opções de texto</translation>
-    </message>
-    <message>
         <source>Color</source>
-        <translation type="obsolete">Cor</translation>
+        <translation>Cor</translation>
     </message>
     <message>
         <source>Co&amp;lor</source>
-        <translation type="obsolete">Co&amp;r</translation>
+        <translation>Co&amp;r</translation>
     </message>
     <message>
         <source>&amp;OK</source>
@@ -14749,7 +13729,7 @@ valores de ponto flutuante (float)
     </message>
     <message>
         <source>Alignement</source>
-        <translation type="obsolete">Alinhamento</translation>
+        <translation>Alinhamento</translation>
     </message>
     <message>
         <source>Center</source>
@@ -14785,63 +13765,63 @@ valores de ponto flutuante (float)
     </message>
     <message>
         <source>Background</source>
-        <translation type="obsolete">Fundo</translation>
+        <translation>Fundo</translation>
     </message>
     <message>
         <source>&amp;Background</source>
-        <translation type="obsolete">Fun&amp;do</translation>
+        <translation>Fun&amp;do</translation>
     </message>
     <message>
         <source>Rotate (deg.)</source>
-        <translation type="obsolete">Rotacionar (graus)</translation>
+        <translation>Rotacionar (graus)</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="obsolete">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>45</source>
-        <translation type="obsolete">45</translation>
+        <translation>45</translation>
     </message>
     <message>
         <source>90</source>
-        <translation type="obsolete">90</translation>
+        <translation>90</translation>
     </message>
     <message>
         <source>135</source>
-        <translation type="obsolete">135</translation>
+        <translation>135</translation>
     </message>
     <message>
         <source>180</source>
-        <translation type="obsolete">180</translation>
+        <translation>180</translation>
     </message>
     <message>
         <source>225</source>
-        <translation type="obsolete">225</translation>
+        <translation>225</translation>
     </message>
     <message>
         <source>270</source>
-        <translation type="obsolete">270</translation>
+        <translation>270</translation>
     </message>
     <message>
         <source>315</source>
-        <translation type="obsolete">315</translation>
+        <translation>315</translation>
     </message>
     <message>
         <source>B</source>
-        <translation type="obsolete">B</translation>
+        <translation>B</translation>
     </message>
     <message>
         <source>It</source>
-        <translation type="obsolete">It</translation>
+        <translation>It</translation>
     </message>
     <message>
         <source>U</source>
-        <translation type="obsolete">U</translation>
+        <translation>U</translation>
     </message>
     <message>
         <source>Set &amp;Default</source>
-        <translation type="obsolete">Definir como &amp;padrão</translation>
+        <translation>Definir como &amp;padrão</translation>
     </message>
     <message>
         <source>Text Color</source>
@@ -14932,10 +13912,6 @@ valores de ponto flutuante (float)
         <translation>Curva selecionada! Mova o cursor, clique para selecionar um ponto e duplo clique/ou  &apos;Enter&apos; para finalisar!</translation>
     </message>
     <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
-    </message>
-    <message>
         <source>This operation cannot be performed on function curves.</source>
         <translation>Esta operação não pode ser realizada sobre curvas de função.</translation>
     </message>
@@ -14978,2789 +13954,2593 @@ valores de ponto flutuante (float)
 <context>
     <name>analysisDialog</name>
     <message>
-        <source>QtiPlot - Analysis Option</source>
-        <translation type="obsolete">QtiPlot - Opção de análise</translation>
-    </message>
-    <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Analysis Options</source>
-        <translation type="obsolete">QtiPlot - Opções de análise</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
 </context>
 <context>
     <name>associationsDialog</name>
     <message>
-        <source>QtiPlot - Plot Associations</source>
-        <translation type="obsolete">QtiPlot - Associações de gráficos</translation>
-    </message>
-    <message>
         <source>Spreadsheet: </source>
-        <translation type="obsolete">Planilha: </translation>
+        <translation>Planilha: </translation>
     </message>
     <message>
         <source>Column</source>
-        <translation type="obsolete">Coluna</translation>
+        <translation>Coluna</translation>
     </message>
     <message>
         <source>X</source>
-        <translation type="obsolete">X</translation>
+        <translation>X</translation>
     </message>
     <message>
         <source>Y</source>
-        <translation type="obsolete">Y</translation>
+        <translation>Y</translation>
     </message>
     <message>
         <source>xErr</source>
-        <translation type="obsolete">xErr</translation>
+        <translation>xErr</translation>
     </message>
     <message>
         <source>yErr</source>
-        <translation type="obsolete">yErr</translation>
+        <translation>yErr</translation>
     </message>
     <message>
         <source>&amp;Update curve</source>
-        <translation type="obsolete">At&amp;ualizar curva</translation>
+        <translation>At&amp;ualizar curva</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>xEnd</source>
-        <translation type="obsolete">xFinal</translation>
+        <translation>xFinal</translation>
     </message>
     <message>
         <source>yEnd</source>
-        <translation type="obsolete">yFinal</translation>
+        <translation>yFinal</translation>
     </message>
 </context>
 <context>
     <name>axesDialog</name>
     <message>
-        <source>QtiPlot - General Plot Options</source>
-        <translation type="obsolete">QtiPlot - Opções gerais do gráfico</translation>
-    </message>
-    <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>From</source>
-        <translation type="obsolete">A partir de</translation>
+        <translation>A partir de</translation>
     </message>
     <message>
         <source>To</source>
-        <translation type="obsolete">Até</translation>
+        <translation>Até</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="obsolete">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>linear</source>
-        <translation type="obsolete">linear</translation>
+        <translation>linear</translation>
     </message>
     <message>
         <source>logarithmic</source>
-        <translation type="obsolete">logaritimico</translation>
+        <translation>logaritimico</translation>
     </message>
     <message>
         <source>Inverted</source>
-        <translation type="obsolete">Invertido</translation>
+        <translation>Invertido</translation>
     </message>
     <message>
         <source>Step</source>
-        <translation type="obsolete">Passo</translation>
+        <translation>Passo</translation>
     </message>
     <message>
         <source>Major Ticks</source>
-        <translation type="obsolete">Marcas maiores</translation>
+        <translation>Marcas maiores</translation>
     </message>
     <message>
         <source>Minor Ticks</source>
-        <translation type="obsolete">Marcas menores</translation>
+        <translation>Marcas menores</translation>
     </message>
     <message>
         <source>Horizontal</source>
-        <translation type="obsolete">Horizontal</translation>
+        <translation>Horizontal</translation>
     </message>
     <message>
         <source>Vertical</source>
-        <translation type="obsolete">Vertical</translation>
+        <translation>Vertical</translation>
     </message>
     <message>
         <source>Scale</source>
-        <translation type="obsolete">Escala</translation>
+        <translation>Escala</translation>
     </message>
     <message>
         <source>Major Grids</source>
-        <translation type="obsolete">Grades primárias</translation>
+        <translation>Grades primárias</translation>
     </message>
     <message>
         <source>Minor Grids</source>
-        <translation type="obsolete">Grades secundárias</translation>
+        <translation>Grades secundárias</translation>
     </message>
     <message>
         <source>Line Color</source>
-        <translation type="obsolete">Cor da inha</translation>
+        <translation>Cor da inha</translation>
     </message>
     <message>
         <source>Line Type</source>
-        <translation type="obsolete">Tipo de linha</translation>
+        <translation>Tipo de linha</translation>
     </message>
     <message>
         <source>Thickness</source>
-        <translation type="obsolete">Espessura</translation>
+        <translation>Espessura</translation>
     </message>
     <message>
         <source>Additional lines</source>
-        <translation type="obsolete">Linhas adicionais</translation>
+        <translation>Linhas adicionais</translation>
     </message>
     <message>
         <source>X=0</source>
-        <translation type="obsolete">X=0</translation>
+        <translation>X=0</translation>
     </message>
     <message>
         <source>Y=0</source>
-        <translation type="obsolete">Y=0</translation>
+        <translation>Y=0</translation>
     </message>
     <message>
         <source>Grid</source>
-        <translation type="obsolete">Grade</translation>
+        <translation>Grade</translation>
     </message>
     <message>
         <source>Show</source>
-        <translation type="obsolete">Mostrar</translation>
+        <translation>Mostrar</translation>
     </message>
     <message>
         <source>Title</source>
-        <translation type="obsolete">Título</translation>
+        <translation>Título</translation>
     </message>
     <message>
         <source>Numeric</source>
-        <translation type="obsolete">Numérico</translation>
+        <translation>Numérico</translation>
     </message>
     <message>
         <source>Text from table</source>
-        <translation type="obsolete">Texto da tabela</translation>
+        <translation>Texto da tabela</translation>
     </message>
     <message>
         <source>Day of the week</source>
-        <translation type="obsolete">Dia da semana</translation>
+        <translation>Dia da semana</translation>
     </message>
     <message>
         <source>Month</source>
-        <translation type="obsolete">Mês</translation>
+        <translation>Mês</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="obsolete">Tempo</translation>
+        <translation>Tempo</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="obsolete">Data</translation>
+        <translation>Data</translation>
     </message>
     <message>
         <source>Font</source>
-        <translation type="obsolete">Fonte</translation>
+        <translation>Fonte</translation>
     </message>
     <message>
         <source>Axis &amp;Font</source>
-        <translation type="obsolete">&amp;Fonte do eixo</translation>
+        <translation>&amp;Fonte do eixo</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="obsolete">Cor</translation>
+        <translation>Cor</translation>
     </message>
     <message>
         <source>Co&amp;lor</source>
-        <translation type="obsolete">Co&amp;r</translation>
+        <translation>Co&amp;r</translation>
     </message>
     <message>
         <source>Ticks</source>
-        <translation type="obsolete">Marcas</translation>
+        <translation>Marcas</translation>
     </message>
     <message>
         <source>In</source>
-        <translation type="obsolete">Dentro</translation>
+        <translation>Dentro</translation>
     </message>
     <message>
         <source>Out</source>
-        <translation type="obsolete">Fora</translation>
+        <translation>Fora</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="obsolete">Ambos</translation>
+        <translation>Ambos</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="obsolete">Nenhum</translation>
+        <translation>Nenhum</translation>
     </message>
     <message>
         <source>Stand-off</source>
-        <translation type="obsolete">Separados</translation>
+        <translation>Separados</translation>
     </message>
     <message>
         <source>Show Labels</source>
-        <translation type="obsolete">Mostrar rótulos</translation>
+        <translation>Mostrar rótulos</translation>
     </message>
     <message>
         <source>Table</source>
-        <translation type="obsolete">Tabela</translation>
+        <translation>Tabela</translation>
     </message>
     <message>
         <source>Format</source>
-        <translation type="obsolete">Formato</translation>
+        <translation>Formato</translation>
     </message>
     <message>
         <source>Precision</source>
-        <translation type="obsolete">Precisão</translation>
+        <translation>Precisão</translation>
     </message>
     <message>
         <source>Angle</source>
-        <translation type="obsolete">Ângulo</translation>
+        <translation>Ângulo</translation>
     </message>
     <message>
         <source>For&amp;mula</source>
-        <translation type="obsolete">Fór&amp;mula</translation>
+        <translation>Fór&amp;mula</translation>
     </message>
     <message>
         <source>Axis</source>
-        <translation type="obsolete">Eixo</translation>
+        <translation>Eixo</translation>
     </message>
     <message>
         <source>Canvas frame</source>
-        <translation type="obsolete">Estrutura do fundo</translation>
+        <translation>Estrutura do fundo</translation>
     </message>
     <message>
         <source>C&amp;olor</source>
-        <translation type="obsolete">C&amp;or</translation>
+        <translation>C&amp;or</translation>
     </message>
     <message>
         <source>Width</source>
-        <translation type="obsolete">Largura</translation>
+        <translation>Largura</translation>
     </message>
     <message>
         <source>Background</source>
-        <translation type="obsolete">Fundo</translation>
+        <translation>Fundo</translation>
     </message>
     <message>
         <source>Border Width</source>
-        <translation type="obsolete">Largura da borda</translation>
+        <translation>Largura da borda</translation>
     </message>
     <message>
         <source>Border Color</source>
-        <translation type="obsolete">Cor da borda</translation>
+        <translation>Cor da borda</translation>
     </message>
     <message>
         <source>Colo&amp;r</source>
-        <translation type="obsolete">Co&amp;r</translation>
+        <translation>Co&amp;r</translation>
     </message>
     <message>
         <source>Axes</source>
-        <translation type="obsolete">Eixos</translation>
+        <translation>Eixos</translation>
     </message>
     <message>
         <source>Draw backbones</source>
-        <translation type="obsolete">Desenhar guias</translation>
+        <translation>Desenhar guias</translation>
     </message>
     <message>
         <source>Line Width</source>
-        <translation type="obsolete">Espessura da linha</translation>
+        <translation>Espessura da linha</translation>
     </message>
     <message>
         <source>Major ticks length</source>
-        <translation type="obsolete">Comprimento das marcas maiores</translation>
+        <translation>Comprimento das marcas maiores</translation>
     </message>
     <message>
         <source>Minor ticks length</source>
-        <translation type="obsolete">Comprimento das marcas menores</translation>
+        <translation>Comprimento das marcas menores</translation>
     </message>
     <message>
         <source>Margin</source>
-        <translation type="obsolete">Margem</translation>
+        <translation>Margem</translation>
     </message>
     <message>
         <source>Apply to all layers</source>
-        <translation type="obsolete">Aplicar a todas as camadas</translation>
+        <translation>Aplicar a todas as camadas</translation>
     </message>
     <message>
         <source>General</source>
-        <translation type="obsolete">Geral</translation>
+        <translation>Geral</translation>
     </message>
     <message>
         <source>Automatic</source>
-        <translation type="obsolete">Automático</translation>
+        <translation>Automático</translation>
     </message>
     <message>
         <source>Decimal: 100.0</source>
-        <translation type="obsolete">Decimal: 100.0</translation>
+        <translation>Decimal: 100.0</translation>
     </message>
     <message>
         <source>Scientific: 1e2</source>
-        <translation type="obsolete">Científico: 1e2</translation>
+        <translation>Científico: 1e2</translation>
     </message>
     <message>
         <source>Scientific: 10^2</source>
-        <translation type="obsolete">Científico: 10^2</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Start limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite inicial</translation>
-    </message>
-    <message>
-        <source>QtiPlot - End limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite final</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Step input error</source>
-        <translation type="obsolete">QtiPlot - Erro no passo</translation>
+        <translation>Científico: 10^2</translation>
     </message>
     <message>
         <source>Please enter a positive step value!</source>
-        <translation type="obsolete">Por favor, forneça um valor positivo para o passo!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Formula input error</source>
-        <translation type="obsolete">QtiPlot - Erro na fórmula fornecida</translation>
+        <translation>Por favor, forneça um valor positivo para o passo!</translation>
     </message>
     <message>
         <source>Valid variables are &apos;x&apos; for Top/Bottom axes and &apos;y&apos; for Left/Right axes!</source>
-        <translation type="obsolete">As variáveis válidas são &apos;x&apos; para os eixos Superior/Inferior e &apos;y&apos; para os eixos esquerdo/direito!</translation>
+        <translation>As variáveis válidas são &apos;x&apos; para os eixos Superior/Inferior e &apos;y&apos; para os eixos esquerdo/direito!</translation>
     </message>
     <message>
         <source>milisec.</source>
-        <translation type="obsolete">miliseg.</translation>
+        <translation>miliseg.</translation>
     </message>
     <message>
         <source>sec.</source>
-        <translation type="obsolete">seg.</translation>
+        <translation>seg.</translation>
     </message>
     <message>
         <source>min.</source>
-        <translation type="obsolete">min.</translation>
+        <translation>min.</translation>
     </message>
     <message>
         <source>hours</source>
-        <translation type="obsolete">horas</translation>
+        <translation>horas</translation>
     </message>
     <message>
         <source>days</source>
-        <translation type="obsolete">dias</translation>
+        <translation>dias</translation>
     </message>
     <message>
         <source>weeks</source>
-        <translation type="obsolete">semanas</translation>
+        <translation>semanas</translation>
     </message>
     <message>
         <source>Column Headings</source>
-        <translation type="obsolete">Cabeçalhos de coluna</translation>
+        <translation>Cabeçalhos de coluna</translation>
     </message>
     <message>
         <source>&amp;Font</source>
-        <translation type="obsolete">&amp;Fonte</translation>
+        <translation>&amp;Fonte</translation>
     </message>
     <message>
         <source>B</source>
-        <translation type="obsolete">B</translation>
+        <translation>B</translation>
     </message>
     <message>
         <source>It</source>
-        <translation type="obsolete">It</translation>
+        <translation>It</translation>
     </message>
     <message>
         <source>U</source>
-        <translation type="obsolete">U</translation>
+        <translation>U</translation>
     </message>
     <message>
         <source>In &amp; Out</source>
-        <translation type="obsolete">Dentro e Fora</translation>
+        <translation>Dentro e Fora</translation>
     </message>
     <message>
         <source>Canvas Color</source>
-        <translation type="obsolete">Cor do fundo</translation>
+        <translation>Cor do fundo</translation>
     </message>
     <message>
         <source>millisec.</source>
-        <translation type="obsolete">miliseg.</translation>
+        <translation>miliseg.</translation>
     </message>
     <message>
         <source>Bottom</source>
-        <translation type="obsolete">Inferior</translation>
+        <translation>Inferior</translation>
     </message>
     <message>
         <source>Left</source>
-        <translation type="obsolete">Esquerdo</translation>
+        <translation>Esquerdo</translation>
     </message>
     <message>
         <source>Top</source>
-        <translation type="obsolete">Superior</translation>
+        <translation>Superior</translation>
     </message>
     <message>
         <source>Right</source>
-        <translation type="obsolete">Direito</translation>
+        <translation>Direito</translation>
     </message>
 </context>
 <context>
     <name>configDialog</name>
     <message>
         <source>Application</source>
-        <translation type="obsolete">Aplicação</translation>
+        <translation>Aplicação</translation>
     </message>
     <message>
         <source>Confirmations</source>
-        <translation type="obsolete">Confirmações</translation>
+        <translation>Confirmações</translation>
     </message>
     <message>
         <source>Tables</source>
-        <translation type="obsolete">Tabelas</translation>
+        <translation>Tabelas</translation>
     </message>
     <message>
         <source>3D Plots</source>
-        <translation type="obsolete">Gráficos 3D</translation>
+        <translation>Gráficos 3D</translation>
     </message>
     <message>
         <source>2D Plots</source>
-        <translation type="obsolete">Gráficos 2D</translation>
+        <translation>Gráficos 2D</translation>
     </message>
     <message>
         <source>2D Curves</source>
-        <translation type="obsolete">Curvas 2D</translation>
+        <translation>Curvas 2D</translation>
     </message>
     <message>
         <source>Colors</source>
-        <translation type="obsolete">Cores</translation>
+        <translation>Cores</translation>
     </message>
     <message>
         <source>Fonts</source>
-        <translation type="obsolete">Fontes</translation>
+        <translation>Fontes</translation>
     </message>
     <message>
         <source>Prompt on closing</source>
-        <translation type="obsolete">Avisar ao fechar</translation>
+        <translation>Avisar ao fechar</translation>
     </message>
     <message>
         <source>Matrixes</source>
-        <translation type="obsolete">Matrizes</translation>
+        <translation>Matrizes</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="obsolete">Opções</translation>
+        <translation>Opções</translation>
     </message>
     <message>
         <source>Frame width</source>
-        <translation type="obsolete">Largura do quadro</translation>
+        <translation>Largura do quadro</translation>
     </message>
     <message>
         <source>Legend frame</source>
-        <translation type="obsolete">Quadro da legenda</translation>
+        <translation>Quadro da legenda</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="obsolete">Nenhum</translation>
+        <translation>Nenhum</translation>
     </message>
     <message>
         <source>Rectangle</source>
-        <translation type="obsolete">Retângulo</translation>
+        <translation>Retângulo</translation>
     </message>
     <message>
         <source>Shadow</source>
-        <translation type="obsolete">Sombra</translation>
+        <translation>Sombra</translation>
     </message>
     <message>
         <source>White out</source>
-        <translation type="obsolete">Branco fora</translation>
+        <translation>Branco fora</translation>
     </message>
     <message>
         <source>Black out</source>
-        <translation type="obsolete">Preto fora</translation>
+        <translation>Preto fora</translation>
     </message>
     <message>
         <source>Ticks</source>
-        <translation type="obsolete">Marcas</translation>
+        <translation>Marcas</translation>
     </message>
     <message>
         <source>In</source>
-        <translation type="obsolete">Dentro</translation>
+        <translation>Dentro</translation>
     </message>
     <message>
         <source>Out</source>
-        <translation type="obsolete">Fora</translation>
+        <translation>Fora</translation>
     </message>
     <message>
         <source>Both</source>
-        <translation type="obsolete">Ambos</translation>
+        <translation>Ambos</translation>
     </message>
     <message>
         <source>Major ticks length</source>
-        <translation type="obsolete">Comprimento das marcas maiores</translation>
+        <translation>Comprimento das marcas maiores</translation>
     </message>
     <message>
         <source>Axes linewidth</source>
-        <translation type="obsolete">Largura de linha dos eixos</translation>
+        <translation>Largura de linha dos eixos</translation>
     </message>
     <message>
         <source>Minor ticks length</source>
-        <translation type="obsolete">comprimento das marcas menores</translation>
+        <translation>comprimento das marcas menores</translation>
     </message>
     <message>
         <source>&amp;Show Legend</source>
-        <translation type="obsolete">Mo&amp;strar legenda</translation>
+        <translation>Mo&amp;strar legenda</translation>
     </message>
     <message>
         <source>Resolution</source>
-        <translation type="obsolete">Resolução</translation>
+        <translation>Resolução</translation>
     </message>
     <message>
         <source>Lab&amp;els</source>
-        <translation type="obsolete">Rótulos</translation>
+        <translation>Rótulos</translation>
     </message>
     <message>
         <source>Mesh &amp;Line</source>
-        <translation type="obsolete">&amp;Linha de grade</translation>
+        <translation>&amp;Linha de grade</translation>
     </message>
     <message>
         <source>&amp;Grid</source>
-        <translation type="obsolete">&amp;Grade</translation>
+        <translation>&amp;Grade</translation>
     </message>
     <message>
         <source>Data &amp;Min</source>
-        <translation type="obsolete">&amp;Min dados</translation>
+        <translation>&amp;Min dados</translation>
     </message>
     <message>
         <source>&amp;Numbers</source>
-        <translation type="obsolete">&amp;Números</translation>
+        <translation>&amp;Números</translation>
     </message>
     <message>
         <source>&amp;Background</source>
-        <translation type="obsolete">Fun&amp;do</translation>
+        <translation>Fun&amp;do</translation>
     </message>
     <message>
         <source>&amp;Title</source>
-        <translation type="obsolete">&amp;Título</translation>
+        <translation>&amp;Título</translation>
     </message>
     <message>
         <source>&amp;Axes Labels</source>
-        <translation type="obsolete">Rótulo dos eixos</translation>
+        <translation>Rótulo dos eixos</translation>
     </message>
     <message>
         <source>General</source>
-        <translation type="obsolete">Geral</translation>
+        <translation>Geral</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="obsolete">Estilo</translation>
+        <translation>Estilo</translation>
     </message>
     <message>
         <source>Choose &amp;font</source>
-        <translation type="obsolete">Escolher &amp;fonte</translation>
+        <translation>Escolher &amp;fonte</translation>
     </message>
     <message>
         <source>Save every</source>
-        <translation type="obsolete">Salvar a cada</translation>
+        <translation>Salvar a cada</translation>
     </message>
     <message>
         <source>Default curve style</source>
-        <translation type="obsolete">Estilo de curva padrão</translation>
+        <translation>Estilo de curva padrão</translation>
     </message>
     <message>
         <source> Line</source>
-        <translation type="obsolete">Linha</translation>
+        <translation>Linha</translation>
     </message>
     <message>
         <source> Scatter</source>
-        <translation type="obsolete"> Dispersão</translation>
+        <translation> Dispersão</translation>
     </message>
     <message>
         <source> Line + Symbol</source>
-        <translation type="obsolete"> Linha + símbolo</translation>
+        <translation> Linha + símbolo</translation>
     </message>
     <message>
         <source> Vertical drop lines</source>
-        <translation type="obsolete"> Linhas verticais</translation>
+        <translation> Linhas verticais</translation>
     </message>
     <message>
         <source> Spline</source>
-        <translation type="obsolete"> Spline</translation>
+        <translation> Spline</translation>
     </message>
     <message>
         <source> Vertical steps</source>
-        <translation type="obsolete"> Passos verticais</translation>
+        <translation> Passos verticais</translation>
     </message>
     <message>
         <source> Area</source>
-        <translation type="obsolete">área</translation>
+        <translation>área</translation>
     </message>
     <message>
         <source> Vertical Bars</source>
-        <translation type="obsolete"> Barras verticais</translation>
+        <translation> Barras verticais</translation>
     </message>
     <message>
         <source> Horizontal Bars</source>
-        <translation type="obsolete">Barras horizontais</translation>
+        <translation>Barras horizontais</translation>
     </message>
     <message>
         <source>Line width</source>
-        <translation type="obsolete">Largura da linha</translation>
+        <translation>Largura da linha</translation>
     </message>
     <message>
         <source>Symbol size</source>
-        <translation type="obsolete">Tamanho do símbolo</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Choose default settings</source>
-        <translation type="obsolete">QtiPlot - Escolher configuração padrão</translation>
+        <translation>Tamanho do símbolo</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>&amp;Text Font</source>
-        <translation type="obsolete">Fonte do &amp;texto</translation>
+        <translation>Fonte do &amp;texto</translation>
     </message>
     <message>
         <source>&amp;Labels Font</source>
-        <translation type="obsolete">Fonte dos rótulos</translation>
+        <translation>Fonte dos rótulos</translation>
     </message>
     <message>
         <source>A&amp;xes Legend</source>
-        <translation type="obsolete">Legenda dos eixos</translation>
+        <translation>Legenda dos eixos</translation>
     </message>
     <message>
         <source>Axes &amp;Numbers</source>
-        <translation type="obsolete">&amp;Números dos eixos</translation>
+        <translation>&amp;Números dos eixos</translation>
     </message>
     <message>
         <source>&amp;Legend</source>
-        <translation type="obsolete">&amp;Legenda</translation>
+        <translation>&amp;Legenda</translation>
     </message>
     <message>
         <source>T&amp;itle</source>
-        <translation type="obsolete">T&amp;ítulo</translation>
+        <translation>T&amp;ítulo</translation>
     </message>
     <message>
         <source>&amp;Workspace</source>
-        <translation type="obsolete">área de trabalho</translation>
+        <translation>área de trabalho</translation>
     </message>
     <message>
         <source>Pa&amp;nels</source>
-        <translation type="obsolete">Pai&amp;néis</translation>
+        <translation>Pai&amp;néis</translation>
     </message>
     <message>
         <source>Panels Te&amp;xt</source>
-        <translation type="obsolete">Te&amp;xto dos painéis</translation>
+        <translation>Te&amp;xto dos painéis</translation>
     </message>
     <message>
         <source>Default Column Separator</source>
-        <translation type="obsolete">Separador de coluna padrão</translation>
+        <translation>Separador de coluna padrão</translation>
     </message>
     <message>
         <source>Background</source>
-        <translation type="obsolete">Fundo</translation>
+        <translation>Fundo</translation>
     </message>
     <message>
         <source>Text</source>
-        <translation type="obsolete">Texto</translation>
+        <translation>Texto</translation>
     </message>
     <message>
         <source>Labels</source>
-        <translation type="obsolete">Rótulos</translation>
+        <translation>Rótulos</translation>
     </message>
     <message>
         <source>Auto&amp;scaling</source>
-        <translation type="obsolete">Autoe&amp;scalar</translation>
+        <translation>Autoe&amp;scalar</translation>
     </message>
     <message>
         <source>Scale &amp;Fonts</source>
-        <translation type="obsolete">Escalar &amp;fontes</translation>
+        <translation>Escalar &amp;fontes</translation>
     </message>
     <message>
         <source>Show &amp;Title</source>
-        <translation type="obsolete">Mostrar &amp;título</translation>
+        <translation>Mostrar &amp;título</translation>
     </message>
     <message>
         <source>Sho&amp;w all axes</source>
-        <translation type="obsolete">Mostrar todos os eixos</translation>
+        <translation>Mostrar todos os eixos</translation>
     </message>
     <message>
         <source>Canvas Fra&amp;me</source>
-        <translation type="obsolete">Quadro de fundo</translation>
+        <translation>Quadro de fundo</translation>
     </message>
     <message>
         <source>Axes &amp;backbones</source>
-        <translation type="obsolete">Guías dos eixos</translation>
+        <translation>Guías dos eixos</translation>
     </message>
     <message>
         <source>Margin</source>
-        <translation type="obsolete">Margem</translation>
+        <translation>Margem</translation>
     </message>
     <message>
         <source>Do not &amp;resize layers when window size changes</source>
-        <translation type="obsolete">Não redimensionar a camada quando o tamanho da janela for alterado</translation>
+        <translation>Não redimensionar a camada quando o tamanho da janela for alterado</translation>
     </message>
     <message>
         <source>(all data shown)</source>
-        <translation type="obsolete">(todos os dados mostrados)</translation>
+        <translation>(todos os dados mostrados)</translation>
     </message>
     <message>
         <source>Show &amp;Projection</source>
-        <translation type="obsolete">Mostrar &amp;projeção</translation>
+        <translation>Mostrar &amp;projeção</translation>
     </message>
     <message>
         <source>Smooth Mes&amp;h</source>
-        <translation type="obsolete">Suavizar grade</translation>
+        <translation>Suavizar grade</translation>
     </message>
     <message>
         <source>&amp;Data Max</source>
-        <translation type="obsolete">Max &amp;dados</translation>
+        <translation>Max &amp;dados</translation>
     </message>
     <message>
         <source>A&amp;xes</source>
-        <translation type="obsolete">Eixos</translation>
+        <translation>Eixos</translation>
     </message>
     <message>
         <source>Workspace</source>
-        <translation type="obsolete">área de trabalho</translation>
+        <translation>área de trabalho</translation>
     </message>
     <message>
         <source>Panels</source>
-        <translation type="obsolete">Painéis</translation>
+        <translation>Painéis</translation>
     </message>
     <message>
         <source>Panels text</source>
-        <translation type="obsolete">Texto dos painéis</translation>
+        <translation>Texto dos painéis</translation>
     </message>
     <message>
         <source>&amp;Close</source>
-        <translation type="obsolete">&amp;Fechar</translation>
+        <translation>&amp;Fechar</translation>
     </message>
     <message>
         <source>Te&amp;xt</source>
-        <translation type="obsolete">Te&amp;xto</translation>
+        <translation>Te&amp;xto</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="obsolete">Linguagem</translation>
+        <translation>Linguagem</translation>
     </message>
     <message>
         <source> minutes</source>
-        <translation type="obsolete"> minutos</translation>
+        <translation> minutos</translation>
     </message>
     <message>
         <source>Smoot&amp;h Line</source>
-        <translation type="obsolete">Linha suave</translation>
+        <translation>Linha suave</translation>
     </message>
     <message>
         <source>&amp;Notes</source>
-        <translation type="obsolete">&amp;Notas</translation>
+        <translation>&amp;Notas</translation>
     </message>
     <message>
         <source>TAB</source>
-        <translation type="obsolete">TAB</translation>
+        <translation>TAB</translation>
     </message>
     <message>
         <source>SPACE</source>
-        <translation type="obsolete">ESPAÇO</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Import options error</source>
-        <translation type="obsolete">QtiPlot - Erro nas opções de importação</translation>
+        <translation>ESPAÇO</translation>
     </message>
     <message>
         <source>The separator must not contain the following characters: 0-9eE.+-</source>
-        <translation type="obsolete">O separador não pode conter os seguintes caracteres: 0-9eE.+-</translation>
+        <translation>O separador não pode conter os seguintes caracteres: 0-9eE.+-</translation>
     </message>
     <message>
         <source>Folders</source>
-        <translation type="obsolete">Pastas</translation>
+        <translation>Pastas</translation>
     </message>
     <message>
         <source>Generated Fit Curve</source>
-        <translation type="obsolete">Curva de ajuste gerada</translation>
+        <translation>Curva de ajuste gerada</translation>
     </message>
     <message>
         <source>Uniform X Function</source>
-        <translation type="obsolete">Distribução uniforme em X</translation>
+        <translation>Distribução uniforme em X</translation>
     </message>
     <message>
         <source>Points</source>
-        <translation type="obsolete">Pontos</translation>
+        <translation>Pontos</translation>
     </message>
     <message>
         <source>Same X as Fitting Data</source>
-        <translation type="obsolete">Mesmos X que dados da regressão</translation>
+        <translation>Mesmos X que dados da regressão</translation>
     </message>
     <message>
         <source>Display Peak Curves for Multi-peak Fits</source>
-        <translation type="obsolete">Mostrar curvas de pico para ajustes multi-pico</translation>
+        <translation>Mostrar curvas de pico para ajustes multi-pico</translation>
     </message>
     <message>
         <source>Peaks Color</source>
-        <translation type="obsolete">Cor dos picos</translation>
+        <translation>Cor dos picos</translation>
     </message>
     <message>
         <source>Parameters Output</source>
-        <translation type="obsolete">Saída de parâmetros</translation>
+        <translation>Saída de parâmetros</translation>
     </message>
     <message>
         <source>Significant Digits</source>
-        <translation type="obsolete">Dígitos significativos</translation>
+        <translation>Dígitos significativos</translation>
     </message>
     <message>
         <source>Write Parameters to Result Log</source>
-        <translation type="obsolete">Escrever parâmetros no registro de resultados</translation>
+        <translation>Escrever parâmetros no registro de resultados</translation>
     </message>
     <message>
         <source>Paste Parameters to Plot</source>
-        <translation type="obsolete">Colar parâmetros no gráfico</translation>
+        <translation>Colar parâmetros no gráfico</translation>
     </message>
     <message>
         <source>Fitting</source>
-        <translation type="obsolete">Ajustes</translation>
+        <translation>Ajustes</translation>
     </message>
     <message>
         <source>Curves</source>
-        <translation type="obsolete">Curvas</translation>
+        <translation>Curvas</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="obsolete">Comprimento</translation>
+        <translation>Comprimento</translation>
     </message>
     <message>
         <source>Major Ticks</source>
-        <translation type="obsolete">Marcas maiores</translation>
+        <translation>Marcas maiores</translation>
     </message>
     <message>
         <source>Minor Ticks</source>
-        <translation type="obsolete">Marcas menores</translation>
+        <translation>Marcas menores</translation>
     </message>
     <message>
         <source>Draw axes &amp;backbone</source>
-        <translation type="obsolete">Desenhar colunas dos eixos</translation>
+        <translation>Desenhar colunas dos eixos</translation>
     </message>
     <message>
         <source>Scale &amp;fonts on resize</source>
-        <translation type="obsolete">Escalar &amp;fontes ao redimensionar</translation>
+        <translation>Escalar &amp;fontes ao redimensionar</translation>
     </message>
     <message>
         <source>Auto&amp;scale axes</source>
-        <translation type="obsolete">Autoe&amp;scalar eixos</translation>
+        <translation>Autoe&amp;scalar eixos</translation>
     </message>
     <message>
         <source>In &amp; Out</source>
-        <translation type="obsolete">Dentro e fora</translation>
+        <translation>Dentro e fora</translation>
     </message>
     <message>
         <source>Check for new versions at startup</source>
-        <translation type="obsolete">Buscar versões novas ao iniciar</translation>
+        <translation>Buscar versões novas ao iniciar</translation>
     </message>
     <message>
         <source>Default scripting language</source>
-        <translation type="obsolete">Linguagem de script padrão</translation>
+        <translation>Linguagem de script padrão</translation>
     </message>
     <message>
         <source>Scale Errors with sqrt(Chi^2/doF)</source>
-        <translation type="obsolete">Escalar erros com sqrt(Chi^2/doF)</translation>
+        <translation>Escalar erros com sqrt(Chi^2/doF)</translation>
     </message>
     <message>
         <source> Horizontal steps</source>
-        <translation type="obsolete"> Escalas horizontais</translation>
+        <translation> Escalas horizontais</translation>
     </message>
     <message>
         <source>O&amp;rthogonal</source>
-        <translation type="obsolete">O&amp;rtogonal</translation>
+        <translation>O&amp;rtogonal</translation>
     </message>
 </context>
 <context>
     <name>curvesDialog</name>
     <message>
-        <source>QtiPlot - Add/Remove curves</source>
-        <translation type="obsolete">QtiPlot - Adicionar/Remover curvas</translation>
-    </message>
-    <message>
         <source> Line</source>
-        <translation type="obsolete"> Linha</translation>
+        <translation> Linha</translation>
     </message>
     <message>
         <source> Scatter</source>
-        <translation type="obsolete"> Dispersão</translation>
+        <translation> Dispersão</translation>
     </message>
     <message>
         <source> Line + Symbol</source>
-        <translation type="obsolete"> Linha + símbolo</translation>
+        <translation> Linha + símbolo</translation>
     </message>
     <message>
         <source> Vertical drop lines</source>
-        <translation type="obsolete"> Linhas verticais</translation>
+        <translation> Linhas verticais</translation>
     </message>
     <message>
         <source> Spline</source>
-        <translation type="obsolete"> Spline</translation>
+        <translation> Spline</translation>
     </message>
     <message>
         <source> Vertical steps</source>
-        <translation type="obsolete"> Passos verticais</translation>
+        <translation> Passos verticais</translation>
     </message>
     <message>
         <source> Area</source>
-        <translation type="obsolete"> área</translation>
+        <translation> área</translation>
     </message>
     <message>
         <source> Vertical Bars</source>
-        <translation type="obsolete"> Barras verticais</translation>
+        <translation> Barras verticais</translation>
     </message>
     <message>
         <source> Horizontal Bars</source>
-        <translation type="obsolete"> Barras horizontais</translation>
+        <translation> Barras horizontais</translation>
     </message>
     <message>
         <source>Available data</source>
-        <translation type="obsolete">Dados disponíveis</translation>
+        <translation>Dados disponíveis</translation>
     </message>
     <message>
         <source>Graph contents</source>
-        <translation type="obsolete">Conteúdo do gráfico</translation>
+        <translation>Conteúdo do gráfico</translation>
     </message>
     <message>
         <source>OK</source>
-        <translation type="obsolete">OK</translation>
+        <translation>OK</translation>
     </message>
     <message>
         <source>&amp;Plot Associations...</source>
-        <translation type="obsolete">Associações entre gráficos...</translation>
+        <translation>Associações entre gráficos...</translation>
     </message>
     <message>
         <source>&amp;Edit Function...</source>
-        <translation type="obsolete">&amp;Editar função...</translation>
+        <translation>&amp;Editar função...</translation>
     </message>
     <message>
         <source>Close</source>
-        <translation type="obsolete">Fechar</translation>
+        <translation>Fechar</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation type="obsolete">&amp;Excluir</translation>
+        <translation>&amp;Excluir</translation>
     </message>
     <message>
         <source>&amp;Plot</source>
-        <translation type="obsolete">&amp;Gráfico</translation>
+        <translation>&amp;Gráfico</translation>
     </message>
     <message>
         <source> Horizontal steps</source>
-        <translation type="obsolete"> Escalas horizontais</translation>
+        <translation> Escalas horizontais</translation>
     </message>
 </context>
 <context>
     <name>epsExportDialog</name>
     <message>
         <source>Orientation</source>
-        <translation type="obsolete">Orientação</translation>
+        <translation>Orientação</translation>
     </message>
     <message>
         <source>Page Size</source>
-        <translation type="obsolete">Tamanho da página</translation>
+        <translation>Tamanho da página</translation>
     </message>
     <message>
         <source>Resolution</source>
-        <translation type="obsolete">Resolução</translation>
+        <translation>Resolução</translation>
     </message>
     <message>
         <source>&amp;Print in color if available</source>
-        <translation type="obsolete">Im&amp;primir em cores se for possível</translation>
-    </message>
-    <message>
-        <source>QtiPlot - EPS Export options</source>
-        <translation type="obsolete">QtiPlot - Opções de exportação EPS</translation>
+        <translation>Im&amp;primir em cores se for possível</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Landscape</source>
-        <translation type="obsolete">Paisagem</translation>
+        <translation>Paisagem</translation>
     </message>
     <message>
         <source>Portrait</source>
-        <translation type="obsolete">Retrato</translation>
+        <translation>Retrato</translation>
     </message>
     <message>
         <source>Warning: Windows users need a default post-script printer enabled!</source>
-        <translation type="obsolete">Aviso: os usuários de Windows precosam de uma impresora post-script habilitada!</translation>
+        <translation>Aviso: os usuários de Windows precosam de uma impresora post-script habilitada!</translation>
     </message>
 </context>
 <context>
     <name>errDialog</name>
     <message>
-        <source>QtiPlot - Error Bars</source>
-        <translation type="obsolete">QtiPlot - Barras de erro</translation>
-    </message>
-    <message>
         <source>&amp;X Error Bars</source>
-        <translation type="obsolete">Barras de erro &amp;X</translation>
+        <translation>Barras de erro &amp;X</translation>
     </message>
     <message>
         <source>Add Error Bars to</source>
-        <translation type="obsolete">Adicionar barras de erro a</translation>
+        <translation>Adicionar barras de erro a</translation>
     </message>
     <message>
         <source>Source of errors</source>
-        <translation type="obsolete">Fonte dos erros</translation>
+        <translation>Fonte dos erros</translation>
     </message>
     <message>
         <source>Percent of data (%)</source>
-        <translation type="obsolete">Porcentagem de dados (%)</translation>
+        <translation>Porcentagem de dados (%)</translation>
     </message>
     <message>
         <source>5</source>
-        <translation type="obsolete">5</translation>
+        <translation>5</translation>
     </message>
     <message>
         <source>Standard Deviation of Data</source>
-        <translation type="obsolete">Desvio padrão dos dados</translation>
+        <translation>Desvio padrão dos dados</translation>
     </message>
     <message>
         <source>&amp;Y Error Bars</source>
-        <translation type="obsolete">Barras de erro &amp;Y</translation>
+        <translation>Barras de erro &amp;Y</translation>
     </message>
     <message>
         <source>&amp;Add</source>
-        <translation type="obsolete">&amp;Adicionar</translation>
+        <translation>&amp;Adicionar</translation>
     </message>
     <message>
         <source>&amp;Close</source>
-        <translation type="obsolete">&amp;Fechar</translation>
+        <translation>&amp;Fechar</translation>
     </message>
 </context>
 <context>
     <name>expDecayDialog</name>
     <message>
-        <source>QtiPlot - Verify initial guesses</source>
-        <translation type="obsolete">QtiPlot - Verificar estimativas iniciais</translation>
-    </message>
-    <message>
         <source>Damping</source>
-        <translation type="obsolete">Amortecimento</translation>
+        <translation>Amortecimento</translation>
     </message>
     <message>
         <source>First decay time (t1)</source>
-        <translation type="obsolete">Primeiro tempo de decaimento (t1)</translation>
+        <translation>Primeiro tempo de decaimento (t1)</translation>
     </message>
     <message>
         <source>1</source>
-        <translation type="obsolete">1</translation>
+        <translation>1</translation>
     </message>
     <message>
         <source>Second decay time (t2)</source>
-        <translation type="obsolete">Segundo tempo de decaimento (t2)</translation>
+        <translation>Segundo tempo de decaimento (t2)</translation>
     </message>
     <message>
         <source>Third decay time (t3)</source>
-        <translation type="obsolete">Terceiro tempo de decaimento (t3)</translation>
+        <translation>Terceiro tempo de decaimento (t3)</translation>
     </message>
     <message>
         <source>Amplitude</source>
-        <translation type="obsolete">Amplitude</translation>
+        <translation>Amplitude</translation>
     </message>
     <message>
         <source>Initial time</source>
-        <translation type="obsolete">Tempo inicial</translation>
+        <translation>Tempo inicial</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="obsolete">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>Y Offset</source>
-        <translation type="obsolete">Deslocamento Y</translation>
+        <translation>Deslocamento Y</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Exponential Fit of</source>
-        <translation type="obsolete">Ajuste exponencial de</translation>
+        <translation>Ajuste exponencial de</translation>
     </message>
     <message>
         <source>Growth time</source>
-        <translation type="obsolete">Tempo de crescimento</translation>
+        <translation>Tempo de crescimento</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="obsolete">Cor</translation>
+        <translation>Cor</translation>
     </message>
     <message>
         <source>&amp;Fit</source>
-        <translation type="obsolete">Ajuste</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
+        <translation>Ajuste</translation>
     </message>
     <message>
         <source>The curve &lt;b&gt; %1 &lt;/b&gt; doesn&apos;t exist anymore! Operation aborted!</source>
-        <translation type="obsolete">A curva &lt;b&gt;%1&lt;/b&gt; não existe mais! Operação abortada!</translation>
+        <translation>A curva &lt;b&gt;%1&lt;/b&gt; não existe mais! Operação abortada!</translation>
     </message>
     <message>
         <source>&amp;Close</source>
-        <translation type="obsolete">&amp;Fechar</translation>
+        <translation>&amp;Fechar</translation>
     </message>
 </context>
 <context>
     <name>exportDialog</name>
     <message>
         <source>Separator</source>
-        <translation type="obsolete">Separador</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Export ASCII</source>
-        <translation type="obsolete">QtiPlot - Exportar para ASCII</translation>
+        <translation>Separador</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Table</source>
-        <translation type="obsolete">Tabela</translation>
+        <translation>Tabela</translation>
     </message>
     <message>
         <source>Include Column &amp;Names</source>
-        <translation type="obsolete">Incluir &amp;nomes das colunas</translation>
+        <translation>Incluir &amp;nomes das colunas</translation>
     </message>
     <message>
         <source>Export &amp;Selection</source>
-        <translation type="obsolete">Exportar &amp;seleção</translation>
+        <translation>Exportar &amp;seleção</translation>
     </message>
     <message>
         <source>&amp;All</source>
-        <translation type="obsolete">&amp;Tudo</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Import options error</source>
-        <translation type="obsolete">QtiPlot - Erro nas opções de importação</translation>
+        <translation>&amp;Tudo</translation>
     </message>
     <message>
         <source>The separator must not contain the following characters: 0-9eE.+-</source>
-        <translation type="obsolete">O separador não pode conter os seguints caracteres: 0-9eE.+-</translation>
+        <translation>O separador não pode conter os seguints caracteres: 0-9eE.+-</translation>
     </message>
     <message>
         <source>The column separator can be customized. The following special codes can be used:
 \t for a TAB character 
 \s for a SPACE</source>
-        <translation type="obsolete">O separador de coluna pode ser personalizado. Os seguintes códigos podem ser usados:
+        <translation>O separador de coluna pode ser personalizado. Os seguintes códigos podem ser usados:
 \t para um  caractere TAB
 \s para um  ESPAÇO</translation>
     </message>
     <message>
-        <source>QtiPlot - Help</source>
-        <translation type="obsolete">QtiPlot - Ajuda</translation>
-    </message>
-    <message>
         <source>&amp;Help</source>
-        <translation type="obsolete">A&amp;juda</translation>
+        <translation>A&amp;juda</translation>
     </message>
     <message>
         <source>TAB</source>
-        <translation type="obsolete">TAB</translation>
+        <translation>TAB</translation>
     </message>
     <message>
         <source>SPACE</source>
-        <translation type="obsolete">ESPAÇO</translation>
+        <translation>ESPAÇO</translation>
     </message>
 </context>
 <context>
     <name>fDialog</name>
     <message>
-        <source>QtiPlot - Start limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite inicial</translation>
-    </message>
-    <message>
-        <source>QtiPlot - End limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite final</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input error</source>
-        <translation type="obsolete">QtiPlot - Erro de entrada</translation>
-    </message>
-    <message>
         <source>Please enter x limits that satisfy: from &lt; end!</source>
-        <translation type="obsolete">Por favor, forneça limites em x tais que: inicio &lt; fim!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input function error</source>
-        <translation type="obsolete">QtiPlot - Erro na fórmula fornecida</translation>
+        <translation>Por favor, forneça limites em x tais que: inicio &lt; fim!</translation>
     </message>
     <message>
         <source>Please enter parameter limits that satisfy: from &lt; end!</source>
-        <translation type="obsolete">Por favor, forneça limites para o parâmetro tais que: inicio &lt; fim!</translation>
+        <translation>Por favor, forneça limites para o parâmetro tais que: inicio &lt; fim!</translation>
     </message>
 </context>
 <context>
     <name>filterDialog</name>
     <message>
         <source>Filter curve: </source>
-        <translation type="obsolete">Curva filtro: </translation>
+        <translation>Curva filtro: </translation>
     </message>
     <message>
         <source>Frequency cutoff (Hz)</source>
-        <translation type="obsolete">Corte de frequências (Hz)</translation>
+        <translation>Corte de frequências (Hz)</translation>
     </message>
     <message>
         <source>Low Frequency (Hz)</source>
-        <translation type="obsolete">Frequência baixa (Hz)</translation>
+        <translation>Frequência baixa (Hz)</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="obsolete">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>High Frequency (Hz)</source>
-        <translation type="obsolete">Frequência alta (Hz)</translation>
+        <translation>Frequência alta (Hz)</translation>
     </message>
     <message>
         <source>Add DC Offset</source>
-        <translation type="obsolete">Adicionar deslocamento DC</translation>
+        <translation>Adicionar deslocamento DC</translation>
     </message>
     <message>
         <source>Substract DC Offset</source>
-        <translation type="obsolete">Subtrair deslocamento DC</translation>
+        <translation>Subtrair deslocamento DC</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="obsolete">Cor</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Filter options</source>
-        <translation type="obsolete">QtiPlot - Opções de filtro</translation>
+        <translation>Cor</translation>
     </message>
     <message>
         <source>&amp;Filter</source>
-        <translation type="obsolete">&amp;Filtro</translation>
+        <translation>&amp;Filtro</translation>
     </message>
     <message>
         <source>&amp;Close</source>
-        <translation type="obsolete">&amp;Fechar</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Frequency input error</source>
-        <translation type="obsolete">QtiPlot - Erro na frequência fornecida</translation>
+        <translation>&amp;Fechar</translation>
     </message>
     <message>
         <source>Please enter positive frequency values!</source>
-        <translation type="obsolete">Por favor, forneça frequências positivas!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - High Frequency input error</source>
-        <translation type="obsolete">QtiPlot - Erro na frequência alta</translation>
+        <translation>Por favor, forneça frequências positivas!</translation>
     </message>
     <message>
         <source>Please enter frequency limits that satisfy: Low &lt; High !</source>
-        <translation type="obsolete">Por favor, forneça limites para a frequência tais que: Baixo &lt; Alto!</translation>
+        <translation>Por favor, forneça limites para a frequência tais que: Baixo &lt; Alto!</translation>
     </message>
 </context>
 <context>
     <name>findDialog</name>
     <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
-    </message>
-    <message>
         <source>Find</source>
-        <translation type="obsolete">Procurar</translation>
+        <translation>Procurar</translation>
     </message>
     <message>
         <source>Start From</source>
-        <translation type="obsolete">Iniciar a partir de</translation>
+        <translation>Iniciar a partir de</translation>
     </message>
     <message>
         <source>Search In</source>
-        <translation type="obsolete">Procurar em</translation>
+        <translation>Procurar em</translation>
     </message>
     <message>
         <source>&amp;Window Names</source>
-        <translation type="obsolete">Nomes das janelas</translation>
+        <translation>Nomes das janelas</translation>
     </message>
     <message>
         <source>Window &amp;Labels</source>
-        <translation type="obsolete">Rótulos das janelas</translation>
+        <translation>Rótulos das janelas</translation>
     </message>
     <message>
         <source>Folder &amp;Names</source>
-        <translation type="obsolete">&amp;Nomes das pastas</translation>
+        <translation>&amp;Nomes das pastas</translation>
     </message>
     <message>
         <source>Case &amp;Sensitive</source>
-        <translation type="obsolete">Sensível à caixa</translation>
+        <translation>Sensível à caixa</translation>
     </message>
     <message>
         <source>&amp;Partial Match Allowed</source>
-        <translation type="obsolete">Coincidência &amp;parcial permitida</translation>
+        <translation>Coincidência &amp;parcial permitida</translation>
     </message>
     <message>
         <source>&amp;Include Subfolders</source>
-        <translation type="obsolete">&amp;Incluir subpastas</translation>
+        <translation>&amp;Incluir subpastas</translation>
     </message>
     <message>
         <source>&amp;Find</source>
-        <translation type="obsolete">Procurar</translation>
+        <translation>Procurar</translation>
     </message>
     <message>
         <source>&amp;Reset Start From</source>
-        <translation type="obsolete">&amp;Reiniciar começo a partir de</translation>
+        <translation>&amp;Reiniciar começo a partir de</translation>
     </message>
     <message>
         <source>&amp;Close</source>
-        <translation type="obsolete">&amp;Fechar</translation>
+        <translation>&amp;Fechar</translation>
     </message>
 </context>
 <context>
     <name>fitDialog</name>
     <message>
-        <source>QtiPlot - Non-linear curve fit</source>
-        <translation type="obsolete">QtiPlot - Ajuste não linear</translation>
-    </message>
-    <message>
         <source>Curve</source>
-        <translation type="obsolete">Curva</translation>
+        <translation>Curva</translation>
     </message>
     <message>
         <source>Function</source>
-        <translation type="obsolete">Função</translation>
+        <translation>Função</translation>
     </message>
     <message>
         <source>Initial guesses</source>
-        <translation type="obsolete">Estimativas iniciais</translation>
+        <translation>Estimativas iniciais</translation>
     </message>
     <message>
         <source>From x=</source>
-        <translation type="obsolete">A partir de x=</translation>
+        <translation>A partir de x=</translation>
     </message>
     <message>
         <source>To x=</source>
-        <translation type="obsolete">Até x=</translation>
+        <translation>Até x=</translation>
     </message>
     <message>
         <source>Iterations</source>
-        <translation type="obsolete">Interações</translation>
+        <translation>Interações</translation>
     </message>
     <message>
         <source>Tolerance</source>
-        <translation type="obsolete">Tolerância</translation>
+        <translation>Tolerância</translation>
     </message>
     <message>
         <source>Algorithm</source>
-        <translation type="obsolete">Algorítmo</translation>
+        <translation>Algorítmo</translation>
     </message>
     <message>
         <source>&amp;Fit</source>
-        <translation type="obsolete">&amp;Ajustar</translation>
+        <translation>&amp;Ajustar</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Scaled Levenberg-Marquardt</source>
-        <translation type="obsolete">Levenberg-Marquardt escalado</translation>
+        <translation>Levenberg-Marquardt escalado</translation>
     </message>
     <message>
         <source>Unscaled Levenberg-Marquardt</source>
-        <translation type="obsolete">Levenberg-Marquardt não escalado</translation>
+        <translation>Levenberg-Marquardt não escalado</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="obsolete">Cor</translation>
+        <translation>Cor</translation>
     </message>
     <message>
         <source>&lt;&lt; &amp;Edit function</source>
-        <translation type="obsolete">&lt;&lt; &amp;Editar função</translation>
+        <translation>&lt;&lt; &amp;Editar função</translation>
     </message>
     <message>
         <source>Category</source>
-        <translation type="obsolete">Categoria</translation>
+        <translation>Categoria</translation>
     </message>
     <message>
         <source>User defined</source>
-        <translation type="obsolete">Definida pelo usuário</translation>
+        <translation>Definida pelo usuário</translation>
     </message>
     <message>
         <source>Built-in</source>
-        <translation type="obsolete">Incorporada</translation>
+        <translation>Incorporada</translation>
     </message>
     <message>
         <source>Basic</source>
-        <translation type="obsolete">Básicas</translation>
+        <translation>Básicas</translation>
     </message>
     <message>
         <source>Plugins</source>
-        <translation type="obsolete">Plugins</translation>
+        <translation>Plugins</translation>
     </message>
     <message>
         <source>Expresion</source>
-        <translation type="obsolete">Expressão</translation>
+        <translation>Expressão</translation>
     </message>
     <message>
         <source>Fit with &amp;built-in function</source>
-        <translation type="obsolete">Ajustar com função incorporada</translation>
+        <translation>Ajustar com função incorporada</translation>
     </message>
     <message>
         <source>&amp;Choose plugins folder...</source>
-        <translation type="obsolete">&amp;Escolher pasta de plugins...</translation>
+        <translation>&amp;Escolher pasta de plugins...</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="obsolete">Nome</translation>
+        <translation>Nome</translation>
     </message>
     <message>
         <source>&amp;Save</source>
-        <translation type="obsolete">Salvar</translation>
+        <translation>Salvar</translation>
     </message>
     <message>
         <source>Parameters</source>
-        <translation type="obsolete">Parâmetros</translation>
+        <translation>Parâmetros</translation>
     </message>
     <message>
         <source>&amp;Remove</source>
-        <translation type="obsolete">Remove&amp;r</translation>
+        <translation>Remove&amp;r</translation>
     </message>
     <message>
         <source>Add &amp;expresion</source>
-        <translation type="obsolete">Adicionar &amp;expressão</translation>
+        <translation>Adicionar &amp;expressão</translation>
     </message>
     <message>
         <source>Add &amp;name</source>
-        <translation type="obsolete">Adicionar &amp;nome</translation>
+        <translation>Adicionar &amp;nome</translation>
     </message>
     <message>
         <source>Clear user &amp;list</source>
-        <translation type="obsolete">Limpar &amp;lista definida por usuário</translation>
+        <translation>Limpar &amp;lista definida por usuário</translation>
     </message>
     <message>
         <source>&amp;Fit &gt;&gt;</source>
-        <translation type="obsolete">&amp;Ajuste &gt;&gt;</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input function error</source>
-        <translation type="obsolete">QtiPlot - Erro na fórmula fornecida</translation>
+        <translation>&amp;Ajuste &gt;&gt;</translation>
     </message>
     <message>
         <source>Please enter a valid function!</source>
-        <translation type="obsolete">Por favor, forneça uma função válida!</translation>
+        <translation>Por favor, forneça uma função válida!</translation>
     </message>
     <message>
         <source>Please enter a function name!</source>
-        <translation type="obsolete">Por favor, forneça um nome de função!</translation>
+        <translation>Por favor, forneça um nome de função!</translation>
     </message>
     <message>
         <source>Please enter at least one parameter name!</source>
-        <translation type="obsolete">Por favor, forneça pelo menos um nome para o parâmetro!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Error: function name</source>
-        <translation type="obsolete">QtiPlot - Erro: o nome da função</translation>
+        <translation>Por favor, forneça pelo menos um nome para o parâmetro!</translation>
     </message>
     <message>
         <source> is a built-in function name&lt;p&gt;You must choose another name for your function!</source>
-        <translation type="obsolete"> é o nome de uma função incorporada&lt;p&gt;Você dee escolher outro nome! </translation>
+        <translation> é o nome de uma função incorporada&lt;p&gt;Você dee escolher outro nome! </translation>
     </message>
     <message>
         <source>You can&apos;t define functions recursevely!</source>
-        <translation type="obsolete">Não é possível definir funções recursivamente!</translation>
+        <translation>Não é possível definir funções recursivamente!</translation>
     </message>
     <message>
         <source>Fit with selected &amp;user function</source>
-        <translation type="obsolete">Ajustar com função definida por &amp;usuários</translation>
+        <translation>Ajustar com função definida por &amp;usuários</translation>
     </message>
     <message>
         <source>Fit using &amp;built-in function</source>
-        <translation type="obsolete">Ajustar usando função incorporada</translation>
+        <translation>Ajustar usando função incorporada</translation>
     </message>
     <message>
         <source>Fit using &amp;plugin function</source>
-        <translation type="obsolete">Ajustar usando função de &amp;plugin</translation>
+        <translation>Ajustar usando função de &amp;plugin</translation>
     </message>
     <message>
         <source>Choose the plugins folder</source>
-        <translation type="obsolete">Escolher pasta de plugins</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
+        <translation>Escolher pasta de plugins</translation>
     </message>
     <message>
         <source>The curve &lt;b&gt; %1 &lt;/b&gt; doesn&apos;t exist anymore! Operation aborted!</source>
-        <translation type="obsolete">A curva &lt;b&gt;%1&lt;/b&gt; não existe mais! Operação abortada!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input error</source>
-        <translation type="obsolete">QtiPlot - Erro de entrada</translation>
+        <translation>A curva &lt;b&gt;%1&lt;/b&gt; não existe mais! Operação abortada!</translation>
     </message>
     <message>
         <source>Please enter initial guesses for your parameters!</source>
-        <translation type="obsolete">Por favor, forneça estimativas iniciais para seus parâmetros!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Start limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite inicial</translation>
-    </message>
-    <message>
-        <source>QtiPlot - End limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite final</translation>
+        <translation>Por favor, forneça estimativas iniciais para seus parâmetros!</translation>
     </message>
     <message>
         <source>Please enter x limits that satisfy: from &lt; end!</source>
-        <translation type="obsolete">Por favor, fornrça limites em x tais que: inicio &lt; fim!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Tolerance input error</source>
-        <translation type="obsolete">QtiPlot - Erro na tolerância</translation>
+        <translation>Por favor, fornrça limites em x tais que: inicio &lt; fim!</translation>
     </message>
     <message>
         <source>The tolerance value must be positive and less than 1!</source>
-        <translation type="obsolete">O valor da tolerância deve ser positivo e menor que 1!</translation>
+        <translation>O valor da tolerância deve ser positivo e menor que 1!</translation>
     </message>
     <message>
         <source>Please verify that you have initialized all the parameters!</source>
-        <translation type="obsolete">Por favor, verifique se todos os parâmetros foram inicializados!</translation>
+        <translation>Por favor, verifique se todos os parâmetros foram inicializados!</translation>
     </message>
     <message>
         <source>Parameter</source>
-        <translation type="obsolete">Parâmetro</translation>
+        <translation>Parâmetro</translation>
     </message>
     <message>
         <source>Value</source>
-        <translation type="obsolete">Valor</translation>
+        <translation>Valor</translation>
     </message>
     <message>
         <source>&amp;Delete Fit Curves</source>
-        <translation type="obsolete">&amp;Excluir curvas de ajuste</translation>
+        <translation>&amp;Excluir curvas de ajuste</translation>
     </message>
     <message>
         <source>Constant</source>
-        <translation type="obsolete">Constante</translation>
+        <translation>Constante</translation>
     </message>
     <message>
         <source>Nelder-Mead Simplex</source>
-        <translation type="obsolete">Nelder-Mead Simplex</translation>
+        <translation>Nelder-Mead Simplex</translation>
     </message>
     <message>
         <source>Weighting Method</source>
-        <translation type="obsolete">Método de ponderação</translation>
+        <translation>Método de ponderação</translation>
     </message>
     <message>
         <source>No weighting</source>
-        <translation type="obsolete">Sie ponderação</translation>
+        <translation>Sie ponderação</translation>
     </message>
     <message>
         <source>Instrumental</source>
-        <translation type="obsolete">Instrumental</translation>
+        <translation>Instrumental</translation>
     </message>
     <message>
         <source>Statistical</source>
-        <translation type="obsolete">Estatístico</translation>
+        <translation>Estatístico</translation>
     </message>
     <message>
         <source>Arbitrary Dataset</source>
-        <translation type="obsolete">Conjunto de dados arbitrário</translation>
+        <translation>Conjunto de dados arbitrário</translation>
     </message>
     <message>
         <source>&amp;Close</source>
-        <translation type="obsolete">&amp;Fechar</translation>
+        <translation>&amp;Fechar</translation>
     </message>
     <message>
         <source>Custom &amp;Output &gt;&gt;</source>
-        <translation type="obsolete">Saída pers&amp;onalizada &gt;&gt;</translation>
+        <translation>Saída pers&amp;onalizada &gt;&gt;</translation>
     </message>
     <message>
         <source>Expression</source>
-        <translation type="obsolete">Expressão</translation>
+        <translation>Expressão</translation>
     </message>
     <message>
         <source>Polynomial Order</source>
-        <translation type="obsolete">Ordem do polinômio</translation>
+        <translation>Ordem do polinômio</translation>
     </message>
     <message>
         <source>Add &amp;expression</source>
-        <translation type="obsolete">Adicionar &amp;expressão</translation>
+        <translation>Adicionar &amp;expressão</translation>
     </message>
     <message>
         <source>Generated Fit Curve</source>
-        <translation type="obsolete">Curva de ajuste gerada</translation>
+        <translation>Curva de ajuste gerada</translation>
     </message>
     <message>
         <source>Uniform X Function</source>
-        <translation type="obsolete">Função X uniforme</translation>
+        <translation>Função X uniforme</translation>
     </message>
     <message>
         <source>Points</source>
-        <translation type="obsolete">Pontos</translation>
+        <translation>Pontos</translation>
     </message>
     <message>
         <source>Same X as Fitting Data</source>
-        <translation type="obsolete">Mesmos X que os dados de ajuste</translation>
+        <translation>Mesmos X que os dados de ajuste</translation>
     </message>
     <message>
         <source>Parameters Output</source>
-        <translation type="obsolete">Saída de parâmetros</translation>
+        <translation>Saída de parâmetros</translation>
     </message>
     <message>
         <source>Significant Digits</source>
-        <translation type="obsolete">Algarismos significativos</translation>
+        <translation>Algarismos significativos</translation>
     </message>
     <message>
         <source>Parameters Table</source>
-        <translation type="obsolete">Tabela de parâmetros</translation>
+        <translation>Tabela de parâmetros</translation>
     </message>
     <message>
         <source>Name: </source>
-        <translation type="obsolete">Nome: </translation>
+        <translation>Nome: </translation>
     </message>
     <message>
         <source>Covariance Matrix</source>
-        <translation type="obsolete">Matriz de covariância</translation>
+        <translation>Matriz de covariância</translation>
     </message>
     <message>
         <source>CovMatrix</source>
-        <translation type="obsolete">CovMatriz</translation>
+        <translation>CovMatriz</translation>
     </message>
     <message>
         <source>Write Parameters to Result Log</source>
-        <translation type="obsolete">Escrever parâmetros resumo de resultados</translation>
+        <translation>Escrever parâmetros resumo de resultados</translation>
     </message>
     <message>
         <source>Paste Parameters to Plot</source>
-        <translation type="obsolete">Colar parâmetros no gráfico</translation>
+        <translation>Colar parâmetros no gráfico</translation>
     </message>
     <message>
         <source>&lt;&lt; &amp;Fit</source>
-        <translation type="obsolete">&lt;&lt; Ajuste</translation>
+        <translation>&lt;&lt; Ajuste</translation>
     </message>
     <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>Please enter a valid name for the parameters table.</source>
-        <translation type="obsolete">Por favor, forneça um nome válido  para a tabela de parâmetros.</translation>
+        <translation>Por favor, forneça um nome válido  para a tabela de parâmetros.</translation>
     </message>
     <message>
         <source>Please perform a fit first and try again.</source>
-        <translation type="obsolete">Por favor, realize um ajuste primeiro e tente novamente.</translation>
+        <translation>Por favor, realize um ajuste primeiro e tente novamente.</translation>
     </message>
     <message>
         <source>Error</source>
-        <translation type="obsolete">Erro</translation>
+        <translation>Erro</translation>
     </message>
     <message>
         <source>Please enter a valid name for the covariance matrix.</source>
-        <translation type="obsolete">Por favor, forneça um  nome válido  para a matriz de covariância.</translation>
+        <translation>Por favor, forneça um  nome válido  para a matriz de covariância.</translation>
     </message>
     <message>
         <source>Gauss</source>
-        <translation type="obsolete">Gauss</translation>
+        <translation>Gauss</translation>
     </message>
     <message>
         <source>Peaks</source>
-        <translation type="obsolete">Picos</translation>
+        <translation>Picos</translation>
     </message>
     <message>
         <source>Lorentz</source>
-        <translation type="obsolete">Lorentz</translation>
+        <translation>Lorentz</translation>
     </message>
     <message>
         <source>Polynomial</source>
-        <translation type="obsolete">Polinomial</translation>
+        <translation>Polinomial</translation>
     </message>
     <message>
         <source>MultiPeak</source>
-        <translation type="obsolete">MultiPicos</translation>
+        <translation>MultiPicos</translation>
     </message>
     <message>
         <source>Scale Errors with sqrt(Chi^2/doF)</source>
-        <translation type="obsolete">Escalar erros com sqrt(Chi^2/doF)</translation>
+        <translation>Escalar erros com sqrt(Chi^2/doF)</translation>
     </message>
 </context>
 <context>
     <name>functionDialogui</name>
     <message>
-        <source>QtiPlot - Add function curve</source>
-        <translation type="obsolete">QtiPlot - Adicionar curva de função</translation>
-    </message>
-    <message>
         <source>Curve type </source>
-        <translation type="obsolete">Tipo de curva </translation>
+        <translation>Tipo de curva </translation>
     </message>
     <message>
         <source>f(x)= </source>
-        <translation type="obsolete">f(x)= </translation>
+        <translation>f(x)= </translation>
     </message>
     <message>
         <source>From x= </source>
-        <translation type="obsolete">Desde x= </translation>
+        <translation>Desde x= </translation>
     </message>
     <message>
         <source>To x= </source>
-        <translation type="obsolete">A x= </translation>
+        <translation>A x= </translation>
     </message>
     <message>
         <source>Points</source>
-        <translation type="obsolete">Pontos</translation>
+        <translation>Pontos</translation>
     </message>
     <message>
         <source>Clear list</source>
-        <translation type="obsolete">Apagar lista</translation>
+        <translation>Apagar lista</translation>
     </message>
     <message>
         <source>Parameter</source>
-        <translation type="obsolete">Parâmetro</translation>
+        <translation>Parâmetro</translation>
     </message>
     <message>
         <source>To</source>
-        <translation type="obsolete">A</translation>
+        <translation>A</translation>
     </message>
     <message>
         <source>y = </source>
-        <translation type="obsolete">y = </translation>
+        <translation>y = </translation>
     </message>
     <message>
         <source>x = </source>
-        <translation type="obsolete">x = </translation>
+        <translation>x = </translation>
     </message>
     <message>
         <source>From</source>
-        <translation type="obsolete">Desde</translation>
+        <translation>Desde</translation>
     </message>
     <message>
         <source>R =</source>
-        <translation type="obsolete">R =</translation>
+        <translation>R =</translation>
     </message>
     <message>
         <source>Theta =</source>
-        <translation type="obsolete">Theta =</translation>
+        <translation>Theta =</translation>
     </message>
     <message>
         <source>Function</source>
-        <translation type="obsolete">Função</translation>
+        <translation>Função</translation>
     </message>
     <message>
         <source>Parametric plot</source>
-        <translation type="obsolete">Gráfico paramétrica</translation>
+        <translation>Gráfico paramétrica</translation>
     </message>
     <message>
         <source>Polar plot</source>
-        <translation type="obsolete">Gráfico polar</translation>
+        <translation>Gráfico polar</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">Cancelar</translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
         <source>Ok</source>
-        <translation type="obsolete">Ok</translation>
+        <translation>Ok</translation>
     </message>
 </context>
 <context>
     <name>future::Folder</name>
     <message>
         <source>unknown element &apos;%1&apos;</source>
-        <translation type="obsolete">elemento &apos;%1&apos; desconhecido</translation>
+        <translation>elemento &apos;%1&apos; desconhecido</translation>
     </message>
     <message>
         <source>no folder element found</source>
-        <translation type="obsolete">sem elemento de pasta</translation>
+        <translation>sem elemento de pasta</translation>
     </message>
     <message>
         <source>Folder %1</source>
-        <translation type="obsolete">Pasta %1</translation>
+        <translation>Pasta %1</translation>
     </message>
     <message>
         <source>Column %1</source>
-        <translation type="obsolete">Coluna %1</translation>
+        <translation>Coluna %1</translation>
     </message>
     <message>
         <source>creation of aspect from element &apos;%1&apos; failed</source>
-        <translation type="obsolete">A criação de aspecto a partir do elemento &apos;%1&apos; falhou</translation>
+        <translation>A criação de aspecto a partir do elemento &apos;%1&apos; falhou</translation>
     </message>
     <message>
         <source>no plugin to load element &apos;%1&apos; found</source>
-        <translation type="obsolete">Nenhum plugin para carregar o elemento &apos;%1&apos; foi encontrado</translation>
+        <translation>Nenhum plugin para carregar o elemento &apos;%1&apos; foi encontrado</translation>
     </message>
 </context>
 <context>
     <name>future::Matrix</name>
     <message>
         <source>%1: cut selected cell(s)</source>
-        <translation type="obsolete">%1: cortar célula(s) selecionada(s)</translation>
+        <translation>%1: cortar célula(s) selecionada(s)</translation>
     </message>
     <message>
         <source>%1: paste from clipboard</source>
-        <translation type="obsolete">%1: colar da área de trabalho</translation>
+        <translation>%1: colar da área de trabalho</translation>
     </message>
     <message>
         <source>%1: clear selected cell(s)</source>
-        <translation type="obsolete">%1: limpar célula(s) selecionada(s)</translation>
+        <translation>%1: limpar célula(s) selecionada(s)</translation>
     </message>
     <message>
         <source>Cu&amp;t</source>
-        <translation type="obsolete">&amp;Cortar</translation>
+        <translation>&amp;Cortar</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
-        <translation type="obsolete">C&amp;opiar</translation>
+        <translation>C&amp;opiar</translation>
     </message>
     <message>
         <source>Past&amp;e</source>
-        <translation type="obsolete">Co&amp;lar</translation>
+        <translation>Co&amp;lar</translation>
     </message>
     <message>
         <source>Clea&amp;r</source>
         <comment>clear selection</comment>
-        <translation type="obsolete">Limpa&amp;r</translation>
+        <translation>Limpa&amp;r</translation>
     </message>
     <message>
         <source>Assign &amp;Formula</source>
-        <translation type="obsolete">&amp;Fórmula</translation>
+        <translation>&amp;Fórmula</translation>
     </message>
     <message>
         <source>Alt+Q</source>
-        <translation type="obsolete">Alt+Q</translation>
+        <translation>Alt+Q</translation>
     </message>
     <message>
         <source>Recalculate</source>
-        <translation type="obsolete">Recalcular</translation>
+        <translation>Recalcular</translation>
     </message>
     <message>
         <source>Ctrl+Return</source>
-        <translation type="obsolete">Ctrl+Enter</translation>
+        <translation>Ctrl+Enter</translation>
     </message>
     <message>
         <source>F12</source>
-        <translation type="obsolete">F12</translation>
+        <translation>F12</translation>
     </message>
     <message>
         <source>Select All</source>
-        <translation type="obsolete">Selecionar tudo</translation>
+        <translation>Selecionar tudo</translation>
     </message>
     <message>
         <source>Clear Matrix</source>
-        <translation type="obsolete">Limpar matriz</translation>
+        <translation>Limpar matriz</translation>
     </message>
     <message>
         <source>&amp;Go to Cell</source>
-        <translation type="obsolete">Ir para célula</translation>
+        <translation>Ir para célula</translation>
     </message>
     <message>
         <source>Ctrl+Alt+G</source>
-        <translation type="obsolete">Ctrl+Alt+G</translation>
+        <translation>Ctrl+Alt+G</translation>
     </message>
     <message>
         <source>&amp;Transpose</source>
-        <translation type="obsolete">&amp;Transpor</translation>
+        <translation>&amp;Transpor</translation>
     </message>
     <message>
         <source>Mirror &amp;Horizontally</source>
-        <translation type="obsolete">Espelhar horizontalmente</translation>
+        <translation>Espelhar horizontalmente</translation>
     </message>
     <message>
         <source>Mirror &amp;Vertically</source>
-        <translation type="obsolete">Espelhar verticalmente</translation>
+        <translation>Espelhar verticalmente</translation>
     </message>
     <message>
         <source>&amp;Import Image</source>
         <comment>import image as matrix</comment>
-        <translation type="obsolete">Importar imagem</translation>
+        <translation>Importar imagem</translation>
     </message>
     <message>
         <source>&amp;Duplicate</source>
         <comment>duplicate matrix</comment>
-        <translation type="obsolete">&amp;Duplicar</translation>
+        <translation>&amp;Duplicar</translation>
     </message>
     <message>
         <source>&amp;Dimensions</source>
         <comment>matrix size</comment>
-        <translation type="obsolete">Dimensões da matriz</translation>
+        <translation>Dimensões da matriz</translation>
     </message>
     <message>
         <source>Set &amp;Coordinates</source>
-        <translation type="obsolete">Coordenadas</translation>
+        <translation>Coordenadas</translation>
     </message>
     <message>
         <source>Set Display &amp;Format</source>
-        <translation type="obsolete">Definir formato do mostrador</translation>
+        <translation>Definir formato do mostrador</translation>
     </message>
     <message>
         <source>&amp;Insert Empty Columns</source>
-        <translation type="obsolete">Inserir coluna vazia</translation>
+        <translation>Inserir coluna vazia</translation>
     </message>
     <message>
         <source>Remo&amp;ve Columns</source>
-        <translation type="obsolete">Remover colunas</translation>
+        <translation>Remover colunas</translation>
     </message>
     <message>
         <source>Clea&amp;r Columns</source>
-        <translation type="obsolete">Limpar colunas</translation>
+        <translation>Limpar colunas</translation>
     </message>
     <message>
         <source>&amp;Add Columns</source>
-        <translation type="obsolete">Adicionar colunas</translation>
+        <translation>Adicionar colunas</translation>
     </message>
     <message>
         <source>&amp;Insert Empty Rows</source>
-        <translation type="obsolete">Inserir linhas vazias</translation>
+        <translation>Inserir linhas vazias</translation>
     </message>
     <message>
         <source>Remo&amp;ve Rows</source>
-        <translation type="obsolete">Remover linhas</translation>
+        <translation>Remover linhas</translation>
     </message>
     <message>
         <source>Clea&amp;r Rows</source>
-        <translation type="obsolete">Lim&amp;par linhas</translation>
+        <translation>Lim&amp;par linhas</translation>
     </message>
     <message>
         <source>&amp;Add Rows</source>
-        <translation type="obsolete">Adicionar linhas</translation>
+        <translation>Adicionar linhas</translation>
     </message>
     <message>
         <source>&amp;Matrix</source>
-        <translation type="obsolete">&amp;Matriz</translation>
+        <translation>&amp;Matriz</translation>
     </message>
     <message>
         <source>Go to Cell</source>
-        <translation type="obsolete">Ir para a célula</translation>
+        <translation>Ir para a célula</translation>
     </message>
     <message>
         <source>Enter column</source>
-        <translation type="obsolete">Inserir coluna</translation>
+        <translation>Inserir coluna</translation>
     </message>
     <message>
         <source>Enter row</source>
-        <translation type="obsolete">Inserir linha</translation>
+        <translation>Inserir linha</translation>
     </message>
     <message>
         <source>Set Matrix Dimensions</source>
-        <translation type="obsolete">Definir dimensões da matriz</translation>
+        <translation>Definir dimensões da matriz</translation>
     </message>
     <message>
         <source>Enter number of columns</source>
-        <translation type="obsolete">Número de colunas</translation>
+        <translation>Número de colunas</translation>
     </message>
     <message>
         <source>Enter number of rows</source>
-        <translation type="obsolete">Número de linhas</translation>
+        <translation>Número de linhas</translation>
     </message>
     <message>
         <source>Images</source>
-        <translation type="obsolete">Imagems</translation>
+        <translation>Imagems</translation>
     </message>
     <message>
         <source>Import image from file</source>
-        <translation type="obsolete">Importar imagem de arquivo</translation>
+        <translation>Importar imagem de arquivo</translation>
     </message>
     <message>
         <source>Error importing image</source>
-        <translation type="obsolete">Erro ao importar imagem</translation>
+        <translation>Erro ao importar imagem</translation>
     </message>
     <message>
         <source>Import of image &apos;%1&apos; failed</source>
-        <translation type="obsolete">A importação da imagem &apos;%1&apos; falhou</translation>
+        <translation>A importação da imagem &apos;%1&apos; falhou</translation>
     </message>
     <message>
         <source>invalid row or column count</source>
-        <translation type="obsolete">Contagem de linhas ou colunas inválidas</translation>
+        <translation>Contagem de linhas ou colunas inválidas</translation>
     </message>
     <message>
         <source>unknown element &apos;%1&apos;</source>
-        <translation type="obsolete">Elemento &apos;%1&apos; desconhecido</translation>
+        <translation>Elemento &apos;%1&apos; desconhecido</translation>
     </message>
     <message>
         <source>no matrix element found</source>
-        <translation type="obsolete">Nenhum elemento de matriz encontrado</translation>
+        <translation>Nenhum elemento de matriz encontrado</translation>
     </message>
     <message>
         <source>invalid or missing numeric format</source>
-        <translation type="obsolete">Formato numérico inválido ou ausente</translation>
+        <translation>Formato numérico inválido ou ausente</translation>
     </message>
     <message>
         <source>invalid or missing number of displayed digits</source>
-        <translation type="obsolete">O número de dígitos mostrados não é válido</translation>
+        <translation>O número de dígitos mostrados não é válido</translation>
     </message>
     <message>
         <source>invalid x start value</source>
-        <translation type="obsolete">O valor inicial de x não é válido</translation>
+        <translation>O valor inicial de x não é válido</translation>
     </message>
     <message>
         <source>invalid x end value</source>
-        <translation type="obsolete">O valor final de x não é válido</translation>
+        <translation>O valor final de x não é válido</translation>
     </message>
     <message>
         <source>invalid y start value</source>
-        <translation type="obsolete">valor inicial de y inválido</translation>
+        <translation>valor inicial de y inválido</translation>
     </message>
     <message>
         <source>invalid y end value</source>
-        <translation type="obsolete">valor final de y inválido</translation>
+        <translation>valor final de y inválido</translation>
     </message>
     <message>
         <source>invalid or missing row index</source>
-        <translation type="obsolete">índice de linhas inválido ou inexistente</translation>
+        <translation>índice de linhas inválido ou inexistente</translation>
     </message>
     <message>
         <source>invalid row height</source>
-        <translation type="obsolete">altura de linha inválida</translation>
+        <translation>altura de linha inválida</translation>
     </message>
     <message>
         <source>invalid or missing column index</source>
-        <translation type="obsolete">índice de colunas inválido ou inexistente</translation>
+        <translation>índice de colunas inválido ou inexistente</translation>
     </message>
     <message>
         <source>invalid column width</source>
-        <translation type="obsolete">largura de coluna inválida</translation>
+        <translation>largura de coluna inválida</translation>
     </message>
     <message>
         <source>invalid cell value</source>
-        <translation type="obsolete">valor da célula inválido</translation>
+        <translation>valor da célula inválido</translation>
     </message>
     <message>
         <source>Hide Controls</source>
-        <translation type="obsolete">Ocultar controles</translation>
+        <translation>Ocultar controles</translation>
     </message>
     <message>
         <source>Show Controls</source>
-        <translation type="obsolete">Mostrar controles</translation>
+        <translation>Mostrar controles</translation>
     </message>
     <message>
         <source>%1: apply formula to selection</source>
-        <translation type="obsolete">%1: aplicar fórmula à seleção</translation>
+        <translation>%1: aplicar fórmula à seleção</translation>
     </message>
     <message>
         <source>Matrix</source>
-        <translation type="obsolete">Matriz</translation>
+        <translation>Matriz</translation>
     </message>
     <message>
         <source>SciDAVis</source>
-        <translation type="obsolete">SciDAVis</translation>
+        <translation>SciDAVis</translation>
     </message>
     <message>
         <source>Import image...</source>
-        <translation type="obsolete">Importar imagem...</translation>
+        <translation>Importar imagem...</translation>
     </message>
     <message>
         <source>Matrix %1</source>
-        <translation type="obsolete">Matriz %1</translation>
+        <translation>Matriz %1</translation>
     </message>
 </context>
 <context>
     <name>future::SortDialog</name>
     <message>
         <source>Sorting Options</source>
-        <translation type="obsolete">Opções de ordenação</translation>
+        <translation>Opções de ordenação</translation>
     </message>
     <message>
         <source>Sort columns</source>
-        <translation type="obsolete">Ordemar colunas</translation>
+        <translation>Ordemar colunas</translation>
     </message>
     <message>
         <source>Separately</source>
-        <translation type="obsolete">Separadamente</translation>
+        <translation>Separadamente</translation>
     </message>
     <message>
         <source>Together</source>
-        <translation type="obsolete">Juntas</translation>
+        <translation>Juntas</translation>
     </message>
     <message>
         <source>Order</source>
-        <translation type="obsolete">Ordem</translation>
+        <translation>Ordem</translation>
     </message>
     <message>
         <source>Ascending</source>
-        <translation type="obsolete">Ascendente</translation>
+        <translation>Ascendente</translation>
     </message>
     <message>
         <source>Descending</source>
-        <translation type="obsolete">Descendente</translation>
+        <translation>Descendente</translation>
     </message>
     <message>
         <source>Leading column</source>
-        <translation type="obsolete">Coluna principal</translation>
+        <translation>Coluna principal</translation>
     </message>
     <message>
         <source>&amp;Sort</source>
-        <translation type="obsolete">&amp;Ordemar</translation>
+        <translation>&amp;Ordemar</translation>
     </message>
     <message>
         <source>&amp;Close</source>
-        <translation type="obsolete">&amp;Fechar</translation>
+        <translation>&amp;Fechar</translation>
     </message>
 </context>
 <context>
     <name>future::Table</name>
     <message>
         <source>%1: cut selected cell(s)</source>
-        <translation type="obsolete">%1: cortar célula(s) selecionada(s)</translation>
+        <translation>%1: cortar célula(s) selecionada(s)</translation>
     </message>
     <message>
         <source>%1: paste from clipboard</source>
-        <translation type="obsolete">%1: colar da área de trabalho</translation>
+        <translation>%1: colar da área de trabalho</translation>
     </message>
     <message>
         <source>%1: mask selected cell(s)</source>
-        <translation type="obsolete">%1: mascarar células(s) selecionada(s)</translation>
+        <translation>%1: mascarar células(s) selecionada(s)</translation>
     </message>
     <message>
         <source>%1: unmask selected cell(s)</source>
-        <translation type="obsolete">%1: remover máscara(s) de célula(s) selecionada(s)</translation>
+        <translation>%1: remover máscara(s) de célula(s) selecionada(s)</translation>
     </message>
     <message>
         <source>%1: apply formula to selection</source>
-        <translation type="obsolete">%1: aplicar fórmula à seleção</translation>
+        <translation>%1: aplicar fórmula à seleção</translation>
     </message>
     <message>
         <source>%1: fill cells with row numbers</source>
-        <translation type="obsolete">%1: preencher células com números das linhas</translation>
+        <translation>%1: preencher células com números das linhas</translation>
     </message>
     <message>
         <source>%1: fill cells with random values</source>
-        <translation type="obsolete">%1: preencher células com valores aleatórios</translation>
+        <translation>%1: preencher células com valores aleatórios</translation>
     </message>
     <message>
         <source>%1: clear selected cell(s)</source>
-        <translation type="obsolete">%1: limpar célula(s) selecionada(s)</translation>
+        <translation>%1: limpar célula(s) selecionada(s)</translation>
     </message>
     <message>
         <source>&amp;Table</source>
-        <translation type="obsolete">&amp;Tabela</translation>
+        <translation>&amp;Tabela</translation>
     </message>
     <message>
         <source>S&amp;et Column(s) As</source>
-        <translation type="obsolete">Definir coluna(s) como</translation>
+        <translation>Definir coluna(s) como</translation>
     </message>
     <message>
         <source>Fi&amp;ll Selection with</source>
-        <translation type="obsolete">&amp;Preencher seleção com</translation>
+        <translation>&amp;Preencher seleção com</translation>
     </message>
     <message>
         <source>Cu&amp;t</source>
-        <translation type="obsolete">Cor&amp;tar</translation>
+        <translation>Cor&amp;tar</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
-        <translation type="obsolete">C&amp;opiar</translation>
+        <translation>C&amp;opiar</translation>
     </message>
     <message>
         <source>Past&amp;e</source>
-        <translation type="obsolete">Co&amp;lar</translation>
+        <translation>Co&amp;lar</translation>
     </message>
     <message>
         <source>&amp;Mask</source>
         <comment>mask selection</comment>
-        <translation type="obsolete">Mascarar</translation>
+        <translation>Mascarar</translation>
     </message>
     <message>
         <source>&amp;Unmask</source>
         <comment>unmask selection</comment>
-        <translation type="obsolete">Desmascarar</translation>
+        <translation>Desmascarar</translation>
     </message>
     <message>
         <source>Assign &amp;Formula</source>
-        <translation type="obsolete">Atribuir fórmula</translation>
+        <translation>Atribuir fórmula</translation>
     </message>
     <message>
         <source>Alt+Q</source>
-        <translation type="obsolete">Alt+Q</translation>
+        <translation>Alt+Q</translation>
     </message>
     <message>
         <source>Clea&amp;r</source>
         <comment>clear selection</comment>
-        <translation type="obsolete">Limpa&amp;r</translation>
+        <translation>Limpa&amp;r</translation>
     </message>
     <message>
         <source>Recalculate</source>
-        <translation type="obsolete">Recalcular</translation>
+        <translation>Recalcular</translation>
     </message>
     <message>
         <source>Ctrl+Return</source>
-        <translation type="obsolete">Ctrl+Enter</translation>
+        <translation>Ctrl+Enter</translation>
     </message>
     <message>
         <source>Row Numbers</source>
-        <translation type="obsolete">Números das linhas</translation>
+        <translation>Números das linhas</translation>
     </message>
     <message>
         <source>Random Values</source>
-        <translation type="obsolete">Valores aleatórios</translation>
+        <translation>Valores aleatórios</translation>
     </message>
     <message>
         <source>F12</source>
-        <translation type="obsolete">F12</translation>
+        <translation>F12</translation>
     </message>
     <message>
         <source>Formula Edit Mode</source>
-        <translation type="obsolete">Modo de edição de fórmula</translation>
+        <translation>Modo de edição de fórmula</translation>
     </message>
     <message>
         <source>Select All</source>
-        <translation type="obsolete">Selecionar tudo</translation>
+        <translation>Selecionar tudo</translation>
     </message>
     <message>
         <source>&amp;Add Column</source>
-        <translation type="obsolete">Adicio&amp;nar coluna</translation>
+        <translation>Adicio&amp;nar coluna</translation>
     </message>
     <message>
         <source>append a new column to the table</source>
-        <translation type="obsolete">adicionar nova coluna à tabela</translation>
+        <translation>adicionar nova coluna à tabela</translation>
     </message>
     <message>
         <source>Clear Table</source>
-        <translation type="obsolete">Limpar tabela</translation>
+        <translation>Limpar tabela</translation>
     </message>
     <message>
         <source>Export to TeX...</source>
-        <translation type="obsolete">Exportar para Tex...</translation>
+        <translation>Exportar para Tex...</translation>
     </message>
     <message>
         <source>Clear Masks</source>
-        <translation type="obsolete">Limpar máscaras</translation>
+        <translation>Limpar máscaras</translation>
     </message>
     <message>
         <source>&amp;Sort Table</source>
-        <translation type="obsolete">Ordemar tabela</translation>
+        <translation>Ordemar tabela</translation>
     </message>
     <message>
         <source>&amp;Go to Cell</source>
-        <translation type="obsolete">Ir para célula</translation>
+        <translation>Ir para célula</translation>
     </message>
     <message>
         <source>Ctrl+Alt+G</source>
-        <translation type="obsolete">Ctrl+Alt+G</translation>
+        <translation>Ctrl+Alt+G</translation>
     </message>
     <message>
         <source>&amp;Dimensions</source>
         <comment>table size</comment>
-        <translation type="obsolete">Dimensões</translation>
+        <translation>Dimensões</translation>
     </message>
     <message>
         <source>change the table size</source>
-        <translation type="obsolete">Modificar dimensões da tabela</translation>
+        <translation>Modificar dimensões da tabela</translation>
     </message>
     <message>
         <source>&amp;Insert Empty Columns</source>
-        <translation type="obsolete">Inserir coluna vazia</translation>
+        <translation>Inserir coluna vazia</translation>
     </message>
     <message>
         <source>Remo&amp;ve Columns</source>
-        <translation type="obsolete">Remover colunas</translation>
+        <translation>Remover colunas</translation>
     </message>
     <message>
         <source>Clea&amp;r Columns</source>
-        <translation type="obsolete">Limpar colunas</translation>
+        <translation>Limpar colunas</translation>
     </message>
     <message>
         <source>&amp;Add Columns</source>
-        <translation type="obsolete">Adicionar colunas</translation>
+        <translation>Adicionar colunas</translation>
     </message>
     <message>
         <source>X</source>
         <comment>plot designation</comment>
-        <translation type="obsolete">X</translation>
+        <translation>X</translation>
     </message>
     <message>
         <source>Y</source>
         <comment>plot designation</comment>
-        <translation type="obsolete">Y</translation>
+        <translation>Y</translation>
     </message>
     <message>
         <source>Z</source>
         <comment>plot designation</comment>
-        <translation type="obsolete">Z</translation>
+        <translation>Z</translation>
     </message>
     <message>
         <source>X Error</source>
         <comment>plot designation</comment>
-        <translation type="obsolete">Erro em X</translation>
+        <translation>Erro em X</translation>
     </message>
     <message>
         <source>Y Error</source>
         <comment>plot designation</comment>
-        <translation type="obsolete">Erro em Y</translation>
+        <translation>Erro em Y</translation>
     </message>
     <message>
         <source>None</source>
         <comment>plot designation</comment>
-        <translation type="obsolete">Nenhum</translation>
+        <translation>Nenhum</translation>
     </message>
     <message>
         <source>&amp;Normalize Columns</source>
-        <translation type="obsolete">Normalizar colunas</translation>
+        <translation>Normalizar colunas</translation>
     </message>
     <message>
         <source>&amp;Normalize Selection</source>
-        <translation type="obsolete">Normalizar seleção</translation>
+        <translation>Normalizar seleção</translation>
     </message>
     <message>
         <source>&amp;Sort Columns</source>
-        <translation type="obsolete">Ordemar colunas</translation>
+        <translation>Ordemar colunas</translation>
     </message>
     <message>
         <source>Column Statisti&amp;cs</source>
-        <translation type="obsolete">Estatísticas das colunas</translation>
+        <translation>Estatísticas das colunas</translation>
     </message>
     <message>
         <source>statistics on columns</source>
-        <translation type="obsolete">Estatísticas em colunas</translation>
+        <translation>Estatísticas em colunas</translation>
     </message>
     <message>
         <source>Change &amp;Type &amp;&amp; Format</source>
-        <translation type="obsolete">Modificar tipo e formato</translation>
+        <translation>Modificar tipo e formato</translation>
     </message>
     <message>
         <source>Ctrl+Alt+O</source>
-        <translation type="obsolete">Ctrl+Alt+O</translation>
+        <translation>Ctrl+Alt+O</translation>
     </message>
     <message>
         <source>Edit Column &amp;Description</source>
-        <translation type="obsolete">Editar descrição da coluna</translation>
+        <translation>Editar descrição da coluna</translation>
     </message>
     <message>
         <source>&amp;Insert Empty Rows</source>
-        <translation type="obsolete">Inserir linhas vazias</translation>
+        <translation>Inserir linhas vazias</translation>
     </message>
     <message>
         <source>Remo&amp;ve Rows</source>
-        <translation type="obsolete">Remover linhas</translation>
+        <translation>Remover linhas</translation>
     </message>
     <message>
         <source>Clea&amp;r Rows</source>
-        <translation type="obsolete">Lim&amp;par linhas</translation>
+        <translation>Lim&amp;par linhas</translation>
     </message>
     <message>
         <source>&amp;Add Rows</source>
-        <translation type="obsolete">Adicionar linhas</translation>
+        <translation>Adicionar linhas</translation>
     </message>
     <message>
         <source>Row Statisti&amp;cs</source>
-        <translation type="obsolete">Estatísticas das linhas</translation>
+        <translation>Estatísticas das linhas</translation>
     </message>
     <message>
         <source>statistics on rows</source>
-        <translation type="obsolete">Estatísticas em linhas</translation>
+        <translation>Estatísticas em linhas</translation>
     </message>
     <message>
         <source>TeX Export Error</source>
-        <translation type="obsolete">Erro ao exportar para Tex</translation>
+        <translation>Erro ao exportar para Tex</translation>
     </message>
     <message>
         <source>Could not write to file: &lt;br&gt;&lt;h4&gt;%1&lt;/h4&gt;&lt;p&gt;Please verify that you have the right to write to this location!</source>
-        <translation type="obsolete">Não foi possível escrever no arquivo: &lt;br&gt;&lt;h4&gt; %1 &lt;/h4&gt;&lt;p&gt;Por favor, verifique se você tem permissão de escrita no local selecionado!</translation>
+        <translation>Não foi possível escrever no arquivo: &lt;br&gt;&lt;h4&gt; %1 &lt;/h4&gt;&lt;p&gt;Por favor, verifique se você tem permissão de escrita no local selecionado!</translation>
     </message>
     <message>
         <source>Go to Cell</source>
-        <translation type="obsolete">Ir para a célula</translation>
+        <translation>Ir para a célula</translation>
     </message>
     <message>
         <source>Enter column</source>
-        <translation type="obsolete">Inserir coluna</translation>
+        <translation>Inserir coluna</translation>
     </message>
     <message>
         <source>Enter row</source>
-        <translation type="obsolete">Inserir linha</translation>
+        <translation>Inserir linha</translation>
     </message>
     <message>
         <source>Set Table Dimensions</source>
-        <translation type="obsolete">Definir dimensões da tabela</translation>
+        <translation>Definir dimensões da tabela</translation>
     </message>
     <message>
         <source>%1: move column %2 from position %3 to %4.</source>
-        <translation type="obsolete">%1: mover coluna %2 da posição %3 para %4.</translation>
+        <translation>%1: mover coluna %2 da posição %3 para %4.</translation>
     </message>
     <message>
         <source>%1: sort column(s)</source>
-        <translation type="obsolete">%1: ordenar coluna(s)</translation>
+        <translation>%1: ordenar coluna(s)</translation>
     </message>
     <message>
         <source>invalid row or column count</source>
-        <translation type="obsolete">Contagem de linhas ou colunas inválidas</translation>
+        <translation>Contagem de linhas ou colunas inválidas</translation>
     </message>
     <message>
         <source>Column %1</source>
-        <translation type="obsolete">Coluna %1</translation>
+        <translation>Coluna %1</translation>
     </message>
     <message>
         <source>unknown element &apos;%1&apos;</source>
-        <translation type="obsolete">elemento &apos;%1&apos; desconhecido</translation>
+        <translation>elemento &apos;%1&apos; desconhecido</translation>
     </message>
     <message>
         <source>columns attribute and number of read columns do not match</source>
-        <translation type="obsolete">os atributos das colunas e o número de colunas lidas não coincidem</translation>
+        <translation>os atributos das colunas e o número de colunas lidas não coincidem</translation>
     </message>
     <message>
         <source>no table element found</source>
-        <translation type="obsolete">nenhum elemento de tabela encontrado</translation>
+        <translation>nenhum elemento de tabela encontrado</translation>
     </message>
     <message>
         <source>Hide Comments</source>
-        <translation type="obsolete">Ocultar comentários</translation>
+        <translation>Ocultar comentários</translation>
     </message>
     <message>
         <source>Show Comments</source>
-        <translation type="obsolete">Mostrar comentários</translation>
+        <translation>Mostrar comentários</translation>
     </message>
     <message>
         <source>Hide Controls</source>
-        <translation type="obsolete">Ocultar controles</translation>
+        <translation>Ocultar controles</translation>
     </message>
     <message>
         <source>Show Controls</source>
-        <translation type="obsolete">Mostrar controles</translation>
+        <translation>Mostrar controles</translation>
     </message>
     <message>
         <source>invalid or missing column index</source>
-        <translation type="obsolete">índice de colunas inválido ou inexistente</translation>
+        <translation>índice de colunas inválido ou inexistente</translation>
     </message>
     <message>
         <source>invalid column width</source>
-        <translation type="obsolete">largura de coluna inválida</translation>
+        <translation>largura de coluna inválida</translation>
     </message>
     <message>
         <source>Table</source>
-        <translation type="obsolete">Tabela</translation>
+        <translation>Tabela</translation>
     </message>
 </context>
 <context>
     <name>imageDialog</name>
     <message>
         <source>Origin</source>
-        <translation type="obsolete">Origen</translation>
+        <translation>Origen</translation>
     </message>
     <message>
         <source>X= </source>
-        <translation type="obsolete">X= </translation>
+        <translation>X= </translation>
     </message>
     <message>
         <source>Y= </source>
-        <translation type="obsolete">Y= </translation>
+        <translation>Y= </translation>
     </message>
     <message>
         <source>Size</source>
-        <translation type="obsolete">Tamanho</translation>
+        <translation>Tamanho</translation>
     </message>
     <message>
         <source>width= </source>
-        <translation type="obsolete">largura= </translation>
+        <translation>largura= </translation>
     </message>
     <message>
         <source>height= </source>
-        <translation type="obsolete">altura= </translation>
-    </message>
-    <message>
-        <source>QtiPlot - Image Geometry</source>
-        <translation type="obsolete">QtiPlot - Geometria de imagem</translation>
+        <translation>altura= </translation>
     </message>
     <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source> pixels</source>
-        <translation type="obsolete"> pixels</translation>
+        <translation> pixels</translation>
     </message>
 </context>
 <context>
     <name>imageExportDialog</name>
     <message>
         <source>Image format</source>
-        <translation type="obsolete">Formato de imagem</translation>
+        <translation>Formato de imagem</translation>
     </message>
     <message>
         <source>Image quality</source>
-        <translation type="obsolete">Qualidade de imagem</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Export options</source>
-        <translation type="obsolete">QtiPlot - Opções de exportação</translation>
+        <translation>Qualidade de imagem</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
 </context>
 <context>
     <name>importDialog</name>
     <message>
         <source>Separator</source>
-        <translation type="obsolete">Separador</translation>
+        <translation>Separador</translation>
     </message>
     <message>
         <source>Ignore first</source>
-        <translation type="obsolete">Ignorar primeiras</translation>
-    </message>
-    <message>
-        <source>QtiPlot - ASCII Import Options</source>
-        <translation type="obsolete">QtiPlot - Opções de importação ASCII</translation>
+        <translation>Ignorar primeiras</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Use first row to &amp;name columns</source>
-        <translation type="obsolete">Usar primeira linha para &amp;nomear colunas</translation>
+        <translation>Usar primeira linha para &amp;nomear colunas</translation>
     </message>
     <message>
         <source>The column separator can be customized. The following special codes can be used:
 \t for a TAB character 
 \s for a SPACE</source>
-        <translation type="obsolete">O separador de colunas pode ser personalizado. Os códigos seguintes podem ser usados:
+        <translation>O separador de colunas pode ser personalizado. Os códigos seguintes podem ser usados:
 \t para um  caractere TAB
 \s para um  ESPAÇO</translation>
     </message>
     <message>
         <source>The separator must not contain the following characters: 0-9eE.+-</source>
-        <translation type="obsolete">O separador no pode conter os caracteres seguintes: 0-9eE.+-</translation>
+        <translation>O separador no pode conter os caracteres seguintes: 0-9eE.+-</translation>
     </message>
     <message>
         <source>lines</source>
-        <translation type="obsolete">linhas</translation>
+        <translation>linhas</translation>
     </message>
     <message>
         <source>By checking this option all white spaces will be removed from the beginning and the end of the lines in the ASCII file.</source>
-        <translation type="obsolete">Marcando esta opção todos os espaços em branco serão eliminados do  principio e o final das linhas no arquivo ASCII.</translation>
+        <translation>Marcando esta opção todos os espaços em branco serão eliminados do  principio e o final das linhas no arquivo ASCII.</translation>
     </message>
     <message>
         <source>Warning: checking this option leads to column overlaping if the columns in the ASCII file don&apos;t have the same number of rows.</source>
-        <translation type="obsolete">Aviso: marcar esta opção conduceà superposição de colunas si as colunas do  arquivo ASCII no tienno mesmo número de linhas.</translation>
+        <translation>Aviso: marcar esta opção conduceà superposição de colunas si as colunas do  arquivo ASCII no tienno mesmo número de linhas.</translation>
     </message>
     <message>
         <source>To avoid this problem you should precisely define the column separator using TAB and SPACE characters.</source>
-        <translation type="obsolete">Para evitar este problema debería definir com precisión o separador de colunas usando os caracteres TAB o ESPAÇO.</translation>
+        <translation>Para evitar este problema debería definir com precisión o separador de colunas usando os caracteres TAB o ESPAÇO.</translation>
     </message>
     <message>
         <source>By checking this option all white spaces will be removed from the beginning and the end of the lines and each sequence of internal whitespaces (including the TAB character) will be replaced with a single space.</source>
-        <translation type="obsolete">Marcando esta opção todos os espaços em branco serão eliminados do  principio e o final das linhas e cada sequência de espaços internos (incluindo o caractere TAB) serão substituídos por um  único ESPAÇO em branco.</translation>
+        <translation>Marcando esta opção todos os espaços em branco serão eliminados do  principio e o final das linhas e cada sequência de espaços internos (incluindo o caractere TAB) serão substituídos por um  único ESPAÇO em branco.</translation>
     </message>
     <message>
         <source>Remove white spaces from line ends</source>
-        <translation type="obsolete">Remover espaços em branco dos  finais de linha</translation>
+        <translation>Remover espaços em branco dos  finais de linha</translation>
     </message>
     <message>
         <source>Simplify white spaces</source>
-        <translation type="obsolete">Simplificar espaços em branco</translation>
+        <translation>Simplificar espaços em branco</translation>
     </message>
     <message>
         <source>By checking this option each sequence of internal whitespaces (including the TAB character) will be replaced with a single space.</source>
-        <translation type="obsolete">Marcando esta opção cada sequência de espaços em branco internos (incluindo o caractere TAB) será substituída por um  único ESPAÇO.</translation>
+        <translation>Marcando esta opção cada sequência de espaços em branco internos (incluindo o caractere TAB) será substituída por um  único ESPAÇO.</translation>
     </message>
     <message>
         <source>Warning: using these two last options leads to column overlaping if the columns in the ASCII file don&apos;t have the same number of rows.</source>
-        <translation type="obsolete">Aviso: usando estas dos últimas opções conduceà superposição de colunas si as colunas do  arquivo ASCII no tienno mesmo número de linhas.</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Help</source>
-        <translation type="obsolete">QtiPlot - Ajuda</translation>
+        <translation>Aviso: usando estas dos últimas opções conduceà superposição de colunas si as colunas do  arquivo ASCII no tienno mesmo número de linhas.</translation>
     </message>
     <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>&amp;Close</source>
-        <translation type="obsolete">&amp;Fechar</translation>
+        <translation>&amp;Fechar</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation type="obsolete">Ajuda</translation>
+        <translation>Ajuda</translation>
     </message>
     <message>
         <source>TAB</source>
-        <translation type="obsolete">TAB</translation>
+        <translation>TAB</translation>
     </message>
     <message>
         <source>SPACE</source>
-        <translation type="obsolete">ESPAÇO</translation>
+        <translation>ESPAÇO</translation>
     </message>
     <message>
         <source>&amp;Remove white spaces from line ends</source>
-        <translation type="obsolete">Quita&amp;r espaços em branco dos  finais de linha</translation>
+        <translation>Quita&amp;r espaços em branco dos  finais de linha</translation>
     </message>
     <message>
         <source>&amp;Simplify white spaces</source>
-        <translation type="obsolete">&amp;Simplificar espaços em branco</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Import options error</source>
-        <translation type="obsolete">QtiPlot - Erro em opções de importação</translation>
-    </message>
-    <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
+        <translation>&amp;Simplificar espaços em branco</translation>
     </message>
     <message>
         <source>Do you want to save the modifications to the ASCII import options before closing?</source>
-        <translation type="obsolete">Gostaria de guardar as modificações das opções de importação ASCII antes de Fechar?</translation>
+        <translation>Gostaria de guardar as modificações das opções de importação ASCII antes de Fechar?</translation>
     </message>
     <message>
         <source>Yes</source>
-        <translation type="obsolete">Sim</translation>
+        <translation>Sim</translation>
     </message>
     <message>
         <source>No</source>
-        <translation type="obsolete">No</translation>
+        <translation>No</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">Cancelar</translation>
+        <translation>Cancelar</translation>
     </message>
 </context>
 <context>
     <name>intDialog</name>
     <message>
-        <source>QtiPlot - Integration Options</source>
-        <translation type="obsolete">QtiPlot - Opções de integração</translation>
-    </message>
-    <message>
         <source>Integration of</source>
-        <translation type="obsolete">integração de</translation>
+        <translation>integração de</translation>
     </message>
     <message>
         <source>Order (1 - 5, 1 = Trapezoid Rule)</source>
-        <translation type="obsolete">Ordem (1 - 5, 1 = Regla do  Trapecio)</translation>
+        <translation>Ordem (1 - 5, 1 = Regla do  Trapecio)</translation>
     </message>
     <message>
         <source>Number of iterations (Max=40)</source>
-        <translation type="obsolete">Número de Interações (Max=40)</translation>
+        <translation>Número de Interações (Max=40)</translation>
     </message>
     <message>
         <source>Tolerance</source>
-        <translation type="obsolete">tolerância</translation>
+        <translation>tolerância</translation>
     </message>
     <message>
         <source>Lower limit</source>
-        <translation type="obsolete">limite inferior</translation>
+        <translation>limite inferior</translation>
     </message>
     <message>
         <source>Upper limit</source>
-        <translation type="obsolete">limite superior</translation>
+        <translation>limite superior</translation>
     </message>
     <message>
         <source>&amp;Integrate</source>
-        <translation type="obsolete">&amp;Integrar</translation>
+        <translation>&amp;Integrar</translation>
     </message>
     <message>
         <source>&amp;Close</source>
-        <translation type="obsolete">&amp;Fechar</translation>
+        <translation>&amp;Fechar</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation type="obsolete">A&amp;yuda</translation>
+        <translation>A&amp;yuda</translation>
     </message>
     <message>
         <source>You can not fit index:</source>
-        <translation type="obsolete">No pode ajustar índice:</translation>
+        <translation>No pode ajustar índice:</translation>
     </message>
     <message>
         <source>because it has less than 2 points!</source>
-        <translation type="obsolete">porque possui menos de 2 Pontos!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Tolerance value error</source>
-        <translation type="obsolete">QtiPlot - Error na tolerância</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input error</source>
-        <translation type="obsolete">QtiPlot - Error de entrada</translation>
+        <translation>porque possui menos de 2 Pontos!</translation>
     </message>
     <message>
         <source>Please give a number larger or equal to the minimum value of X, for the lower limit.
  If you do not know that value, type min in the box.</source>
-        <translation type="obsolete">Por favor, dé um  número maior o igual que o valor mínimo de X para o limite inferior.
+        <translation>Por favor, dé um  número maior o igual que o valor mínimo de X para o limite inferior.
 Si no conhece ese valor, escreva min no cuadro.</translation>
     </message>
     <message>
         <source>Please give a number smaller or equal to the maximum value of X, for the lower limit.
  If you do not know that value, type max in the box.</source>
-        <translation type="obsolete">Por favor, dé um  número menor o igual que o valor máximo de X para o limite inferior.
+        <translation>Por favor, dé um  número menor o igual que o valor máximo de X para o limite inferior.
 Si no conhece ese valor, escreva max no cuadro.</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Start limit error</source>
-        <translation type="obsolete">QtiPlot - Error no limite inicial</translation>
     </message>
     <message>
         <source>Please give a number smaller or equal to the maximum value of X, for the upper limit.
  If you do not know that value, type max in the box.</source>
-        <translation type="obsolete">Por favor, dé um  número menor o igual que o valor máximo de X para o limite superior.
+        <translation>Por favor, dé um  número menor o igual que o valor máximo de X para o limite superior.
 Si no conhece ese valor, escreva max no cuadro.</translation>
     </message>
     <message>
         <source>Please give a number larger or equal to the minimum value of X, for the upper limit.
  If you do not know that value, type min in the box.</source>
-        <translation type="obsolete">Por favor, dé um  número maior o igual que o valor mínimo de X para o limite superior.
+        <translation>Por favor, dé um  número maior o igual que o valor mínimo de X para o limite superior.
 Si no conhece ese valor, escreva min no cuadro.</translation>
-    </message>
-    <message>
-        <source>QtiPlot - End limit error</source>
-        <translation type="obsolete">QtiPlot - Error no limite final</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Help for Integration</source>
-        <translation type="obsolete">QtiPlot - Ajuda para a integração</translation>
     </message>
     <message>
         <source>The integration of a curve consists of the following five steps:
@@ -17773,7 +16553,7 @@ Si no conhece ese valor, escreva min no cuadro.</translation>
  Because, sometimes we ask for too much accuracy, the number of iterations makes sure that the solver will not work for ever.
  IMPORTANT 
 The limits must be within the range of x; If you do not know the maximum (minimum) value of x, type max (min) in the boxes.</source>
-        <translation type="obsolete">La integração de uma curva consta dos  seguintes cinco passos:
+        <translation>La integração de uma curva consta dos  seguintes cinco passos:
 1) Escolher que curva integrar
 2) Escolher o Ordem de integração. Cuanto maior sea más preciso será o cálculo
 3) Escolher o número de Interações
@@ -17786,11 +16566,11 @@ Os limites devem estar dentro do  rango de x; si no conhece o valor máximo (mí
     </message>
     <message>
         <source>The curve &lt;b&gt; %1 &lt;/b&gt; doesn&apos;t exist anymore! Operation aborted!</source>
-        <translation type="obsolete">A curva &lt;b&gt;%1&lt;/b&gt; não existe mais! Operação abortada!</translation>
+        <translation>A curva &lt;b&gt;%1&lt;/b&gt; não existe mais! Operação abortada!</translation>
     </message>
     <message>
         <source>You cannot fit index:</source>
-        <translation type="obsolete">No pode ajustar o índice:</translation>
+        <translation>No pode ajustar o índice:</translation>
     </message>
     <message>
         <source>The integration of a curve consists of the following five steps:
@@ -17803,7 +16583,7 @@ Os limites devem estar dentro do  rango de x; si no conhece o valor máximo (mí
  Because, sometimes we ask for too much accuracy, the number of iterations makes sure that the solver will not work for ever.
  IMPORTANT 
 The limits must be within the range of x; If you do not know the maximum (minimum) value of x, type max (min) in the boxes.</source>
-        <translation type="obsolete">La integração de uma curva consiste en os cinco passos seguintes:
+        <translation>La integração de uma curva consiste en os cinco passos seguintes:
 1) Escolha qué curva deseja integrar
 2) defina o Ordem de integração. Cuanto más alto sea más preciso será o cálculo
 3) Escolha o número de Interações
@@ -17817,2347 +16597,2131 @@ Os limites devem estar dentro do  rango de x; si no conhece o máximo (mínimo) 
 <context>
     <name>interpolationDialog</name>
     <message>
-        <source>QtiPlot - Interpolation Options</source>
-        <translation type="obsolete">QtiPlot - Opções de Interpolação</translation>
-    </message>
-    <message>
         <source>Make curve from</source>
-        <translation type="obsolete">Hacer curva de</translation>
+        <translation>Hacer curva de</translation>
     </message>
     <message>
         <source>Spline</source>
-        <translation type="obsolete">Spline</translation>
+        <translation>Spline</translation>
     </message>
     <message>
         <source>Points</source>
-        <translation type="obsolete">Pontos</translation>
+        <translation>Pontos</translation>
     </message>
     <message>
         <source>From Xmin</source>
-        <translation type="obsolete">Desde Xmin</translation>
+        <translation>Desde Xmin</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="obsolete">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>To Xmax</source>
-        <translation type="obsolete">A Xmax</translation>
+        <translation>A Xmax</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="obsolete">Color</translation>
+        <translation>Color</translation>
     </message>
     <message>
         <source>&amp;Make</source>
-        <translation type="obsolete">Hacer</translation>
+        <translation>Hacer</translation>
     </message>
     <message>
         <source>&amp;Close</source>
-        <translation type="obsolete">&amp;Fechar</translation>
+        <translation>&amp;Fechar</translation>
     </message>
     <message>
         <source>Linear</source>
-        <translation type="obsolete">linear</translation>
+        <translation>linear</translation>
     </message>
     <message>
         <source>Cubic</source>
-        <translation type="obsolete">Cúbica</translation>
+        <translation>Cúbica</translation>
     </message>
     <message>
         <source>Non-rounded Akima</source>
-        <translation type="obsolete">Akima no redondeado</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Start limit error</source>
-        <translation type="obsolete">QtiPlot - Error no limite inicial</translation>
-    </message>
-    <message>
-        <source>QtiPlot - End limit error</source>
-        <translation type="obsolete">QtiPlot - Error no limite final</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input error</source>
-        <translation type="obsolete">QtiPlot - Error de entrada</translation>
+        <translation>Akima no redondeado</translation>
     </message>
     <message>
         <source>Please enter x limits that satisfy: from &lt; to!</source>
-        <translation type="obsolete">Por favor, forneça limites em x tais que: inicio &lt; fim!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
+        <translation>Por favor, forneça limites em x tais que: inicio &lt; fim!</translation>
     </message>
     <message>
         <source>The curve &lt;b&gt; %1 &lt;/b&gt; doesn&apos;t exist anymore! Operation aborted!</source>
-        <translation type="obsolete">A curva &lt;b&gt;%1&lt;/b&gt; não existe mais! Operação abortada!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
+        <translation>A curva &lt;b&gt;%1&lt;/b&gt; não existe mais! Operação abortada!</translation>
     </message>
     <message>
         <source>You need at least %1 points to perform this operation! Operation aborted!</source>
-        <translation type="obsolete">São necessários pelo menos %1 pontos para realizar esta operação! Operação abortada!</translation>
+        <translation>São necessários pelo menos %1 pontos para realizar esta operação! Operação abortada!</translation>
     </message>
 </context>
 <context>
     <name>layerDialog</name>
     <message>
         <source>Grid</source>
-        <translation type="obsolete">Grade</translation>
+        <translation>Grade</translation>
     </message>
     <message>
         <source>Columns</source>
-        <translation type="obsolete">Colunas</translation>
+        <translation>Colunas</translation>
     </message>
     <message>
         <source>Rows</source>
-        <translation type="obsolete">Linhas</translation>
+        <translation>Linhas</translation>
     </message>
     <message>
         <source>Spacing</source>
-        <translation type="obsolete">Espaçamento</translation>
+        <translation>Espaçamento</translation>
     </message>
     <message>
         <source>Columns gap</source>
-        <translation type="obsolete">Espaço entre colunas</translation>
+        <translation>Espaço entre colunas</translation>
     </message>
     <message>
         <source>Rows gap</source>
-        <translation type="obsolete">Espaço entre linhas</translation>
+        <translation>Espaço entre linhas</translation>
     </message>
     <message>
         <source>Layout</source>
-        <translation type="obsolete">Esquema</translation>
+        <translation>Esquema</translation>
     </message>
     <message>
         <source>Fonts</source>
-        <translation type="obsolete">Fontes</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Image Geometry</source>
-        <translation type="obsolete">QtiPlot - Geometria da imagem</translation>
+        <translation>Fontes</translation>
     </message>
     <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Automatic &amp;layout</source>
-        <translation type="obsolete">Esquema automático</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Columns input error</source>
-        <translation type="obsolete">QtiPlot - Erro nas colunas</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Rows input error</source>
-        <translation type="obsolete">QtiPlot - Erro nas linhas</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Arrange Layers</source>
-        <translation type="obsolete">QtiPlot - Organizar camadas</translation>
+        <translation>Esquema automático</translation>
     </message>
     <message>
         <source>Number of Layers</source>
-        <translation type="obsolete">Número de camadas</translation>
+        <translation>Número de camadas</translation>
     </message>
     <message>
         <source>Alignement</source>
-        <translation type="obsolete">Alinhamento</translation>
+        <translation>Alinhamento</translation>
     </message>
     <message>
         <source>Horizontal</source>
-        <translation type="obsolete">Horizontal</translation>
+        <translation>Horizontal</translation>
     </message>
     <message>
         <source>Center</source>
-        <translation type="obsolete">Centro</translation>
+        <translation>Centro</translation>
     </message>
     <message>
         <source>Left</source>
-        <translation type="obsolete">Esquerda</translation>
+        <translation>Esquerda</translation>
     </message>
     <message>
         <source>Right</source>
-        <translation type="obsolete">Direita</translation>
+        <translation>Direita</translation>
     </message>
     <message>
         <source>Vertical</source>
-        <translation type="obsolete">Vertical</translation>
+        <translation>Vertical</translation>
     </message>
     <message>
         <source>Top</source>
-        <translation type="obsolete">Superior</translation>
+        <translation>Superior</translation>
     </message>
     <message>
         <source>Bottom</source>
-        <translation type="obsolete">Inferior</translation>
+        <translation>Inferior</translation>
     </message>
     <message>
         <source>&amp;Layer Canvas Size</source>
-        <translation type="obsolete">Tamanho do fundo da camada</translation>
+        <translation>Tamanho do fundo da camada</translation>
     </message>
     <message>
         <source>Width</source>
-        <translation type="obsolete">Largura</translation>
+        <translation>Largura</translation>
     </message>
     <message>
         <source> pixels</source>
-        <translation type="obsolete"> pixels</translation>
+        <translation> pixels</translation>
     </message>
     <message>
         <source>Height</source>
-        <translation type="obsolete">Altura</translation>
+        <translation>Altura</translation>
     </message>
     <message>
         <source>Left margin</source>
-        <translation type="obsolete">Margem esquerda</translation>
+        <translation>Margem esquerda</translation>
     </message>
     <message>
         <source>Right margin</source>
-        <translation type="obsolete">Margem direita</translation>
+        <translation>Margem direita</translation>
     </message>
     <message>
         <source>Top margin</source>
-        <translation type="obsolete">Margem superior</translation>
+        <translation>Margem superior</translation>
     </message>
     <message>
         <source>Bottom margin</source>
-        <translation type="obsolete">Margem inferior</translation>
+        <translation>Margem inferior</translation>
     </message>
     <message>
         <source>Titles</source>
-        <translation type="obsolete">Títulos</translation>
+        <translation>Títulos</translation>
     </message>
     <message>
         <source>Axis Legends</source>
-        <translation type="obsolete">Legendas dos eixos</translation>
+        <translation>Legendas dos eixos</translation>
     </message>
     <message>
         <source>Axis Numbers</source>
-        <translation type="obsolete">Números dos eixos</translation>
+        <translation>Números dos eixos</translation>
     </message>
     <message>
         <source>Legends</source>
-        <translation type="obsolete">Legendas</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Delete Layers?</source>
-        <translation type="obsolete">QtiPlot - Remover camadas?</translation>
+        <translation>Legendas</translation>
     </message>
     <message>
         <source>You are about to delete %1 existing layers.</source>
-        <translation type="obsolete">Você está preste aremover %1 camadas existentes.</translation>
+        <translation>Você está preste aremover %1 camadas existentes.</translation>
     </message>
     <message>
         <source>Are you sure you want to continue this operation?</source>
-        <translation type="obsolete">Está certo de que quer continuar com esta operação?</translation>
+        <translation>Está certo de que quer continuar com esta operação?</translation>
     </message>
     <message>
         <source>&amp;Continue</source>
-        <translation type="obsolete">&amp;Continuar</translation>
+        <translation>&amp;Continuar</translation>
     </message>
     <message>
         <source>The number of columns you&apos;ve entered is greater than the number of graphs (%1)!</source>
-        <translation type="obsolete">O número de colunas fornecido é maior que o número de gráficos (%1)!</translation>
+        <translation>O número de colunas fornecido é maior que o número de gráficos (%1)!</translation>
     </message>
     <message>
         <source>The number of rows you&apos;ve entered is greater than the number of graphs (%1)!</source>
-        <translation type="obsolete">O número de linhas fornecido é maior que o número de gráficos (%1)!</translation>
+        <translation>O número de linhas fornecido é maior que o número de gráficos (%1)!</translation>
     </message>
 </context>
 <context>
     <name>lineDialog</name>
     <message>
-        <source>QtiPlot - Line options</source>
-        <translation type="obsolete">QtiPlot- Opções de linha</translation>
-    </message>
-    <message>
         <source>Color</source>
-        <translation type="obsolete">Cor</translation>
+        <translation>Cor</translation>
     </message>
     <message>
         <source>Line type</source>
-        <translation type="obsolete">Tipo de Linha</translation>
+        <translation>Tipo de Linha</translation>
     </message>
     <message>
         <source>Line width</source>
-        <translation type="obsolete">Espessura de Linha</translation>
+        <translation>Espessura de Linha</translation>
     </message>
     <message>
         <source>1</source>
-        <translation type="obsolete">1</translation>
+        <translation>1</translation>
     </message>
     <message>
         <source>2</source>
-        <translation type="obsolete">2</translation>
+        <translation>2</translation>
     </message>
     <message>
         <source>3</source>
-        <translation type="obsolete">3</translation>
+        <translation>3</translation>
     </message>
     <message>
         <source>4</source>
-        <translation type="obsolete">4</translation>
+        <translation>4</translation>
     </message>
     <message>
         <source>5</source>
-        <translation type="obsolete">5</translation>
+        <translation>5</translation>
     </message>
     <message>
         <source>Arrow at &amp;start</source>
-        <translation type="obsolete">Seta no início</translation>
+        <translation>Seta no início</translation>
     </message>
     <message>
         <source>Arrow at &amp;end</source>
-        <translation type="obsolete">Seta no final</translation>
+        <translation>Seta no final</translation>
     </message>
     <message>
         <source>Opti&amp;ons</source>
-        <translation type="obsolete">&amp;Opciões</translation>
+        <translation>&amp;Opciões</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="obsolete">Comprimento</translation>
+        <translation>Comprimento</translation>
     </message>
     <message>
         <source>Angle</source>
-        <translation type="obsolete">Ângulo</translation>
+        <translation>Ângulo</translation>
     </message>
     <message>
         <source>&amp;Filled</source>
-        <translation type="obsolete">Preenc&amp;hido</translation>
+        <translation>Preenc&amp;hido</translation>
     </message>
     <message>
         <source>Arrow &amp;Head</source>
-        <translation type="obsolete">Cabeça da se&amp;ta</translation>
+        <translation>Cabeça da se&amp;ta</translation>
     </message>
     <message>
         <source>Start Point</source>
-        <translation type="obsolete">Ponto inicial</translation>
+        <translation>Ponto inicial</translation>
     </message>
     <message>
         <source>X</source>
-        <translation type="obsolete">X</translation>
+        <translation>X</translation>
     </message>
     <message>
         <source>Y</source>
-        <translation type="obsolete">Y</translation>
+        <translation>Y</translation>
     </message>
     <message>
         <source>End Point</source>
-        <translation type="obsolete">Ponto final</translation>
+        <translation>Ponto final</translation>
     </message>
     <message>
         <source>&amp;Geometry</source>
-        <translation type="obsolete">&amp;Geometria</translation>
+        <translation>&amp;Geometria</translation>
     </message>
     <message>
         <source>&amp;Ok</source>
-        <translation type="obsolete">&amp;Ok</translation>
+        <translation>&amp;Ok</translation>
     </message>
     <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Co&amp;lor</source>
-        <translation type="obsolete">C&amp;or</translation>
+        <translation>C&amp;or</translation>
     </message>
     <message>
         <source>Set &amp;Default</source>
-        <translation type="obsolete">Definir como &amp;padrão</translation>
+        <translation>Definir como &amp;padrão</translation>
     </message>
     <message>
         <source>Unit</source>
-        <translation type="obsolete">Unidade</translation>
+        <translation>Unidade</translation>
     </message>
     <message>
         <source>Pixels</source>
-        <translation type="obsolete">Pixels</translation>
+        <translation>Pixels</translation>
     </message>
     <message>
         <source>Scale Coordinates</source>
-        <translation type="obsolete">Coordenadas da escala</translation>
+        <translation>Coordenadas da escala</translation>
     </message>
 </context>
 <context>
     <name>matrixDialog</name>
     <message>
         <source>Cell Width</source>
-        <translation type="obsolete">Largura da célula</translation>
+        <translation>Largura da célula</translation>
     </message>
     <message>
         <source>Data Format</source>
-        <translation type="obsolete">Formato dos dados</translation>
+        <translation>Formato dos dados</translation>
     </message>
     <message>
         <source>Numeric Display</source>
-        <translation type="obsolete">Mostrador numérico</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Matrix Properties</source>
-        <translation type="obsolete">QtiPlot - Propriedades da matriz</translation>
+        <translation>Mostrador numérico</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>Decimal: 1000</source>
-        <translation type="obsolete">Decimal: 1000</translation>
+        <translation>Decimal: 1000</translation>
     </message>
     <message>
         <source>Scientific: 1E3</source>
-        <translation type="obsolete">Científico: 1E3</translation>
+        <translation>Científico: 1E3</translation>
     </message>
     <message>
         <source>Default Decimal Digits</source>
-        <translation type="obsolete">Dígitos decimais padrão</translation>
+        <translation>Dígitos decimais padrão</translation>
     </message>
     <message>
         <source>Significant Digits=</source>
-        <translation type="obsolete">Algarismos significativos=</translation>
+        <translation>Algarismos significativos=</translation>
     </message>
 </context>
 <context>
     <name>matrixSizeDialog</name>
     <message>
         <source>Rows</source>
-        <translation type="obsolete">Linhas</translation>
+        <translation>Linhas</translation>
     </message>
     <message>
         <source>Columns</source>
-        <translation type="obsolete">Colunas</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Matrix Dimensions</source>
-        <translation type="obsolete">QtiPlot - Dimensões da matriz</translation>
+        <translation>Colunas</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Dimensions</source>
-        <translation type="obsolete">Dimensões</translation>
+        <translation>Dimensões</translation>
     </message>
     <message>
         <source>Coordinates</source>
-        <translation type="obsolete">Coordenadas</translation>
+        <translation>Coordenadas</translation>
     </message>
     <message>
         <source>X (Columns)</source>
-        <translation type="obsolete">X (Colunas)</translation>
+        <translation>X (Colunas)</translation>
     </message>
     <message>
         <source>Y (Rows)</source>
-        <translation type="obsolete">Y (linhas)</translation>
+        <translation>Y (linhas)</translation>
     </message>
     <message>
         <source>First</source>
-        <translation type="obsolete">Primeiro</translation>
+        <translation>Primeiro</translation>
     </message>
     <message>
         <source>Last</source>
-        <translation type="obsolete">�ltimo</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input error</source>
-        <translation type="obsolete">QtiPlot - Erro de entrada</translation>
+        <translation>�ltimo</translation>
     </message>
 </context>
 <context>
     <name>matrixValuesDialog</name>
     <message>
-        <source>QtiPlot - Set Matrix Values</source>
-        <translation type="obsolete">QtiPlot - Definir valores da matriz</translation>
-    </message>
-    <message>
         <source>For row (i)</source>
-        <translation type="obsolete">Da linha (i)</translation>
+        <translation>Da linha (i)</translation>
     </message>
     <message>
         <source>to</source>
-        <translation type="obsolete">até</translation>
+        <translation>até</translation>
     </message>
     <message>
         <source>For col (j)</source>
-        <translation type="obsolete">Da col (j)</translation>
+        <translation>Da col (j)</translation>
     </message>
     <message>
         <source>Add function</source>
-        <translation type="obsolete">Adicionar função</translation>
+        <translation>Adicionar função</translation>
     </message>
     <message>
         <source>Add Cell</source>
-        <translation type="obsolete">Adicionar célula</translation>
+        <translation>Adicionar célula</translation>
     </message>
     <message>
         <source>Cell(i,j)=</source>
-        <translation type="obsolete">Célula(i,j)=</translation>
+        <translation>Célula(i,j)=</translation>
     </message>
     <message>
         <source>OK</source>
-        <translation type="obsolete">OK</translation>
+        <translation>OK</translation>
     </message>
     <message>
         <source>Apply</source>
-        <translation type="obsolete">Aplicar</translation>
+        <translation>Aplicar</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">Cancelar</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input function error</source>
-        <translation type="obsolete">QtiPlot - Erro na fórmula fornecida</translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
         <source>You can not use cells recursevely!</source>
-        <translation type="obsolete">Não é possível usar as células recursivamente!</translation>
+        <translation>Não é possível usar as células recursivamente!</translation>
     </message>
     <message>
         <source>Column and row indexes must be greater than zero!</source>
-        <translation type="obsolete">Os índices de coluna e linha devem ser maiores que zero!</translation>
+        <translation>Os índices de coluna e linha devem ser maiores que zero!</translation>
     </message>
 </context>
 <context>
     <name>muParserScript</name>
     <message>
         <source>Out of memory</source>
-        <translation type="obsolete">Memória esgotada</translation>
+        <translation>Memória esgotada</translation>
     </message>
     <message>
         <source>You cannot use imbricated columns!</source>
-        <translation type="obsolete">Não é possível usar colunas mescladas!</translation>
+        <translation>Não é possível usar colunas mescladas!</translation>
     </message>
     <message>
         <source>You cannot use cells recursively!</source>
-        <translation type="obsolete">Não é possível usar as células recursivamente!</translation>
+        <translation>Não é possível usar as células recursivamente!</translation>
     </message>
     <message>
         <source>Too many &apos;=&apos; in one line.</source>
-        <translation type="obsolete">Excessivos &apos;=&apos; em uma única linha.</translation>
+        <translation>Excessivos &apos;=&apos; em uma única linha.</translation>
     </message>
     <message>
         <source>Syntax error: &apos;=&apos; without variable name.</source>
-        <translation type="obsolete">Erro de sintaxe: &apos;=&apos; sem nome de variável.</translation>
+        <translation>Erro de sintaxe: &apos;=&apos; sem nome de variável.</translation>
     </message>
     <message>
         <source>col() works only on tables!</source>
-        <translation type="obsolete">col() funciona somente em tabelas!</translation>
+        <translation>col() funciona somente em tabelas!</translation>
     </message>
     <message>
         <source>There&apos;s no column named %1 in table %2!</source>
-        <translation type="obsolete">Não existe uma coluna chamada %1 na tabela %2!</translation>
+        <translation>Não existe uma coluna chamada %1 na tabela %2!</translation>
     </message>
     <message>
         <source>There&apos;s no row %1 in table %2!</source>
-        <translation type="obsolete">Não existe a linha %1 na tabela %2!</translation>
+        <translation>Não existe a linha %1 na tabela %2!</translation>
     </message>
     <message>
         <source>There&apos;s no column %1 in table %2!</source>
-        <translation type="obsolete">Não existe a coluna %1 na tabela %2!</translation>
+        <translation>Não existe a coluna %1 na tabela %2!</translation>
     </message>
     <message>
         <source>cell() works only on matrizes!</source>
-        <translation type="obsolete">cell() funciona somente com matrizes!</translation>
+        <translation>cell() funciona somente com matrizes!</translation>
     </message>
     <message>
         <source>There&apos;s no row %1 in matrix %2!</source>
-        <translation type="obsolete">Não existe a linha %1 na matriz %2!</translation>
+        <translation>Não existe a linha %1 na matriz %2!</translation>
     </message>
     <message>
         <source>There&apos;s no column %1 in matrix %2!</source>
-        <translation type="obsolete">Não existe a coluna %1 na matriz %2!</translation>
+        <translation>Não existe a coluna %1 na matriz %2!</translation>
     </message>
     <message>
         <source>tablecol() works only on tables!</source>
-        <translation type="obsolete">tablecol() funciona somente em tabelas!</translation>
+        <translation>tablecol() funciona somente em tabelas!</translation>
     </message>
     <message>
         <source>tablecol: wrong number of arguments (need 2, got %1)</source>
-        <translation type="obsolete">tablecol: número incorreto de argumentos (necessários 2, obtener %1) </translation>
+        <translation>tablecol: número incorreto de argumentos (necessários 2, obtener %1) </translation>
     </message>
     <message>
         <source>tablecol: first argument must be a string (table name)</source>
-        <translation type="obsolete">tablecol: o primeiro argumento deve ser uma string (nome da tabela)</translation>
+        <translation>tablecol: o primeiro argumento deve ser uma string (nome da tabela)</translation>
     </message>
     <message>
         <source>Couldn&apos;t find a table named %1.</source>
-        <translation type="obsolete">Não foi possível encontrar a tabela chamada %1.</translation>
+        <translation>Não foi possível encontrar a tabela chamada %1.</translation>
     </message>
     <message>
         <source>cell() works only on tables and matrizes!</source>
-        <translation type="obsolete">cell() funciona somente em tabelas e matrizes!</translation>
+        <translation>cell() funciona somente em tabelas e matrizes!</translation>
     </message>
     <message>
         <source>cell() works only on tables and matrices!</source>
-        <translation type="obsolete">o uso de &quot;cell()&quot; só funciona com tabelas e matrizes!</translation>
+        <translation>o uso de &quot;cell()&quot; só funciona com tabelas e matrizes!</translation>
     </message>
 </context>
 <context>
     <name>myWidget</name>
     <message>
-        <source>QtiPlot</source>
-        <translation type="obsolete">QtiPlot</translation>
-    </message>
-    <message>
         <source>Do you want to hide or delete</source>
-        <translation type="obsolete">Deseja ocultar ou excluir</translation>
+        <translation>Deseja ocultar ou excluir</translation>
     </message>
     <message>
         <source>Delete</source>
-        <translation type="obsolete">Excluir</translation>
+        <translation>Excluir</translation>
     </message>
     <message>
         <source>Hide</source>
-        <translation type="obsolete">Ocultar</translation>
+        <translation>Ocultar</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">Cancelar</translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
         <source>Normal</source>
-        <translation type="obsolete">Normal</translation>
+        <translation>Normal</translation>
     </message>
     <message>
         <source>Hidden</source>
-        <translation type="obsolete">Oculto</translation>
+        <translation>Oculto</translation>
     </message>
     <message>
         <source>Minimized</source>
-        <translation type="obsolete">Minimizada</translation>
+        <translation>Minimizada</translation>
     </message>
     <message>
         <source>Maximized</source>
-        <translation type="obsolete">Maximizada</translation>
+        <translation>Maximizada</translation>
     </message>
     <message>
         <source>kB</source>
-        <translation type="obsolete">kB</translation>
+        <translation>kB</translation>
     </message>
 </context>
 <context>
     <name>pieDialog</name>
     <message>
-        <source>QtiPlot - Pie Options</source>
-        <translation type="obsolete">QtiPlot - Opções de pizza</translation>
-    </message>
-    <message>
         <source>Border</source>
-        <translation type="obsolete">Borda</translation>
+        <translation>Borda</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="obsolete">Cor</translation>
+        <translation>Cor</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="obsolete">Estilo</translation>
+        <translation>Estilo</translation>
     </message>
     <message>
         <source>Width</source>
-        <translation type="obsolete">Largura</translation>
+        <translation>Largura</translation>
     </message>
     <message>
         <source>Fill</source>
-        <translation type="obsolete">Preenchimento</translation>
+        <translation>Preenchimento</translation>
     </message>
     <message>
         <source>First color</source>
-        <translation type="obsolete">Primeira cor</translation>
+        <translation>Primeira cor</translation>
     </message>
     <message>
         <source>Pattern</source>
-        <translation type="obsolete">Modelo</translation>
+        <translation>Modelo</translation>
     </message>
     <message>
         <source>Pie ray</source>
-        <translation type="obsolete">Pizza raiada</translation>
+        <translation>Pizza raiada</translation>
     </message>
     <message>
         <source>Pie</source>
-        <translation type="obsolete">Pizza</translation>
+        <translation>Pizza</translation>
     </message>
     <message>
         <source>&amp;Worksheet</source>
-        <translation type="obsolete">&amp;Planilha</translation>
+        <translation>&amp;Planilha</translation>
     </message>
     <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Background</source>
-        <translation type="obsolete">Fundo</translation>
+        <translation>Fundo</translation>
     </message>
     <message>
         <source>Co&amp;lor</source>
-        <translation type="obsolete">C&amp;or</translation>
+        <translation>C&amp;or</translation>
     </message>
     <message>
         <source>Border Width</source>
-        <translation type="obsolete">Largura da borda</translation>
+        <translation>Largura da borda</translation>
     </message>
     <message>
         <source>Border Color</source>
-        <translation type="obsolete">Cor de borda</translation>
+        <translation>Cor de borda</translation>
     </message>
     <message>
         <source>Colo&amp;r</source>
-        <translation type="obsolete">Co&amp;r</translation>
+        <translation>Co&amp;r</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="obsolete">Opções</translation>
+        <translation>Opções</translation>
     </message>
     <message>
         <source>Margin</source>
-        <translation type="obsolete">Margem</translation>
+        <translation>Margem</translation>
     </message>
     <message>
         <source>Apply to all layers</source>
-        <translation type="obsolete">Aplicar a todas as camadas</translation>
+        <translation>Aplicar a todas as camadas</translation>
     </message>
     <message>
         <source>General</source>
-        <translation type="obsolete">Geral</translation>
+        <translation>Geral</translation>
     </message>
     <message>
         <source>Pie radius</source>
-        <translation type="obsolete">Raio da pizza</translation>
+        <translation>Raio da pizza</translation>
     </message>
     <message>
         <source>Canvas Color</source>
-        <translation type="obsolete">Cor da camada</translation>
+        <translation>Cor da camada</translation>
     </message>
 </context>
 <context>
     <name>plot3DDialog</name>
     <message>
-        <source>QtiPlot - Surface Plot Options</source>
-        <translation type="obsolete">QtiPlot - Opções de gráfico de superfície</translation>
-    </message>
-    <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>X</source>
-        <translation type="obsolete">X</translation>
+        <translation>X</translation>
     </message>
     <message>
         <source>Y</source>
-        <translation type="obsolete">Y</translation>
+        <translation>Y</translation>
     </message>
     <message>
         <source>Z</source>
-        <translation type="obsolete">Z</translation>
+        <translation>Z</translation>
     </message>
     <message>
         <source>From</source>
-        <translation type="obsolete">A partir de</translation>
+        <translation>A partir de</translation>
     </message>
     <message>
         <source>To</source>
-        <translation type="obsolete">Até</translation>
+        <translation>Até</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="obsolete">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>linear</source>
-        <translation type="obsolete">linear</translation>
+        <translation>linear</translation>
     </message>
     <message>
         <source>logarithmic</source>
-        <translation type="obsolete">logarítmico</translation>
+        <translation>logarítmico</translation>
     </message>
     <message>
         <source>Major Ticks</source>
-        <translation type="obsolete">Marcas maiores</translation>
+        <translation>Marcas maiores</translation>
     </message>
     <message>
         <source>MinorTicks</source>
-        <translation type="obsolete">Marcas menores</translation>
+        <translation>Marcas menores</translation>
     </message>
     <message>
         <source>&amp;Scale</source>
-        <translation type="obsolete">E&amp;scala</translation>
+        <translation>E&amp;scala</translation>
     </message>
     <message>
         <source>Title</source>
-        <translation type="obsolete">Título</translation>
+        <translation>Título</translation>
     </message>
     <message>
         <source>Axis Font</source>
-        <translation type="obsolete">Fonte do eixo</translation>
+        <translation>Fonte do eixo</translation>
     </message>
     <message>
         <source>&amp;Choose font</source>
-        <translation type="obsolete">Escolher fonte</translation>
+        <translation>Escolher fonte</translation>
     </message>
     <message>
         <source>Major Ticks Length</source>
-        <translation type="obsolete">Comprimrnto das marcas maiores</translation>
+        <translation>Comprimrnto das marcas maiores</translation>
     </message>
     <message>
         <source>Minor Ticks Length</source>
-        <translation type="obsolete">Comprimento das marcas menores</translation>
+        <translation>Comprimento das marcas menores</translation>
     </message>
     <message>
         <source>&amp;Axis</source>
-        <translation type="obsolete">Eixos</translation>
+        <translation>Eixos</translation>
     </message>
     <message>
         <source>&amp;Color</source>
-        <translation type="obsolete">&amp;Cor</translation>
+        <translation>&amp;Cor</translation>
     </message>
     <message>
         <source>&amp;Font</source>
-        <translation type="obsolete">&amp;Fonte</translation>
+        <translation>&amp;Fonte</translation>
     </message>
     <message>
         <source>&amp;Title</source>
-        <translation type="obsolete">&amp;Título</translation>
+        <translation>&amp;Título</translation>
     </message>
     <message>
         <source>Data</source>
-        <translation type="obsolete">Dados</translation>
+        <translation>Dados</translation>
     </message>
     <message>
         <source>Ma&amp;x</source>
-        <translation type="obsolete">Ma&amp;x</translation>
+        <translation>Ma&amp;x</translation>
     </message>
     <message>
         <source>&amp;Min</source>
-        <translation type="obsolete">&amp;Min</translation>
+        <translation>&amp;Min</translation>
     </message>
     <message>
         <source>General</source>
-        <translation type="obsolete">Geral</translation>
+        <translation>Geral</translation>
     </message>
     <message>
         <source>&amp;Line</source>
-        <translation type="obsolete">&amp;Linha</translation>
+        <translation>&amp;Linha</translation>
     </message>
     <message>
         <source>&amp;Background</source>
-        <translation type="obsolete">Fun&amp;do</translation>
+        <translation>Fun&amp;do</translation>
     </message>
     <message>
         <source>Coordinate System</source>
-        <translation type="obsolete">Sistema de coordenadas</translation>
+        <translation>Sistema de coordenadas</translation>
     </message>
     <message>
         <source>&amp;Axes</source>
-        <translation type="obsolete">Eixos</translation>
+        <translation>Eixos</translation>
     </message>
     <message>
         <source>Lab&amp;els</source>
-        <translation type="obsolete">Rótulos</translation>
+        <translation>Rótulos</translation>
     </message>
     <message>
         <source>&amp;Numbers</source>
-        <translation type="obsolete">&amp;Números</translation>
+        <translation>&amp;Números</translation>
     </message>
     <message>
         <source>&amp;Grid</source>
-        <translation type="obsolete">Grade</translation>
+        <translation>Grade</translation>
     </message>
     <message>
         <source>Opacity</source>
-        <translation type="obsolete">Opacidade</translation>
+        <translation>Opacidade</translation>
     </message>
     <message>
         <source>&amp;Colors</source>
-        <translation type="obsolete">&amp;Cores</translation>
+        <translation>&amp;Cores</translation>
     </message>
     <message>
         <source>Line Width</source>
-        <translation type="obsolete">Espessura da linha</translation>
+        <translation>Espessura da linha</translation>
     </message>
     <message>
         <source>Resolution</source>
-        <translation type="obsolete">Resolução</translation>
+        <translation>Resolução</translation>
     </message>
     <message>
         <source>Numbers Font</source>
-        <translation type="obsolete">Fonte dos números</translation>
+        <translation>Fonte dos números</translation>
     </message>
     <message>
         <source>&amp;Choose Font</source>
-        <translation type="obsolete">Escolher fonte</translation>
+        <translation>Escolher fonte</translation>
     </message>
     <message>
         <source>Distance labels - axis</source>
-        <translation type="obsolete">Distância rótulos - eixo</translation>
+        <translation>Distância rótulos - eixo</translation>
     </message>
     <message>
         <source>Zoom (%)</source>
-        <translation type="obsolete">Zoom (%)</translation>
+        <translation>Zoom (%)</translation>
     </message>
     <message>
         <source>X Zoom (%)</source>
-        <translation type="obsolete">X Zoom (%)</translation>
+        <translation>X Zoom (%)</translation>
     </message>
     <message>
         <source>Y Zoom (%)</source>
-        <translation type="obsolete">Y Zoom (%)</translation>
+        <translation>Y Zoom (%)</translation>
     </message>
     <message>
         <source>Z Zoom (%)</source>
-        <translation type="obsolete">Z Zoom (%)</translation>
+        <translation>Z Zoom (%)</translation>
     </message>
     <message>
         <source>&amp;General</source>
-        <translation type="obsolete">&amp;Geral</translation>
+        <translation>&amp;Geral</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="obsolete">Estilo</translation>
+        <translation>Estilo</translation>
     </message>
     <message>
         <source>Dot</source>
-        <translation type="obsolete">Ponto</translation>
+        <translation>Ponto</translation>
     </message>
     <message>
         <source>Cross Hair</source>
-        <translation type="obsolete">Cruzes</translation>
+        <translation>Cruzes</translation>
     </message>
     <message>
         <source>Cone</source>
-        <translation type="obsolete">Cone</translation>
+        <translation>Cone</translation>
     </message>
     <message>
         <source>Width</source>
-        <translation type="obsolete">Largura</translation>
+        <translation>Largura</translation>
     </message>
     <message>
         <source>Smooth angles</source>
-        <translation type="obsolete">Ângulos suaves</translation>
+        <translation>Ângulos suaves</translation>
     </message>
     <message>
         <source>Radius</source>
-        <translation type="obsolete">Raio</translation>
+        <translation>Raio</translation>
     </message>
     <message>
         <source>Smooth line</source>
-        <translation type="obsolete">Linha suave</translation>
+        <translation>Linha suave</translation>
     </message>
     <message>
         <source>Boxed</source>
-        <translation type="obsolete">Quadrado</translation>
+        <translation>Quadrado</translation>
     </message>
     <message>
         <source>Quality</source>
-        <translation type="obsolete">Qualidade</translation>
+        <translation>Qualidade</translation>
     </message>
     <message>
         <source>Points</source>
-        <translation type="obsolete">Pontos</translation>
+        <translation>Pontos</translation>
     </message>
     <message>
         <source>Bars</source>
-        <translation type="obsolete">Barras</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Start limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite inicial</translation>
-    </message>
-    <message>
-        <source>QtiPlot - End limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite final</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input error</source>
-        <translation type="obsolete">QtiPlot - Erro de entrada</translation>
+        <translation>Barras</translation>
     </message>
     <message>
         <source>Please enter scale limits that satisfy: from &lt; to!</source>
-        <translation type="obsolete">Por favor, forneça limites de escala tais que: início &lt; fim!</translation>
+        <translation>Por favor, forneça limites de escala tais que: início &lt; fim!</translation>
     </message>
     <message>
         <source>Color Ma&amp;p</source>
-        <translation type="obsolete">Ma&amp;pa de Cor</translation>
+        <translation>Ma&amp;pa de Cor</translation>
     </message>
     <message>
         <source>Colormap files</source>
-        <translation type="obsolete">Arquivos de mapas de cor</translation>
+        <translation>Arquivos de mapas de cor</translation>
     </message>
 </context>
 <context>
     <name>plotDialog</name>
     <message>
-        <source>QtiPlot - Custom curves</source>
-        <translation type="obsolete">QtiPlot - Curvas personalizadas</translation>
-    </message>
-    <message>
         <source>Plot type</source>
-        <translation type="obsolete">Tipo de gráfico</translation>
+        <translation>Tipo de gráfico</translation>
     </message>
     <message>
         <source>&amp;Plot Associations...</source>
-        <translation type="obsolete">Associações do gráfico...</translation>
+        <translation>Associações do gráfico...</translation>
     </message>
     <message>
         <source>&amp;Edit Function...</source>
-        <translation type="obsolete">&amp;Editar função...</translation>
+        <translation>&amp;Editar função...</translation>
     </message>
     <message>
         <source>&amp;Worksheet</source>
-        <translation type="obsolete">&amp;Planilha de trabalho</translation>
+        <translation>&amp;Planilha de trabalho</translation>
     </message>
     <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Connect</source>
-        <translation type="obsolete">Conectar</translation>
+        <translation>Conectar</translation>
     </message>
     <message>
         <source>No line</source>
-        <translation type="obsolete">Sem linha</translation>
+        <translation>Sem linha</translation>
     </message>
     <message>
         <source>Lines</source>
-        <translation type="obsolete">Linhas</translation>
+        <translation>Linhas</translation>
     </message>
     <message>
         <source>Sticks</source>
-        <translation type="obsolete">Traços</translation>
+        <translation>Traços</translation>
     </message>
     <message>
         <source>Steps</source>
-        <translation type="obsolete">Passos</translation>
+        <translation>Passos</translation>
     </message>
     <message>
         <source>Dots</source>
-        <translation type="obsolete">Pontos</translation>
+        <translation>Pontos</translation>
     </message>
     <message>
         <source>Spline</source>
-        <translation type="obsolete">Spline</translation>
+        <translation>Spline</translation>
     </message>
     <message>
         <source>Style</source>
-        <translation type="obsolete">Estilo</translation>
+        <translation>Estilo</translation>
     </message>
     <message>
         <source>Width</source>
-        <translation type="obsolete">Largura</translation>
+        <translation>Largura</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="obsolete">Cor</translation>
+        <translation>Cor</translation>
     </message>
     <message>
         <source>Fill area under curve</source>
-        <translation type="obsolete">Preencher área sob a curva</translation>
+        <translation>Preencher área sob a curva</translation>
     </message>
     <message>
         <source>Fill color</source>
-        <translation type="obsolete">Cor de preenchimento</translation>
+        <translation>Cor de preenchimento</translation>
     </message>
     <message>
         <source>Pattern</source>
-        <translation type="obsolete">Modelo</translation>
+        <translation>Modelo</translation>
     </message>
     <message>
         <source>Line</source>
-        <translation type="obsolete">Linha</translation>
+        <translation>Linha</translation>
     </message>
     <message>
         <source>Rectangle</source>
-        <translation type="obsolete">Retângulo</translation>
+        <translation>Retângulo</translation>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="obsolete">Diamante</translation>
+        <translation>Diamante</translation>
     </message>
     <message>
         <source>Size</source>
-        <translation type="obsolete">Tamanho</translation>
+        <translation>Tamanho</translation>
     </message>
     <message>
         <source>Fill Color</source>
-        <translation type="obsolete">Cor de preenchimento</translation>
+        <translation>Cor de preenchimento</translation>
     </message>
     <message>
         <source>Symbol</source>
-        <translation type="obsolete">Símbolo</translation>
+        <translation>Símbolo</translation>
     </message>
     <message>
         <source>Box</source>
-        <translation type="obsolete">Caixa</translation>
+        <translation>Caixa</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="obsolete">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>Notch</source>
-        <translation type="obsolete">Entalhe</translation>
+        <translation>Entalhe</translation>
     </message>
     <message>
         <source>Range</source>
-        <translation type="obsolete">Faixa</translation>
+        <translation>Faixa</translation>
     </message>
     <message>
         <source>Coef</source>
-        <translation type="obsolete">Coef</translation>
+        <translation>Coef</translation>
     </message>
     <message>
         <source>Box Width</source>
-        <translation type="obsolete">Largura da Caixa</translation>
+        <translation>Largura da Caixa</translation>
     </message>
     <message>
         <source>No Whiskers</source>
-        <translation type="obsolete">Sem barbas</translation>
+        <translation>Sem barbas</translation>
     </message>
     <message>
         <source>Constant</source>
-        <translation type="obsolete">Constante</translation>
+        <translation>Constante</translation>
     </message>
     <message>
         <source>Box/Whiskers</source>
-        <translation type="obsolete">Caixa/Barbas</translation>
+        <translation>Caixa/Barbas</translation>
     </message>
     <message>
         <source>Max</source>
-        <translation type="obsolete">Max</translation>
+        <translation>Max</translation>
     </message>
     <message>
         <source>99%</source>
-        <translation type="obsolete">99%</translation>
+        <translation>99%</translation>
     </message>
     <message>
         <source>Mean</source>
-        <translation type="obsolete">Média</translation>
+        <translation>Média</translation>
     </message>
     <message>
         <source>1%</source>
-        <translation type="obsolete">1%</translation>
+        <translation>1%</translation>
     </message>
     <message>
         <source>Min</source>
-        <translation type="obsolete">Min</translation>
+        <translation>Min</translation>
     </message>
     <message>
         <source>Edge Color</source>
-        <translation type="obsolete">Cor da borda</translation>
+        <translation>Cor da borda</translation>
     </message>
     <message>
         <source>Edge Width</source>
-        <translation type="obsolete">Espessura do borda</translation>
+        <translation>Espessura do borda</translation>
     </message>
     <message>
         <source>Percentile</source>
-        <translation type="obsolete">Porcentagem</translation>
+        <translation>Porcentagem</translation>
     </message>
     <message>
         <source>Direction</source>
-        <translation type="obsolete">Direção</translation>
+        <translation>Direção</translation>
     </message>
     <message>
         <source>Plus</source>
-        <translation type="obsolete">Mais</translation>
+        <translation>Mais</translation>
     </message>
     <message>
         <source>Minus</source>
-        <translation type="obsolete">Menos</translation>
+        <translation>Menos</translation>
     </message>
     <message>
         <source>&amp;X Error Bar</source>
-        <translation type="obsolete">Barra de erro &amp;X</translation>
+        <translation>Barra de erro &amp;X</translation>
     </message>
     <message>
         <source>Co&amp;lor</source>
-        <translation type="obsolete">C&amp;or</translation>
+        <translation>C&amp;or</translation>
     </message>
     <message>
         <source>Line Width</source>
-        <translation type="obsolete">Espessura da linha</translation>
+        <translation>Espessura da linha</translation>
     </message>
     <message>
         <source>1</source>
-        <translation type="obsolete">1</translation>
+        <translation>1</translation>
     </message>
     <message>
         <source>2</source>
-        <translation type="obsolete">2</translation>
+        <translation>2</translation>
     </message>
     <message>
         <source>3</source>
-        <translation type="obsolete">3</translation>
+        <translation>3</translation>
     </message>
     <message>
         <source>4</source>
-        <translation type="obsolete">4</translation>
+        <translation>4</translation>
     </message>
     <message>
         <source>5</source>
-        <translation type="obsolete">5</translation>
+        <translation>5</translation>
     </message>
     <message>
         <source>Cap Width</source>
-        <translation type="obsolete">Largura das maiusculas</translation>
+        <translation>Largura das maiusculas</translation>
     </message>
     <message>
         <source>8</source>
-        <translation type="obsolete">8</translation>
+        <translation>8</translation>
     </message>
     <message>
         <source>10</source>
-        <translation type="obsolete">10</translation>
+        <translation>10</translation>
     </message>
     <message>
         <source>12</source>
-        <translation type="obsolete">12</translation>
+        <translation>12</translation>
     </message>
     <message>
         <source>16</source>
-        <translation type="obsolete">16</translation>
+        <translation>16</translation>
     </message>
     <message>
         <source>20</source>
-        <translation type="obsolete">20</translation>
+        <translation>20</translation>
     </message>
     <message>
         <source>Through Symbol</source>
-        <translation type="obsolete">Atravéz de símbolo</translation>
+        <translation>Atravéz de símbolo</translation>
     </message>
     <message>
         <source>Error Bars</source>
-        <translation type="obsolete">Barras de erro</translation>
+        <translation>Barras de erro</translation>
     </message>
     <message>
         <source>Automatic Binning</source>
-        <translation type="obsolete">Binning automático</translation>
+        <translation>Binning automático</translation>
     </message>
     <message>
         <source>&amp;Show statistics</source>
-        <translation type="obsolete">&amp;Mostrar estatísticas</translation>
+        <translation>&amp;Mostrar estatísticas</translation>
     </message>
     <message>
         <source>Bin Size</source>
-        <translation type="obsolete">Tamanho do bin</translation>
+        <translation>Tamanho do bin</translation>
     </message>
     <message>
         <source>Begin</source>
-        <translation type="obsolete">Iniciar</translation>
+        <translation>Iniciar</translation>
     </message>
     <message>
         <source>End</source>
-        <translation type="obsolete">Terminar</translation>
+        <translation>Terminar</translation>
     </message>
     <message>
         <source>Histogram Data</source>
-        <translation type="obsolete">Dados do histograma</translation>
+        <translation>Dados do histograma</translation>
     </message>
     <message>
         <source>Gap Between Bars (in %)</source>
-        <translation type="obsolete">Espaço entre barras (em %)</translation>
+        <translation>Espaço entre barras (em %)</translation>
     </message>
     <message>
         <source>Offset (in %)</source>
-        <translation type="obsolete">Deslocamento (em %)</translation>
+        <translation>Deslocamento (em %)</translation>
     </message>
     <message>
         <source>Spacing</source>
-        <translation type="obsolete">Espaçando</translation>
+        <translation>Espaçando</translation>
     </message>
     <message>
         <source>Arrowheads</source>
-        <translation type="obsolete">Pontas de flecha</translation>
+        <translation>Pontas de flecha</translation>
     </message>
     <message>
         <source>Length</source>
-        <translation type="obsolete">Longitude</translation>
+        <translation>Longitude</translation>
     </message>
     <message>
         <source>Angle</source>
-        <translation type="obsolete">Ângulo</translation>
+        <translation>Ângulo</translation>
     </message>
     <message>
         <source>&amp;Filled</source>
-        <translation type="obsolete">Preenchimento</translation>
+        <translation>Preenchimento</translation>
     </message>
     <message>
         <source>End Point</source>
-        <translation type="obsolete">Ponto final</translation>
+        <translation>Ponto final</translation>
     </message>
     <message>
         <source>X End</source>
-        <translation type="obsolete">X final</translation>
+        <translation>X final</translation>
     </message>
     <message>
         <source>Y End</source>
-        <translation type="obsolete">Y final</translation>
+        <translation>Y final</translation>
     </message>
     <message>
         <source>Vector</source>
-        <translation type="obsolete">Vetor</translation>
+        <translation>Vetor</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation type="obsolete">E&amp;xcluir</translation>
+        <translation>E&amp;xcluir</translation>
     </message>
     <message>
         <source>&amp;Edit...</source>
-        <translation type="obsolete">&amp;Editar...</translation>
+        <translation>&amp;Editar...</translation>
     </message>
     <message>
         <source>Vertical Bars</source>
-        <translation type="obsolete">Barras verticais</translation>
+        <translation>Barras verticais</translation>
     </message>
     <message>
         <source>Horizontal Bars</source>
-        <translation type="obsolete">Barras horizontais</translation>
+        <translation>Barras horizontais</translation>
     </message>
     <message>
         <source>Histogram</source>
-        <translation type="obsolete">Histograma</translation>
+        <translation>Histograma</translation>
     </message>
     <message>
         <source>Vector XYXY</source>
-        <translation type="obsolete">Vetor XYXY</translation>
+        <translation>Vetor XYXY</translation>
     </message>
     <message>
         <source>Scatter</source>
-        <translation type="obsolete">Dispersão</translation>
+        <translation>Dispersão</translation>
     </message>
     <message>
         <source>Line + Symbol</source>
-        <translation type="obsolete"> Linha + símbolo</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input error</source>
-        <translation type="obsolete">QtiPlot - Erro de entrada</translation>
+        <translation> Linha + símbolo</translation>
     </message>
     <message>
         <source>Please enter a valid start limit!</source>
-        <translation type="obsolete">Por favor, forneça um limite inicial válido !</translation>
+        <translation>Por favor, forneça um limite inicial válido !</translation>
     </message>
     <message>
         <source>Please enter a valid end limit!</source>
-        <translation type="obsolete">Por favor, forneça um limite final válido !</translation>
+        <translation>Por favor, forneça um limite final válido !</translation>
     </message>
     <message>
         <source>Please enter a valid bin size value!</source>
-        <translation type="obsolete">Por favor, forneça um tamanho de bin válido !</translation>
+        <translation>Por favor, forneça um tamanho de bin válido !</translation>
     </message>
     <message>
         <source>Please enter limits that satisfy: begin &lt; end!</source>
-        <translation type="obsolete">Por favor, forneça limites que satisfaçam: inicio &lt; fim!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Bin size input error</source>
-        <translation type="obsolete">QtiPlot - Erro no tamanho do bin</translation>
+        <translation>Por favor, forneça limites que satisfaçam: inicio &lt; fim!</translation>
     </message>
     <message>
         <source>Please enter a positive bin size value!</source>
-        <translation type="obsolete">Por favor, forneça um valor positivo de bin!</translation>
+        <translation>Por favor, forneça um valor positivo de bin!</translation>
     </message>
     <message>
         <source>No Box</source>
-        <translation type="obsolete">Sem caixa</translation>
+        <translation>Sem caixa</translation>
     </message>
     <message>
         <source>Perc 10, 25, 75, 90</source>
-        <translation type="obsolete">Perc 10, 25, 75, 90</translation>
+        <translation>Perc 10, 25, 75, 90</translation>
     </message>
     <message>
         <source>Standard Deviation</source>
-        <translation type="obsolete">Desvio padrão</translation>
+        <translation>Desvio padrão</translation>
     </message>
     <message>
         <source>Standard Error</source>
-        <translation type="obsolete">Erro padrão</translation>
+        <translation>Erro padrão</translation>
     </message>
     <message>
         <source>Perc 25, 75</source>
-        <translation type="obsolete">Perc 25, 75</translation>
+        <translation>Perc 25, 75</translation>
     </message>
     <message>
         <source>Perc 10, 90</source>
-        <translation type="obsolete">Perc 10, 90</translation>
+        <translation>Perc 10, 90</translation>
     </message>
     <message>
         <source>Perc 5, 95</source>
-        <translation type="obsolete">Perc 5, 95</translation>
+        <translation>Perc 5, 95</translation>
     </message>
     <message>
         <source>Perc 1, 99</source>
-        <translation type="obsolete">Perc 1, 99</translation>
+        <translation>Perc 1, 99</translation>
     </message>
     <message>
         <source>Max-Min</source>
-        <translation type="obsolete">Max-Min</translation>
+        <translation>Max-Min</translation>
     </message>
     <message>
         <source>Percentile (%)</source>
-        <translation type="obsolete">Porcentagem (%)</translation>
+        <translation>Porcentagem (%)</translation>
     </message>
     <message>
         <source>Whiskers</source>
-        <translation type="obsolete">Barbas</translation>
+        <translation>Barbas</translation>
     </message>
     <message>
         <source>75-25</source>
-        <translation type="obsolete">75-25</translation>
+        <translation>75-25</translation>
     </message>
     <message>
         <source>90-10</source>
-        <translation type="obsolete">90-10</translation>
+        <translation>90-10</translation>
     </message>
     <message>
         <source>95-5</source>
-        <translation type="obsolete">95-5</translation>
+        <translation>95-5</translation>
     </message>
     <message>
         <source>99-1</source>
-        <translation type="obsolete">99-1</translation>
+        <translation>99-1</translation>
     </message>
     <message>
         <source>Position</source>
-        <translation type="obsolete">Posição</translation>
+        <translation>Posição</translation>
     </message>
     <message>
         <source>Tail</source>
-        <translation type="obsolete">Cauda</translation>
+        <translation>Cauda</translation>
     </message>
     <message>
         <source>Middle</source>
-        <translation type="obsolete">Meio</translation>
+        <translation>Meio</translation>
     </message>
     <message>
         <source>Head</source>
-        <translation type="obsolete">Cabeça</translation>
+        <translation>Cabeça</translation>
     </message>
     <message>
         <source>Vector XYAM</source>
-        <translation type="obsolete">Vetor XYAM</translation>
+        <translation>Vetor XYAM</translation>
     </message>
     <message>
         <source>Vector Data</source>
-        <translation type="obsolete">Dados vetoriais</translation>
+        <translation>Dados vetoriais</translation>
     </message>
     <message>
         <source>Magnitude</source>
-        <translation type="obsolete">Magnitude</translation>
+        <translation>Magnitude</translation>
     </message>
     <message>
         <source>Attach curve to: </source>
-        <translation type="obsolete">Anexar curva a: </translation>
+        <translation>Anexar curva a: </translation>
     </message>
     <message>
         <source>x Axis</source>
-        <translation type="obsolete">Eixo x</translation>
+        <translation>Eixo x</translation>
     </message>
     <message>
         <source>Bottom</source>
-        <translation type="obsolete">Inferior</translation>
+        <translation>Inferior</translation>
     </message>
     <message>
         <source>Top</source>
-        <translation type="obsolete">Superior</translation>
+        <translation>Superior</translation>
     </message>
     <message>
         <source>y Axis</source>
-        <translation type="obsolete">Eixo y</translation>
+        <translation>Eixo y</translation>
     </message>
     <message>
         <source>Left</source>
-        <translation type="obsolete">Esquerda</translation>
+        <translation>Esquerda</translation>
     </message>
     <message>
         <source>Right</source>
-        <translation type="obsolete">Direita</translation>
+        <translation>Direita</translation>
     </message>
     <message>
         <source>Axes</source>
-        <translation type="obsolete">Eixos</translation>
+        <translation>Eixos</translation>
     </message>
     <message>
         <source>Horizontal Steps</source>
-        <translation type="obsolete">Escalas horizontais</translation>
+        <translation>Escalas horizontais</translation>
     </message>
     <message>
         <source>Vertical Steps</source>
-        <translation type="obsolete">Escalas verticais</translation>
+        <translation>Escalas verticais</translation>
     </message>
     <message>
         <source>Image</source>
-        <translation type="obsolete">Imagem</translation>
+        <translation>Imagem</translation>
     </message>
     <message>
         <source>&amp;Gray Scale</source>
-        <translation type="obsolete">Escala de &amp;cinza</translation>
+        <translation>Escala de &amp;cinza</translation>
     </message>
     <message>
         <source>&amp;Default Colors</source>
-        <translation type="obsolete">Cores &amp;padrão</translation>
+        <translation>Cores &amp;padrão</translation>
     </message>
     <message>
         <source>Custom Co&amp;lors</source>
-        <translation type="obsolete">Co&amp;res personalizadas</translation>
+        <translation>Co&amp;res personalizadas</translation>
     </message>
     <message>
         <source>Contour Lines</source>
-        <translation type="obsolete">Linhas de contorno</translation>
+        <translation>Linhas de contorno</translation>
     </message>
     <message>
         <source>Levels</source>
-        <translation type="obsolete">Níveis</translation>
+        <translation>Níveis</translation>
     </message>
     <message>
         <source>Use &amp;Color Map</source>
-        <translation type="obsolete">Usar mapa de &amp;cores</translation>
+        <translation>Usar mapa de &amp;cores</translation>
     </message>
     <message>
         <source>Use Default &amp;Pen</source>
-        <translation type="obsolete">Usar caneta padrão</translation>
+        <translation>Usar caneta padrão</translation>
     </message>
     <message>
         <source>Color Bar Scale</source>
-        <translation type="obsolete">Escala da barra de cores</translation>
+        <translation>Escala da barra de cores</translation>
     </message>
     <message>
         <source>Axis</source>
-        <translation type="obsolete">Eixos</translation>
+        <translation>Eixos</translation>
     </message>
     <message>
         <source>Contour</source>
-        <translation type="obsolete">Contorno</translation>
+        <translation>Contorno</translation>
     </message>
     <message>
         <source>Colors</source>
-        <translation type="obsolete">Cores</translation>
+        <translation>Cores</translation>
     </message>
 </context>
 <context>
     <name>plotWizard</name>
     <message>
         <source>Worksheet</source>
-        <translation type="obsolete">Planilha de trabalho</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Select Columns to Plot</source>
-        <translation type="obsolete">QtiPlot - Selecione colunas para o gráfico</translation>
+        <translation>Planilha de trabalho</translation>
     </message>
     <message>
         <source>&amp;New curve</source>
-        <translation type="obsolete">&amp;Nova curva</translation>
+        <translation>&amp;Nova curva</translation>
     </message>
     <message>
         <source>&amp;Delete curve</source>
-        <translation type="obsolete">Remover curva</translation>
+        <translation>Remover curva</translation>
     </message>
     <message>
         <source>&amp;Plot</source>
-        <translation type="obsolete">&amp;Gráfico</translation>
+        <translation>&amp;Gráfico</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Redefinitions of the same curve are ignored!</source>
-        <translation type="obsolete">As redefinições da mesma curva são ignoradas!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
+        <translation>As redefinições da mesma curva são ignoradas!</translation>
     </message>
     <message>
         <source>You have allready defined a X column!</source>
-        <translation type="obsolete">Já foi definida uma coluna X!</translation>
+        <translation>Já foi definida uma coluna X!</translation>
     </message>
     <message>
         <source>You must define a X column first!</source>
-        <translation type="obsolete">É necessário definir uma coluna X primeiro!</translation>
+        <translation>É necessário definir uma coluna X primeiro!</translation>
     </message>
     <message>
         <source>You have allready defined a e column!</source>
-        <translation type="obsolete">Já foi definida uma coluna Y!</translation>
-    </message>
-    <message>
-        <source>This kind of curve is not handled by QtiPlot!</source>
-        <translation type="obsolete">Este tipo de gráfico não é manipulado pelo QtiPlot!</translation>
+        <translation>Já foi definida uma coluna Y!</translation>
     </message>
     <message>
         <source>You have allready defined a Z column!</source>
-        <translation type="obsolete">Já foi definida uma coluna Z!</translation>
+        <translation>Já foi definida uma coluna Z!</translation>
     </message>
     <message>
         <source>You must define a e column first!</source>
-        <translation type="obsolete">É necessário definir uma coluna e primeiro!</translation>
+        <translation>É necessário definir uma coluna e primeiro!</translation>
     </message>
     <message>
         <source>You have allready defined an error-bars column!</source>
-        <translation type="obsolete">Já foi definida uma coluna de barras de erro!</translation>
+        <translation>Já foi definida uma coluna de barras de erro!</translation>
     </message>
     <message>
         <source>You must add a new curve first!</source>
-        <translation type="obsolete">É necessário adicionar uma nova curva primeiro!</translation>
+        <translation>É necessário adicionar uma nova curva primeiro!</translation>
     </message>
 </context>
 <context>
     <name>polynomFitDialog</name>
     <message>
-        <source>QtiPlot - Polynomial Fit Options</source>
-        <translation type="obsolete">QtiPlot - Opções de ajuste polinomial</translation>
-    </message>
-    <message>
         <source>Polynomial Fit of</source>
-        <translation type="obsolete">Ajuste polinomial de </translation>
+        <translation>Ajuste polinomial de </translation>
     </message>
     <message>
         <source>Order (1 - 9, 1 = linear)</source>
-        <translation type="obsolete">Ordem (1 - 9, 1 = linear)</translation>
+        <translation>Ordem (1 - 9, 1 = linear)</translation>
     </message>
     <message>
         <source>Fit curve # pts</source>
-        <translation type="obsolete">Ajustar # pts da curva</translation>
+        <translation>Ajustar # pts da curva</translation>
     </message>
     <message>
         <source>Fit curve Xmin</source>
-        <translation type="obsolete">Ajustar Xmin da curva</translation>
+        <translation>Ajustar Xmin da curva</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="obsolete">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>Fit curve Xmax</source>
-        <translation type="obsolete">Ajustar Xmax da curva</translation>
+        <translation>Ajustar Xmax da curva</translation>
     </message>
     <message>
         <source>Show Formula on Graph?</source>
-        <translation type="obsolete">Mostrar fórmula no gráfico?</translation>
+        <translation>Mostrar fórmula no gráfico?</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="obsolete">Cor</translation>
+        <translation>Cor</translation>
     </message>
     <message>
         <source>&amp;Fit</source>
-        <translation type="obsolete">Ajuste</translation>
+        <translation>Ajuste</translation>
     </message>
     <message>
         <source>&amp;Close</source>
-        <translation type="obsolete">&amp;Fechar</translation>
+        <translation>&amp;Fechar</translation>
     </message>
     <message>
         <source>Not enough points</source>
-        <translation type="obsolete">Não existem pontos suficientes</translation>
+        <translation>Não existem pontos suficientes</translation>
     </message>
     <message>
         <source>You can not fit curve:</source>
-        <translation type="obsolete">Não é possível ajustar a curva:</translation>
+        <translation>Não é possível ajustar a curva:</translation>
     </message>
     <message>
         <source>because it has less than 2 points!</source>
-        <translation type="obsolete">porque possui menos de 2 Pontos!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
+        <translation>porque possui menos de 2 Pontos!</translation>
     </message>
     <message>
         <source>The curve &lt;b&gt; %1 &lt;/b&gt; doesn&apos;t exist anymore! Operation aborted!</source>
-        <translation type="obsolete">A curva &lt;b&gt;%1&lt;/b&gt; não existe mais! Operação abortada!</translation>
+        <translation>A curva &lt;b&gt;%1&lt;/b&gt; não existe mais! Operação abortada!</translation>
     </message>
     <message>
         <source>You cannot fit curve:</source>
-        <translation type="obsolete">Não é possível ajustar a curva:</translation>
+        <translation>Não é possível ajustar a curva:</translation>
     </message>
 </context>
 <context>
     <name>renameWindowDialog</name>
     <message>
-        <source>QtiPlot - Rename Window</source>
-        <translation type="obsolete">QtiPlot - Renomear janela</translation>
-    </message>
-    <message>
         <source>Window Title</source>
-        <translation type="obsolete">Título da janela</translation>
+        <translation>Título da janela</translation>
     </message>
     <message>
         <source>&amp;Name (single word)</source>
-        <translation type="obsolete">&amp;Nome (uma palavra)</translation>
+        <translation>&amp;Nome (uma palavra)</translation>
     </message>
     <message>
         <source>&amp;Label</source>
-        <translation type="obsolete">Rótulo</translation>
+        <translation>Rótulo</translation>
     </message>
     <message>
         <source>&amp;Both Name and Label</source>
-        <translation type="obsolete">No&amp;me e rótulo</translation>
+        <translation>No&amp;me e rótulo</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Please enter a valid name!</source>
-        <translation type="obsolete">Por favor, forneça um  nome válido!</translation>
+        <translation>Por favor, forneça um  nome válido!</translation>
     </message>
     <message>
         <source>The name you chose is not valid: only letters and digits are allowed!</source>
-        <translation type="obsolete">O nome escolhido não é válido: somente dígitos e letras são permitidos!</translation>
+        <translation>O nome escolhido não é válido: somente dígitos e letras são permitidos!</translation>
     </message>
     <message>
         <source>Please choose another name!</source>
-        <translation type="obsolete">Por favor, escolha outro nome!</translation>
+        <translation>Por favor, escolha outro nome!</translation>
     </message>
     <message>
         <source>Name already exists!</source>
-        <translation type="obsolete">O nome não existe mais!</translation>
+        <translation>O nome não existe mais!</translation>
     </message>
     <message>
         <source>The table name must be different from the names of its columns!</source>
-        <translation type="obsolete">O nome da tabela deve ser diferente dos nomes das colunas!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
+        <translation>O nome da tabela deve ser diferente dos nomes das colunas!</translation>
     </message>
     <message>
         <source>For internal consistency reasons the underscore character is replaced with a minus sign.</source>
-        <translation type="obsolete">Por razones de consistência interna o caractere sublinha é substituído pelo sinal de menos.</translation>
+        <translation>Por razones de consistência interna o caractere sublinha é substituído pelo sinal de menos.</translation>
     </message>
 </context>
 <context>
     <name>sDialog</name>
     <message>
-        <source>QtiPlot - Define surface plot</source>
-        <translation type="obsolete">QtiPlot - Definir gráfico de superfície</translation>
-    </message>
-    <message>
         <source>f(x,y)=</source>
-        <translation type="obsolete">f(x,y)=</translation>
+        <translation>f(x,y)=</translation>
     </message>
     <message>
         <source>X - axis</source>
-        <translation type="obsolete">Eixo - X</translation>
+        <translation>Eixo - X</translation>
     </message>
     <message>
         <source>From</source>
-        <translation type="obsolete">A partir de</translation>
+        <translation>A partir de</translation>
     </message>
     <message>
         <source>-1</source>
-        <translation type="obsolete">-1</translation>
+        <translation>-1</translation>
     </message>
     <message>
         <source>To</source>
-        <translation type="obsolete">Até</translation>
+        <translation>Até</translation>
     </message>
     <message>
         <source>1</source>
-        <translation type="obsolete">1</translation>
+        <translation>1</translation>
     </message>
     <message>
         <source>Y - axis</source>
-        <translation type="obsolete">Eixo - Y</translation>
+        <translation>Eixo - Y</translation>
     </message>
     <message>
         <source>Z - axis</source>
-        <translation type="obsolete">Eixo - Z</translation>
+        <translation>Eixo - Z</translation>
     </message>
     <message>
         <source>Clear &amp;list</source>
-        <translation type="obsolete">Limpar &amp;lista</translation>
+        <translation>Limpar &amp;lista</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>QtiPlot - X Start limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite inicial em X</translation>
-    </message>
-    <message>
-        <source>QtiPlot - X End limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite final em X</translation>
-    </message>
-    <message>
-        <source>QtiPlot - e Start limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite inicial em Y</translation>
-    </message>
-    <message>
-        <source>QtiPlot - e End limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite final em Y</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Z Start limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite inicial em Z</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Z End limit error</source>
-        <translation type="obsolete">QtiPlot - Erro no limite final em Z</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input error</source>
-        <translation type="obsolete">QtiPlot - Erro de entrada</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Please enter limits that satisfy: from &lt; end!</source>
-        <translation type="obsolete">Por favor, forneça limites que satisfaçam: inicio &lt; fim!</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input function error</source>
-        <translation type="obsolete">QtiPlot - Erro na fórmula introduzida</translation>
+        <translation>Por favor, forneça limites que satisfaçam: inicio &lt; fim!</translation>
     </message>
 </context>
 <context>
     <name>setColValuesDialog</name>
     <message>
-        <source>QtiPlot - Set column values</source>
-        <translation type="obsolete">QtiPlot - fixar valores da coluna</translation>
-    </message>
-    <message>
         <source>For row (i)</source>
-        <translation type="obsolete">Para linha (i)</translation>
+        <translation>Para linha (i)</translation>
     </message>
     <message>
         <source>to</source>
-        <translation type="obsolete">até</translation>
+        <translation>até</translation>
     </message>
     <message>
         <source>Add function</source>
-        <translation type="obsolete">Adicionar função</translation>
+        <translation>Adicionar função</translation>
     </message>
     <message>
         <source>Add column</source>
-        <translation type="obsolete">Adicionar coluna</translation>
+        <translation>Adicionar coluna</translation>
     </message>
     <message>
         <source>Add cell</source>
-        <translation type="obsolete">Adicionar célula</translation>
+        <translation>Adicionar célula</translation>
     </message>
     <message>
         <source>OK</source>
-        <translation type="obsolete">OK</translation>
+        <translation>OK</translation>
     </message>
     <message>
         <source>Apply</source>
-        <translation type="obsolete">Aplicar</translation>
+        <translation>Aplicar</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="obsolete">Cancelar</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Input function error</source>
-        <translation type="obsolete">QtiPlot - Erro na fórmula fornecida</translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
         <source>You can not use imbricated columns!</source>
-        <translation type="obsolete">Não é possível usar colunas entrelaçadas!</translation>
+        <translation>Não é possível usar colunas entrelaçadas!</translation>
     </message>
 </context>
 <context>
     <name>smoothCurveDialog</name>
     <message>
-        <source>QtiPlot - Smoothing Options</source>
-        <translation type="obsolete">QtiPlot - Opções de suavização</translation>
-    </message>
-    <message>
         <source>Curve</source>
-        <translation type="obsolete">Curva</translation>
+        <translation>Curva</translation>
     </message>
     <message>
         <source>Polynomial Order</source>
-        <translation type="obsolete">Ordem do polinômio</translation>
+        <translation>Ordem do polinômio</translation>
     </message>
     <message>
         <source>Points to the Left</source>
-        <translation type="obsolete">Pontos à esquerda</translation>
+        <translation>Pontos à esquerda</translation>
     </message>
     <message>
         <source>Points to the Right</source>
-        <translation type="obsolete">Pontos à direita</translation>
+        <translation>Pontos à direita</translation>
     </message>
     <message>
         <source>Points</source>
-        <translation type="obsolete">Pontos</translation>
+        <translation>Pontos</translation>
     </message>
     <message>
         <source>Color</source>
-        <translation type="obsolete">Cor</translation>
+        <translation>Cor</translation>
     </message>
     <message>
         <source>&amp;Smooth</source>
-        <translation type="obsolete">&amp;Suavizar</translation>
+        <translation>&amp;Suavizar</translation>
     </message>
     <message>
         <source>&amp;Close</source>
-        <translation type="obsolete">&amp;Fechar</translation>
+        <translation>&amp;Fechar</translation>
     </message>
 </context>
 <context>
     <name>sortDialog</name>
     <message>
-        <source>QtiPlot - Sorting Options</source>
-        <translation type="obsolete">QtiPlot - Opções de ordenação</translation>
-    </message>
-    <message>
         <source>Sort columns</source>
-        <translation type="obsolete">Ordemar col&amp;unas</translation>
+        <translation>Ordemar col&amp;unas</translation>
     </message>
     <message>
         <source>Order</source>
-        <translation type="obsolete">Ordem</translation>
+        <translation>Ordem</translation>
     </message>
     <message>
         <source>Leading column</source>
-        <translation type="obsolete">Coluna principal</translation>
+        <translation>Coluna principal</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Separately</source>
-        <translation type="obsolete">Separadamente</translation>
+        <translation>Separadamente</translation>
     </message>
     <message>
         <source>Together</source>
-        <translation type="obsolete">Juntas</translation>
+        <translation>Juntas</translation>
     </message>
     <message>
         <source>Ascending</source>
-        <translation type="obsolete">Ascendente</translation>
+        <translation>Ascendente</translation>
     </message>
     <message>
         <source>Descending</source>
-        <translation type="obsolete">Descendente</translation>
+        <translation>Descendente</translation>
     </message>
 </context>
 <context>
     <name>symbolDialog</name>
-    <message>
-        <source>QtiPlot - Choose Symbol</source>
-        <translation type="obsolete">QtiPlot - Escolher símbolo</translation>
-    </message>
 </context>
 <context>
     <name>tableDialog</name>
     <message>
         <source>Enumerate all to the right</source>
-        <translation type="obsolete">Enumerar todas à direita</translation>
+        <translation>Enumerar todas à direita</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="obsolete">Opções</translation>
+        <translation>Opções</translation>
     </message>
     <message>
         <source>Display</source>
-        <translation type="obsolete">Mostrador</translation>
+        <translation>Mostrador</translation>
     </message>
     <message>
         <source>X (abscissae)</source>
-        <translation type="obsolete">X (abscissas)</translation>
+        <translation>X (abscissas)</translation>
     </message>
     <message>
         <source>Y (ordinates)</source>
-        <translation type="obsolete">Y (ordenadas)</translation>
+        <translation>Y (ordenadas)</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="obsolete">Nenhum</translation>
+        <translation>Nenhum</translation>
     </message>
     <message>
         <source>Numeric</source>
-        <translation type="obsolete">Numérico</translation>
+        <translation>Numérico</translation>
     </message>
     <message>
         <source>Text</source>
-        <translation type="obsolete">Texto</translation>
+        <translation>Texto</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="obsolete">Data</translation>
+        <translation>Data</translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="obsolete">Tempo</translation>
+        <translation>Tempo</translation>
     </message>
     <message>
         <source>Month</source>
-        <translation type="obsolete">Mês</translation>
+        <translation>Mês</translation>
     </message>
     <message>
         <source>Day of Week</source>
-        <translation type="obsolete">Dia da semana</translation>
+        <translation>Dia da semana</translation>
     </message>
     <message>
         <source>Apply to all columns to the right</source>
-        <translation type="obsolete">Aplicar a todas as colunas à direita</translation>
+        <translation>Aplicar a todas as colunas à direita</translation>
     </message>
     <message>
         <source>Decimal: 1000</source>
-        <translation type="obsolete">Decimal: 1000</translation>
+        <translation>Decimal: 1000</translation>
     </message>
     <message>
         <source>Scientific: 1E3</source>
-        <translation type="obsolete">Científico: 1E3</translation>
+        <translation>Científico: 1E3</translation>
     </message>
     <message>
         <source>yyyy-MM-dd</source>
-        <translation type="obsolete">aaaa-MM-dd</translation>
+        <translation>aaaa-MM-dd</translation>
     </message>
     <message>
         <source>h</source>
-        <translation type="obsolete">h</translation>
+        <translation>h</translation>
     </message>
     <message>
         <source>h ap</source>
-        <translation type="obsolete">h ap</translation>
+        <translation>h ap</translation>
     </message>
     <message>
         <source>h AP</source>
-        <translation type="obsolete">h AP</translation>
+        <translation>h AP</translation>
     </message>
     <message>
         <source>h:mm</source>
-        <translation type="obsolete">h:mm</translation>
+        <translation>h:mm</translation>
     </message>
     <message>
         <source>h:mm ap</source>
-        <translation type="obsolete">h:mm ap</translation>
+        <translation>h:mm ap</translation>
     </message>
     <message>
         <source>hh:mm</source>
-        <translation type="obsolete">hh:mm</translation>
+        <translation>hh:mm</translation>
     </message>
     <message>
         <source>h:mm:ss</source>
-        <translation type="obsolete">h:mm:ss</translation>
+        <translation>h:mm:ss</translation>
     </message>
     <message>
         <source>h:mm:ss.zzz</source>
-        <translation type="obsolete">h:mm:ss.zzz</translation>
+        <translation>h:mm:ss.zzz</translation>
     </message>
     <message>
         <source>mm:ss</source>
-        <translation type="obsolete">mm:ss</translation>
+        <translation>mm:ss</translation>
     </message>
     <message>
         <source>mm:ss.zzz</source>
-        <translation type="obsolete">mm:ss.zzz</translation>
+        <translation>mm:ss.zzz</translation>
     </message>
     <message>
         <source>hmm</source>
-        <translation type="obsolete">hmm</translation>
+        <translation>hmm</translation>
     </message>
     <message>
         <source>hmmss</source>
-        <translation type="obsolete">hmmss</translation>
+        <translation>hmmss</translation>
     </message>
     <message>
         <source>hhmmss</source>
-        <translation type="obsolete">hhmmss</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Column options</source>
-        <translation type="obsolete">QtiPlot - Opções de coluna</translation>
+        <translation>hhmmss</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>Default</source>
-        <translation type="obsolete">Padrão</translation>
+        <translation>Padrão</translation>
     </message>
     <message>
         <source>Apply to all</source>
-        <translation type="obsolete">Aplicar a todos</translation>
+        <translation>Aplicar a todos</translation>
     </message>
     <message>
         <source>Column Name:</source>
-        <translation type="obsolete">Nome da coluna:</translation>
+        <translation>Nome da coluna:</translation>
     </message>
     <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>Plot Designation:</source>
-        <translation type="obsolete">Designação do gráfico:</translation>
+        <translation>Designação do gráfico:</translation>
     </message>
     <message>
         <source>Format:</source>
-        <translation type="obsolete">Formato:</translation>
+        <translation>Formato:</translation>
     </message>
     <message>
         <source>Precision:</source>
-        <translation type="obsolete">Precisão:</translation>
+        <translation>Precisão:</translation>
     </message>
     <message>
         <source>Z (height)</source>
-        <translation type="obsolete">Z (altura)</translation>
+        <translation>Z (altura)</translation>
     </message>
     <message>
         <source>Column Width:</source>
-        <translation type="obsolete">Largura da coluna:</translation>
+        <translation>Largura da coluna:</translation>
     </message>
     <message>
         <source>Comment:</source>
-        <translation type="obsolete">Comentário:</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Error</source>
-        <translation type="obsolete">QtiPlot - Erro</translation>
+        <translation>Comentário:</translation>
     </message>
     <message>
         <source>The column names must only contain letters and digits!</source>
-        <translation type="obsolete">Os nome das colunas podem conter somente dígitos e letras!</translation>
+        <translation>Os nome das colunas podem conter somente dígitos e letras!</translation>
     </message>
     <message>
         <source>X Error</source>
-        <translation type="obsolete">Erro em X</translation>
+        <translation>Erro em X</translation>
     </message>
     <message>
         <source>Y Error</source>
-        <translation type="obsolete">Erro em Y</translation>
-    </message>
-    <message>
-        <source>QtiPlot - Warning</source>
-        <translation type="obsolete">QtiPlot- Aviso</translation>
+        <translation>Erro em Y</translation>
     </message>
     <message>
         <source>For internal consistency reasons the underscore character is replaced with a minus sign.</source>
-        <translation type="obsolete">Por razões de consistência interna o caractere sublinha é substituído pelo sinal de menos.</translation>
+        <translation>Por razões de consistência interna o caractere sublinha é substituído pelo sinal de menos.</translation>
     </message>
 </context>
 <context>
     <name>textDialog</name>
     <message>
-        <source>QtiPlot - Text Dialog</source>
-        <translation type="obsolete">QtiPlot - Diálogo de texto</translation>
-    </message>
-    <message>
         <source>Title Color</source>
-        <translation type="obsolete">Cor do título</translation>
+        <translation>Cor do título</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>Title Font</source>
-        <translation type="obsolete">Fonte do título</translation>
+        <translation>Fonte do título</translation>
     </message>
     <message>
         <source>&amp;Font</source>
-        <translation type="obsolete">&amp;Fonte</translation>
+        <translation>&amp;Fonte</translation>
     </message>
     <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>Alignement</source>
-        <translation type="obsolete">Alinhamento</translation>
+        <translation>Alinhamento</translation>
     </message>
     <message>
         <source>Center</source>
-        <translation type="obsolete">Centro</translation>
+        <translation>Centro</translation>
     </message>
     <message>
         <source>Left</source>
-        <translation type="obsolete">Esquerda</translation>
+        <translation>Esquerda</translation>
     </message>
     <message>
         <source>Right</source>
-        <translation type="obsolete">Direita</translation>
+        <translation>Direita</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Co&amp;lor</source>
-        <translation type="obsolete">C&amp;or</translation>
+        <translation>C&amp;or</translation>
     </message>
 </context>
 <context>
     <name>textDlg</name>
     <message>
-        <source>QtiPlot - Text options</source>
-        <translation type="obsolete">QtiPlot- Opções de texto</translation>
-    </message>
-    <message>
         <source>Color</source>
-        <translation type="obsolete">Cor</translation>
+        <translation>Cor</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="obsolete">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>Background</source>
-        <translation type="obsolete">Fundo</translation>
+        <translation>Fundo</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="obsolete">Nenhum</translation>
+        <translation>Nenhum</translation>
     </message>
     <message>
         <source>Rectangle</source>
-        <translation type="obsolete">Retângulo</translation>
+        <translation>Retângulo</translation>
     </message>
     <message>
         <source>Shadow</source>
-        <translation type="obsolete">Sombra</translation>
+        <translation>Sombra</translation>
     </message>
     <message>
         <source>&amp;Apply</source>
-        <translation type="obsolete">&amp;Aplicar</translation>
+        <translation>&amp;Aplicar</translation>
     </message>
     <message>
         <source>&amp;Font</source>
-        <translation type="obsolete">&amp;Fonte</translation>
+        <translation>&amp;Fonte</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="obsolete">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Rotate (deg.)</source>
-        <translation type="obsolete">Rotcionar (graus)</translation>
+        <translation>Rotcionar (graus)</translation>
     </message>
     <message>
         <source>0</source>
-        <translation type="obsolete">0</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>45</source>
-        <translation type="obsolete">45</translation>
+        <translation>45</translation>
     </message>
     <message>
         <source>90</source>
-        <translation type="obsolete">90</translation>
+        <translation>90</translation>
     </message>
     <message>
         <source>135</source>
-        <translation type="obsolete">135</translation>
+        <translation>135</translation>
     </message>
     <message>
         <source>180</source>
-        <translation type="obsolete">180</translation>
+        <translation>180</translation>
     </message>
     <message>
         <source>225</source>
-        <translation type="obsolete">225</translation>
+        <translation>225</translation>
     </message>
     <message>
         <source>270</source>
-        <translation type="obsolete">270</translation>
+        <translation>270</translation>
     </message>
     <message>
         <source>315</source>
-        <translation type="obsolete">315</translation>
+        <translation>315</translation>
     </message>
     <message>
         <source>Co&amp;lor</source>
-        <translation type="obsolete">C&amp;or</translation>
+        <translation>C&amp;or</translation>
     </message>
     <message>
         <source>Frame</source>
-        <translation type="obsolete">Estrutura</translation>
+        <translation>Estrutura</translation>
     </message>
     <message>
         <source>Font</source>
-        <translation type="obsolete">Fonte</translation>
+        <translation>Fonte</translation>
     </message>
     <message>
         <source>&amp;Background</source>
-        <translation type="obsolete">Fun&amp;do</translation>
+        <translation>Fun&amp;do</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Added some entries in scidavis/scidavis.pro file in order to solve the issue reported in ticket #307 [1]. I guess it will work fine in all Linux distributions.

[1] https://sourceforge.net/p/scidavis/scidavis-bugs/307/

OBS: to add that entries causes some warnings during the 'make install'. Here are them:
Makefile:684: warning: overriding recipe for target 'install_icon_hicolor_16'
Makefile:546: warning: ignoring old recipe for target 'install_icon_hicolor_16'
Makefile:689: warning: overriding recipe for target 'uninstall_icon_hicolor_16'
Makefile:551: warning: ignoring old recipe for target 'uninstall_icon_hicolor_16'
Makefile:694: warning: overriding recipe for target 'install_icon_hicolor_22'
Makefile:556: warning: ignoring old recipe for target 'install_icon_hicolor_22'
Makefile:699: warning: overriding recipe for target 'uninstall_icon_hicolor_22'
Makefile:561: warning: ignoring old recipe for target 'uninstall_icon_hicolor_22'
Makefile:704: warning: overriding recipe for target 'install_icon_hicolor_32'
Makefile:566: warning: ignoring old recipe for target 'install_icon_hicolor_32'
Makefile:709: warning: overriding recipe for target 'uninstall_icon_hicolor_32'
Makefile:571: warning: ignoring old recipe for target 'uninstall_icon_hicolor_32'
Makefile:714: warning: overriding recipe for target 'install_icon_hicolor_48'
Makefile:576: warning: ignoring old recipe for target 'install_icon_hicolor_48'
Makefile:719: warning: overriding recipe for target 'uninstall_icon_hicolor_48'
Makefile:581: warning: ignoring old recipe for target 'uninstall_icon_hicolor_48'
Makefile:724: warning: overriding recipe for target 'install_icon_hicolor_64'
Makefile:586: warning: ignoring old recipe for target 'install_icon_hicolor_64'
Makefile:729: warning: overriding recipe for target 'uninstall_icon_hicolor_64'
Makefile:591: warning: ignoring old recipe for target 'uninstall_icon_hicolor_64'
Makefile:734: warning: overriding recipe for target 'install_icon_hicolor_128'
Makefile:596: warning: ignoring old recipe for target 'install_icon_hicolor_128'
Makefile:739: warning: overriding recipe for target 'uninstall_icon_hicolor_128'
Makefile:601: warning: ignoring old recipe for target 'uninstall_icon_hicolor_128'
Makefile:744: warning: overriding recipe for target 'install_icon_locolor_16'
Makefile:606: warning: ignoring old recipe for target 'install_icon_locolor_16'
Makefile:749: warning: overriding recipe for target 'uninstall_icon_locolor_16'
Makefile:611: warning: ignoring old recipe for target 'uninstall_icon_locolor_16'
Makefile:754: warning: overriding recipe for target 'install_icon_locolor_22'
Makefile:616: warning: ignoring old recipe for target 'install_icon_locolor_22'
Makefile:759: warning: overriding recipe for target 'uninstall_icon_locolor_22'
Makefile:621: warning: ignoring old recipe for target 'uninstall_icon_locolor_22'
Makefile:764: warning: overriding recipe for target 'install_icon_locolor_32'
Makefile:626: warning: ignoring old recipe for target 'install_icon_locolor_32'
Makefile:769: warning: overriding recipe for target 'uninstall_icon_locolor_32'
Makefile:631: warning: ignoring old recipe for target 'uninstall_icon_locolor_32'
