### PR TITLE
Update config.pri

### DIFF
--- a/config.pri
+++ b/config.pri
@@ -137,7 +137,7 @@ unix {# Linux / MacOS X
 	mime_package.path = "$$INSTALLBASE/share/mime/packages"
 
 	man_page.files = scidavis.1
-	man_page.path = "$$INSTALLBASE/share/man/man1/scidavis.1"
+	man_page.path = "$$INSTALLBASE/share/man/man1"
 
 	#deprecated
 	mime_link.files = scidavis/x-sciprj.desktop


### PR DESCRIPTION
That line caused the man page to get installed under a scidavis.1 subdirectory in /usr/share/man/man1/, so man (and rpmlint) complained about a missing man page.