### PR TITLE
Future-proof the id tag

### DIFF
--- a/scidavis/scidavis.appdata.xml
+++ b/scidavis/scidavis.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2017 Russell Standish <hpcoder _at_ hpcoders.com.au> -->
 <component type="desktop-application">
-  <id>scidavis</id>
+  <id>net.sourceforge.scidavis</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <name>SciDAVis</name>


### PR DESCRIPTION
I was told that the component/project doesn't need to literally own the id, so net.sourceforge.scidavis is fine.