### PR TITLE
Port the python code to python3.x

### DIFF
--- a/libscidavis/python-sipcmd.py
+++ b/libscidavis/python-sipcmd.py
@@ -27,22 +27,28 @@
 #                                                                          #
 ############################################################################
 
-import sipconfig
+
+import sys, sipconfig
 config = sipconfig.Configuration()
-from PyQt4.QtCore import QT_VERSION_STR
-
-
-import re
-flags = ["-I ../scidavis"]
 
 try:
-        from PyQt4.pyqtconfig import Configuration
-        sipFlags=Configuration().pyqt_sip_flags
-except:
-        sipFlags="-x VendorID -t WS_X11 -x PyQt_NoPrintRangeBug -x Py_v3 -g -t Qt_"+re.sub('\.','_',QT_VERSION_STR)
-        
+    pyqt = sys.argv[1]
+except IndexError:
+    pyqt = 'PyQt4'
 
+try:
+    exec("from "+pyqt+".QtCore import PYQT_CONFIGURATION")
+except ImportError:
+    pass
+
+sipBin = config.sip_bin
+sipDir = config.default_sip_dir+'/'+pyqt
+
+sipFlags =  PYQT_CONFIGURATION['sip_flags']
+
+flags = ["-I ../scidavis"]
 if config.sip_version >= 0x040a00:
 	# make use of docstring generation feature in SIP >= 4.10
 	flags.append("-o")
-print " ".join([config.sip_bin, "-I", config.default_sip_dir+"/PyQt4",sipFlags] + flags)
+
+sys.stdout.write(" ".join([sipBin, '-I', sipDir, sipFlags]+flags))

--- a/libscidavis/python.pri
+++ b/libscidavis/python.pri
@@ -16,19 +16,24 @@
   SOURCES += src/PythonScript.cpp src/PythonScripting.cpp
 
   message("Making PyQt bindings via SIP")
+  PYTHONBIN = $$(PYTHON)
+  isEmpty( PYTHONBIN ) {
+    PYTHONBIN = python
+  }
+
   unix {
-    INCLUDEPATH += $$system(python-config --includes|sed -e 's/-I//')
+    INCLUDEPATH += $$system($$PYTHONBIN-config --includes|sed -e 's/-I//')
     osx_dist {
       DEFINES += PYTHONHOME=/Applications/scidavis.app/Contents/Resources
     } 
     system(mkdir -p $${SIP_DIR})
-    system($$system(python python-sipcmd.py) $$system(python-config --includes) -c $${SIP_DIR}  src/scidavis.sip)
+    system($$system($$PYTHONBIN python-sipcmd.py) $$system($$PYTHONBIN-config --includes) -c $${SIP_DIR}  src/scidavis.sip)
   }
 
   win32 {
   mxe {
      DEFINES += SIP_STATIC_MODULE
-    system($$system(python python-sipcmd.py) -c $${SIP_DIR} src/scidavis.sip)
+    system($$system($$PYTHONBIN python-sipcmd.py) -c $${SIP_DIR} src/scidavis.sip)
   } else {
     INCLUDEPATH += $$system(call ../python-includepath.py)
     # TODO: fix the command below (only really necessary if SIP_DIR != MOC/OBJECTS_DIR)

--- a/libscidavis/src/ApplicationWindow.cpp
+++ b/libscidavis/src/ApplicationWindow.cpp
@@ -3944,9 +3944,9 @@ void ApplicationWindow::scriptError(const QString &message, const QString &scrip
 void ApplicationWindow::scriptPrint(const QString &text)
 {
 #ifdef SCRIPTING_CONSOLE
-	if(!text.trimmed().isEmpty()) console->append(text);
+	if(!text.isEmpty()) console->insertPlainText(text);
 #else
-	printf(text.toAscii().constData());
+	printf(text.toUtf8().constData());
 #endif
 }
 

--- a/libscidavis/src/PythonScript.cpp
+++ b/libscidavis/src/PythonScript.cpp
@@ -164,7 +164,7 @@ bool PythonScript::compile(bool for_eval)
 #endif
 		QString signature = "";
 		while(PyDict_Next(topLevelLocal, &i, &key, &value))
-			signature.append(PyString_AsString(key)).append(",");
+			signature.append(PYSTRING_AsString(key)).append(",");
 		signature.truncate(signature.length()-1);
 		QString fdef = "def __doit__("+signature+"):\n";
 		fdef.append(Code);
@@ -325,21 +325,21 @@ void PythonScript::endStdoutRedirect()
 
 bool PythonScript::setQObject(QObject *val, const char *name)
 {
-	if (!PyDict_Contains(modLocalDict, PyString_FromString(name)))
+	if (!PyDict_Contains(modLocalDict, PYSTRING_FromString(name)))
 		compiled = notCompiled;
 	return (env()->setQObject(val, name, modLocalDict) && env()->setQObject(val, name, modGlobalDict));
 }
 
 bool PythonScript::setInt(int val, const char *name)
 {
-	if (!PyDict_Contains(modLocalDict, PyString_FromString(name)))
+	if (!PyDict_Contains(modLocalDict, PYSTRING_FromString(name)))
 		compiled = notCompiled;
 	return (env()->setInt(val, name, modLocalDict) && env()->setInt(val, name, modGlobalDict));
 }
 
 bool PythonScript::setDouble(double val, const char *name)
 {
-	if (!PyDict_Contains(modLocalDict, PyString_FromString(name)))
+	if (!PyDict_Contains(modLocalDict, PYSTRING_FromString(name)))
 		compiled = notCompiled;
 	return (env()->setDouble(val, name, modLocalDict) && env()->setDouble(val, name, modGlobalDict));
 }

--- a/libscidavis/src/PythonScript.cpp
+++ b/libscidavis/src/PythonScript.cpp
@@ -40,6 +40,19 @@
 #include <QVariant>
 
 #include <iostream>
+#if PY_MAJOR_VERSION >= 3
+#define PYSTRING_AsString   PyUnicode_AsUTF8
+#define PYSTRING_FromString PyUnicode_FromString
+#define PYLong_Check        PyLong_Check
+#define PYLong_AsLong       PyLong_AsLong
+#define PYCodeObject_cast
+#else
+#define PYSTRING_AsString   PyString_AsString
+#define PYSTRING_FromString PyString_FromString
+#define PYLong_Check        PyInt_Check
+#define PYLong_AsLong       PyInt_AsLong
+#define PYCodeObject_cast   (PyCodeObject*)
+#endif
 using namespace std;
 
 PythonScript::PythonScript(PythonScripting *env, const QString &code, QObject *context, const QString &name)

--- a/libscidavis/src/PythonScript.cpp
+++ b/libscidavis/src/PythonScript.cpp
@@ -190,7 +190,10 @@ bool PythonScript::compile(bool for_eval)
 	if (!success)
 	{
 		compiled = compileErr;
-		emit_error(env()->errorMsg(), 0);
+		if (batchMode)
+			cerr << env()->errorMsg().toStdString() << endl;
+		else
+			emit_error(env()->errorMsg(), 0);
 	} else
 		compiled = isCompiled;
 	return success;

--- a/libscidavis/src/PythonScript.cpp
+++ b/libscidavis/src/PythonScript.cpp
@@ -244,8 +244,16 @@ QVariant PythonScript::eval()
 	// could handle advanced types (such as PyList->QList) here if needed
 	/* fallback: try to convert to (unicode) string */
 	if(!qret.isValid()) {
+#if PY_MAJOR_VERSION >= 3
+		PyObject *pystring = PyObject_Str(pyret);
+#else
 		PyObject *pystring = PyObject_Unicode(pyret);
+#endif
 		if (pystring) {
+#if PY_MAJOR_VERSION >= 3
+			qret = QVariant(QString(PYSTRING_AsString(pystring)));
+			Py_DECREF(pystring);
+#else
 			PyObject *asUTF8 = PyUnicode_EncodeUTF8(PyUnicode_AS_UNICODE(pystring), PyUnicode_GET_DATA_SIZE(pystring), 0);
 			Py_DECREF(pystring);
 			if (asUTF8) {
@@ -255,6 +263,7 @@ QVariant PythonScript::eval()
 				qret = QVariant(QString(PyString_AS_STRING(pystring)));
 				Py_DECREF(pystring);
 			}
+#endif
 		}
 	}
 

--- a/libscidavis/src/PythonScript.cpp
+++ b/libscidavis/src/PythonScript.cpp
@@ -226,8 +226,8 @@ QVariant PythonScript::eval()
 	/* numeric types */
 	else if (PyFloat_Check(pyret))
 		qret = QVariant(PyFloat_AS_DOUBLE(pyret));
-	else if (PyInt_Check(pyret))
-		qret = QVariant((qlonglong)PyInt_AS_LONG(pyret));
+	else if (PYLong_Check(pyret))
+		qret = QVariant((qlonglong)PYLong_AsLong(pyret));
 	else if (PyLong_Check(pyret))
 		qret = QVariant((qlonglong)PyLong_AsLongLong(pyret));
 	else if (PyNumber_Check(pyret))

--- a/libscidavis/src/PythonScript.cpp
+++ b/libscidavis/src/PythonScript.cpp
@@ -144,7 +144,7 @@ bool PythonScript::compile(bool for_eval)
 	bool success=false;
 	Py_XDECREF(PyCode);
 	// Simplest case: Code is a single expression
-	PyCode = Py_CompileString(Code.toAscii().constData(), Name, Py_eval_input);
+	PyCode = Py_CompileString(Code.toUtf8().constData(), Name, Py_eval_input);
 	if (PyCode) {
 		success = true;
 	} else if (for_eval) {
@@ -184,7 +184,7 @@ bool PythonScript::compile(bool for_eval)
 		// Code contains statements (or errors), but we do not need to get
 		// a return value.
 		PyErr_Clear(); // silently ignore errors
-		PyCode = Py_CompileString(Code.toAscii().constData(), Name, Py_file_input);
+		PyCode = Py_CompileString(Code.toUtf8().constData(), Name, Py_file_input);
 		success = PyCode != NULL;
 	}
 	if (!success)

--- a/libscidavis/src/PythonScript.cpp
+++ b/libscidavis/src/PythonScript.cpp
@@ -173,7 +173,7 @@ bool PythonScript::compile(bool for_eval)
 		if (PyCode)
 		{
 			PyObject *tmp = PyDict_New();
-			Py_XDECREF(PyEval_EvalCode((PyCodeObject*)PyCode, topLevelLocal, tmp));
+			Py_XDECREF(PyEval_EvalCode(PYCodeObject_cast PyCode, topLevelLocal, tmp));
 			Py_DECREF(PyCode);
 			PyCode = PyDict_GetItemString(tmp,"__doit__");
 			Py_XINCREF(PyCode);
@@ -211,7 +211,7 @@ QVariant PythonScript::eval()
 		pyret = PyObject_Call(PyCode, empty_tuple, topLevelLocal);
 		Py_DECREF(empty_tuple);
 	} else
-		pyret = PyEval_EvalCode((PyCodeObject*)PyCode, topLevelGlobal, topLevelLocal);
+		pyret = PyEval_EvalCode(PYCodeObject_cast PyCode, topLevelGlobal, topLevelLocal);
 	endStdoutRedirect();
 	if (!pyret)
 	{
@@ -285,7 +285,7 @@ bool PythonScript::exec()
 		pyret = PyObject_Call(PyCode,empty_tuple,topLevelLocal);
 		Py_DECREF(empty_tuple);
 	} else
-		pyret = PyEval_EvalCode((PyCodeObject*)PyCode, topLevelGlobal, topLevelLocal);
+		pyret = PyEval_EvalCode(PYCodeObject_cast PyCode, topLevelGlobal, topLevelLocal);
 	endStdoutRedirect();
 	if (pyret) {
 		Py_DECREF(pyret);

--- a/libscidavis/src/PythonScripting.cpp
+++ b/libscidavis/src/PythonScripting.cpp
@@ -107,7 +107,7 @@ PyObject *PythonScripting::eval(const QString &code, PyObject *argDict, const ch
 	PyObject *co = Py_CompileString(code.toAscii().constData(), name, Py_eval_input);
 	if (co)
 	{
-		ret = PyEval_EvalCode((PyCodeObject*)co, globals, args);
+		ret = PyEval_EvalCode(PYCodeObject_cast co, globals, args);
 		Py_DECREF(co);
 	}
 	return ret;
@@ -124,7 +124,7 @@ bool PythonScripting::exec (const QString &code, PyObject *argDict, const char *
 	PyObject *co = Py_CompileString(code.toAscii().constData(), name, Py_file_input);
 	if (co)
 	{
-		tmp = PyEval_EvalCode((PyCodeObject*)co, globals, args);
+		tmp = PyEval_EvalCode(PYCodeObject_cast co, globals, args);
 		Py_DECREF(co);
 	}
 	if (!tmp) return false;

--- a/libscidavis/src/PythonScripting.cpp
+++ b/libscidavis/src/PythonScripting.cpp
@@ -75,6 +75,7 @@ extern "C"
 #define PYLong_AsLong       PyInt_AsLong
 #define PYCodeObject_cast   (PyCodeObject*)
 #else
+  PyMODINIT_FUNC PyInit_scidavis(void);
 #define PYSTRING_AsString   PyUnicode_AsUTF8
 #define PYSTRING_FromString PyUnicode_FromString
 #define PYLong_AsLong       PyLong_AsLong
@@ -212,18 +213,22 @@ PythonScripting::PythonScripting(ApplicationWindow *parent, bool batch)
     Py_SetPythonHome(str(PYTHONHOME));
 #endif
     //		PyEval_InitThreads ();
+#if PY_MAJOR_VERSION >= 3
+    PyImport_AppendInittab("scidavis", &PyInit_scidavis);
+#endif
     Py_Initialize ();
     if (!Py_IsInitialized ())
       return;
 
 
+#if PY_MAJOR_VERSION < 3
 #ifdef SIP_STATIC_MODULE
     initsip();
     initQtCore();
     initQtGui();
 #endif
     initscidavis();
-
+#endif
     mainmod = PyImport_AddModule("__main__");
     if (!mainmod)
       {

--- a/libscidavis/src/PythonScripting.cpp
+++ b/libscidavis/src/PythonScripting.cpp
@@ -105,7 +105,7 @@ PyObject *PythonScripting::eval(const QString &code, PyObject *argDict, const ch
 	else
 		args = globals;
 	PyObject *ret=NULL;
-	PyObject *co = Py_CompileString(code.toAscii().constData(), name, Py_eval_input);
+	PyObject *co = Py_CompileString(code.toUtf8().constData(), name, Py_eval_input);
 	if (co)
 	{
 		ret = PyEval_EvalCode(PYCodeObject_cast co, globals, args);
@@ -122,7 +122,7 @@ bool PythonScripting::exec (const QString &code, PyObject *argDict, const char *
 	else
 		args = globals;
 	PyObject *tmp = NULL;
-	PyObject *co = Py_CompileString(code.toAscii().constData(), name, Py_file_input);
+	PyObject *co = Py_CompileString(code.toUtf8().constData(), name, Py_file_input);
 	if (co)
 	{
 		tmp = PyEval_EvalCode(PYCodeObject_cast co, globals, args);

--- a/libscidavis/src/PythonScripting.cpp
+++ b/libscidavis/src/PythonScripting.cpp
@@ -91,7 +91,7 @@ QString PythonScripting::toString(PyObject *object, bool decref)
 	PyObject *repr = PyObject_Str(object);
 	if (decref) Py_DECREF(object);
 	if (!repr) return "";
-	ret = PyString_AsString(repr);
+	ret = PYSTRING_AsString(repr);
 	Py_DECREF(repr);
 	return ret;
 }
@@ -173,9 +173,9 @@ QString PythonScripting::errorMsg()
 		while (excit && (PyObject*)excit != Py_None)
 		{
 			frame = excit->tb_frame;
-			msg.append("at ").append(PyString_AsString(frame->f_code->co_filename));
+			msg.append("at ").append(PYSTRING_AsString(frame->f_code->co_filename));
 			msg.append(":").append(QString::number(excit->tb_lineno));
-			if (frame->f_code->co_name && *(fname = PyString_AsString(frame->f_code->co_name)) != '?')
+			if (frame->f_code->co_name && *(fname = PYSTRING_AsString(frame->f_code->co_name)) != '?')
 				msg.append(" in ").append(fname);
 			msg.append("\n");
 			excit = excit->tb_next;
@@ -339,8 +339,8 @@ bool PythonScripting::loadInitFile(const QString &path)
 			PyObject *compile = PyDict_GetItemString(PyModule_GetDict(compileModule), "compile");
 			if (compile) {
 				PyObject *tmp = PyObject_CallFunctionObjArgs(compile,
-						PyString_FromString(pyFile.filePath()),
-						PyString_FromString(pycFile.filePath()),
+						PYSTRING_FromString(pyFile.filePath().toUtf8().constData()),
+						PYSTRING_FromString(pycFile.filePath().toUtf8().constData()),
 						NULL);
 				if (tmp)
 					Py_DECREF(tmp);
@@ -438,7 +438,7 @@ const QStringList PythonScripting::mathFunctions() const
 #endif
 	while(PyDict_Next(math, &i, &key, &value))
 		if (PyCallable_Check(value))
-			flist << PyString_AsString(key);
+			flist << PYSTRING_AsString(key);
 	flist.sort();
 	return flist;
 }
@@ -448,7 +448,7 @@ const QString PythonScripting::mathFunctionDoc(const QString &name) const
 	PyObject *mathf = PyDict_GetItemString(math,name); // borrowed
 	if (!mathf) return "";
 	PyObject *pydocstr = PyObject_GetAttrString(mathf, "__doc__"); // new
-	QString qdocstr = PyString_AsString(pydocstr);
+	QString qdocstr = PYSTRING_AsString(pydocstr);
 	Py_XDECREF(pydocstr);
 	return qdocstr;
 }

--- a/libscidavis/src/PythonScripting.cpp
+++ b/libscidavis/src/PythonScripting.cpp
@@ -65,10 +65,21 @@ typedef struct _traceback {
 #include "sipAPIscidavis.h"
 extern "C" 
 {
+#if PY_MAJOR_VERSION < 3
   void initsip();
   void initQtCore();
   void initQtGui();
   void initscidavis();
+#define PYSTRING_AsString   PyString_AsString
+#define PYSTRING_FromString PyString_FromString
+#define PYLong_AsLong       PyInt_AsLong
+#define PYCodeObject_cast   (PyCodeObject*)
+#else
+#define PYSTRING_AsString   PyUnicode_AsUTF8
+#define PYSTRING_FromString PyUnicode_FromString
+#define PYLong_AsLong       PyLong_AsLong
+#define PYCodeObject_cast
+#endif
 }
 
 const char* PythonScripting::langName = "Python";

--- a/libscidavis/src/PythonScripting.cpp
+++ b/libscidavis/src/PythonScripting.cpp
@@ -148,7 +148,7 @@ QString PythonScripting::errorMsg()
 		QString text = toString(PyObject_GetAttrString(value, "text"), true);
 		msg.append(text + "\n");
 		PyObject *offset = PyObject_GetAttrString(value, "offset");
-		for (int i=0; i<(PyInt_AsLong(offset)-1); i++)
+		for (int i=0; i<(PYLong_AsLong(offset)-1); i++)
 			if (text[i] == '\t')
 				msg.append("\t");
 			else

--- a/libscidavis/src/ScriptEdit.cpp
+++ b/libscidavis/src/ScriptEdit.cpp
@@ -176,8 +176,6 @@ void ScriptEdit::insertErrorMsg(const QString &message)
 
 void ScriptEdit::scriptPrint(const QString &text)
 {
-	if(lineNumber(printCursor.position()) == lineNumber(textCursor().selectionEnd()))
-		printCursor.insertText("\n");
 	printCursor.insertText(text);
 }
 
@@ -233,6 +231,7 @@ void ScriptEdit::execute()
 	myScript->setCode(codeCursor.selectedText().replace(QChar::ParagraphSeparator,"\n"));
 	printCursor.setPosition(codeCursor.selectionEnd(), QTextCursor::MoveAnchor);
 	printCursor.movePosition(QTextCursor::EndOfLine, QTextCursor::MoveAnchor);
+	printCursor.insertText("\n");
 	myScript->exec();
 	d_changing_fmt = true;
 	if (d_error)
@@ -250,6 +249,7 @@ bool ScriptEdit::executeAll()
 	myScript->setName(fname);
 	myScript->setCode(text());
 	printCursor.movePosition(QTextCursor::End, QTextCursor::MoveAnchor);
+	printCursor.insertText("\n");
 	return myScript->exec();
 }
 
@@ -268,6 +268,7 @@ void ScriptEdit::evaluate()
 	myScript->setCode(codeCursor.selectedText().replace(QChar::ParagraphSeparator,"\n"));
 	printCursor.setPosition(codeCursor.selectionEnd(), QTextCursor::MoveAnchor);
 	printCursor.movePosition(QTextCursor::EndOfLine, QTextCursor::MoveAnchor);
+	printCursor.insertText("\n");
 	QVariant res = myScript->eval();
 
 	d_changing_fmt = true;

--- a/libscidavis/src/scidavis.sip
+++ b/libscidavis/src/scidavis.sip
@@ -135,13 +135,13 @@ class Column: AbstractAspect
 		SIP_PYOBJECT dataType() const;
 %MethodCode
 		int mode = sipCpp->dataType();
-  		sipRes = PyString_FromString(SciDAVis::enumValueToString(mode, "ColumnDataType"));
+		sipRes = PYSTRING_FromString(SciDAVis::enumValueToString(mode, "ColumnDataType").toUtf8().constData());
 %End
 */
 		SIP_PYOBJECT columnMode() const;
 %MethodCode
 		int mode = sipCpp->columnMode();
-  		sipRes = PyString_FromString(SciDAVis::enumValueToString(mode, "ColumnMode"));
+		sipRes = PYSTRING_FromString(SciDAVis::enumValueToString(mode, "ColumnMode").toUtf8().constData());
 %End
 		void setColumnMode(QString mode);
 %MethodCode
@@ -161,7 +161,7 @@ class Column: AbstractAspect
 		{
 			filterformat = filter->format();
 		}
-		sipRes = PyString_FromString(filterformat.toUtf8().constData());
+		sipRes = PYSTRING_FromString(filterformat.toUtf8().constData());
 %End
 		void setColumnFormat(QString cformat);
 %MethodCode
@@ -173,7 +173,7 @@ class Column: AbstractAspect
 		SIP_PYOBJECT plotDesignation() const;
 %MethodCode
 		int pd = sipCpp->plotDesignation();
-  		sipRes = PyString_FromString(SciDAVis::enumValueToString(pd, "PlotDesignation"));
+		sipRes = PYSTRING_FromString(SciDAVis::enumValueToString(pd, "PlotDesignation").toUtf8().constData());
 %End
 		void setPlotDesignation(QString pd);
 %MethodCode
@@ -250,7 +250,7 @@ public:
 
   SIP_PYOBJECT windowLabel();
 %MethodCode
-  sipRes = PyString_FromString(sipCpp->windowLabel());
+  sipRes = PYSTRING_FromString(sipCpp->windowLabel().toUtf8().constData());
 %End
   void setWindowLabel(const QString&);
 
@@ -276,7 +276,7 @@ public:
   /*
   virtual SIP_PYOBJECT saveAsTemplate(const QString& );
 %MethodCode
-  sipRes = PyString_FromString(sipCpp->saveAsTemplate(*a0));
+  sipRes = PYSTRING_FromString(sipCpp->saveAsTemplate(*a0).toUtf8().constData());
 %End
 */
   // same issues as with saveAsTemplate
@@ -312,10 +312,10 @@ class Table: MyWidget
 			sipIsErr = 1;\
 			PyErr_Format(PyExc_TypeError, "Column argument must be either int or string.");\
 		} else {\
-			col = sipCpp->colNames().indexOf(PyString_AsString(tmp));\
+			col = sipCpp->colNames().indexOf(PYSTRING_AsString(tmp));\
 			if (col < 0) {\
 				sipIsErr = 1;\
-				PyErr_Format(PyExc_ValueError, "There's no column named %s in table %s!", PyString_AsString(tmp),\
+				PyErr_Format(PyExc_ValueError, "There's no column named %s in table %s!", PYSTRING_AsString(tmp),\
 						sipCpp->name().toAscii().constData());\
 				Py_DECREF(tmp);\
 			}\
@@ -359,12 +359,8 @@ public:
   CHECK_TABLE_COL(a0);
   CHECK_TABLE_ROW(a1);
   if (sipIsErr == 0) {
-		PyObject *encstr = PyString_FromString(sipCpp->text(row, col).utf8());
-		if (encstr) {
-			sipRes = PyUnicode_FromEncodedObject(encstr, "utf8", 0);
-			Py_DECREF(encstr);
-		} else {
-			sipRes = NULL;
+		sipRes = PYSTRING_FromString(sipCpp->text(row, col).toUtf8().constData());
+		if (!sipRes) {
 			sipIsErr = 1;
 		}
 	}
@@ -399,7 +395,7 @@ public:
 		sipIsErr = 1;\
 		PyErr_SetString(PyExc_ValueError, "Invalid column argument");\
 	} else
-		sipRes = PyString_FromString(sipCpp->colLabel(a0-1));
+		sipRes = PYSTRING_FromString(sipCpp->colLabel(a0-1).toUtf8().constData());
 %End
   void setColName(SIP_PYOBJECT, const QString&) /Deprecated/;
 %MethodCode
@@ -458,7 +454,7 @@ public:
   for (int i=0; i<n; i++) {
 	  PyObject *str = PyObject_Str(PyTuple_GET_ITEM(a0,i));
 	  if (str) {
-		  cols << sipCpp->column(PyString_AsString(str));
+		  cols << sipCpp->column(PYSTRING_AsString(str));
 		  Py_DECREF(str);
 	  } else {
 		  sipIsErr = 1;
@@ -517,7 +513,7 @@ public:
 	CHECK_MATRIX_ROW(a0);
 	CHECK_MATRIX_COL(a1);
 	if (sipIsErr == 0)
-		sipRes = PyString_FromString(sipCpp->text(row, col));
+		sipRes = PYSTRING_FromString(sipCpp->text(row, col).toUtf8().constData());
 %End
   double cell(int, int);
 %MethodCode
@@ -917,7 +913,7 @@ public:
   bool isPiePlot();
   SIP_PYOBJECT pieLegendText() /PyName=pieLegend/;
 %MethodCode
-  sipRes = PyString_FromString(sipCpp->pieLegendText());
+  sipRes = PYSTRING_FromString(sipCpp->pieLegendText().toUtf8().constData());
 %End
 
   bool insertCurve(Table*, const QString&, int=1, int color=-1);
@@ -1240,7 +1236,7 @@ public:
   for (int i=0; i<n; i++) {
     PyObject *str = PyObject_Str(PyTuple_GET_ITEM(a1,i));
     if (str) {
-      l << PyString_AsString(str);
+      l << PYSTRING_AsString(str);
 		Py_DECREF(str);
 	 } else {
       sipIsErr = 1;
@@ -1570,7 +1566,7 @@ public:
   QStringList l;
   char *item;
   for (int i=0; i<PyTuple_GET_SIZE(a0); i++)
-    if ((item = PyString_AsString(PyTuple_GET_ITEM(a0, i))))
+    if ((item = PYSTRING_AsString(PyTuple_GET_ITEM(a0, i))))
       l << item;
     else
       sipIsErr = 1;

--- a/libscidavis/src/scidavis.sip
+++ b/libscidavis/src/scidavis.sip
@@ -35,6 +35,21 @@
 %Import QtCore/QtCoremod.sip
 %Import QtGui/QtGuimod.sip
 
+%ModuleHeaderCode
+#if PY_MAJOR_VERSION >= 3
+#define PYSTRING_AsString   PyUnicode_AsUTF8
+#define PYSTRING_FromString PyUnicode_FromString
+#define PYLong_Check        PyLong_Check
+#define PYLong_AsLong       PyLong_AsLong
+#else
+#define PYSTRING_AsString   PyString_AsString
+#define PYSTRING_FromString PyString_FromString
+#define PYLong_Check        PyInt_Check
+#define PYLong_AsLong       PyInt_AsLong
+#endif
+%End
+
+
 class AbstractAspect : QObject
 {
 %TypeHeaderCode

--- a/libscidavis/src/scidavis.sip
+++ b/libscidavis/src/scidavis.sip
@@ -300,8 +300,8 @@ class Table: MyWidget
 
 #define CHECK_TABLE_COL(arg)\
     int col;\
-    if (PyInt_Check(arg)) {\
-      col = (int)PyInt_AsLong(arg) - 1;\
+    if (PYLong_Check(arg)) {\
+      col = (int)PYLong_AsLong(arg) - 1;\
 		if (col < 0 || col >= sipCpp->numCols()) {\
 			sipIsErr = 1;\
 			PyErr_Format(PyExc_ValueError, "There's no column %d in table %s!", col+1, sipCpp->name().toAscii().constData());\

--- a/scidavis/python.pri
+++ b/scidavis/python.pri
@@ -23,15 +23,20 @@
   DEFINES += SCRIPTING_PYTHON
 
   message("Making PyQt bindings via SIP")
+  PYTHONBIN = $$(PYTHON)
+  isEmpty( PYTHONBIN ) {
+    PYTHONBIN = python
+  }
+
   unix {
-    INCLUDEPATH += $$system(python-config --includes|sed -e 's/-I//')
+    INCLUDEPATH += $$system($$PYTHONBIN-config --includes|sed -e 's/-I//')
     osx_dist {
       DEFINES += PYTHONHOME=/Applications/scidavis.app/Contents/Resources
     } else {
       macx {
         LIBS += -framework Python
       } else {
-        LIBS += $$system(python -c "\"from distutils import sysconfig; print '-lpython'+sysconfig.get_config_var('VERSION')\"")
+        LIBS += $$system($$PYTHONBIN -c "\"from distutils import sysconfig;import sys; sys.stdout.write('-lpython'+sysconfig.get_config_var('VERSION')+(sysconfig.get_config_var('ABIFLAGS') or ''))\"")
       }
     }     
     LIBS        += -lm

--- a/scidavis/scidavisrc.py
+++ b/scidavis/scidavisrc.py
@@ -28,6 +28,7 @@
 #                                                                          #
 ############################################################################
 
+from __future__ import print_function
 import __main__
 
 def import_to_global(modname, attrs=None, math=False):
@@ -321,7 +322,7 @@ import sys
 sys.path.append(".")
 try:
 	import_to_global("scidavisUtil")
-	print "scidavisUtil successfully imported"
+	print("scidavisUtil successfully imported")
 except(ImportError): 
-	print "failed to import scidavisUtil"
+	print("failed to import scidavisUtil")
 

--- a/test/pythonTests/integration_with_python-crash.py
+++ b/test/pythonTests/integration_with_python-crash.py
@@ -6,7 +6,7 @@ curveName="Table1_2"
 integral = Integration(g.activeLayer(),curveName,lower_limit,upper_limit)
 integral.setMethod(0) #method = 1 -> Linear interpolation
 integral.run()
-print "#",integral.result()
+print("#",integral.result())
 app.exit()
 # 10.2358922829 : area calculated running this script in SciDAVis 1.21. Exactly the
 # same result obtained using Analysis -> Integrate... using both 1.21 and 1.22 versions

--- a/test/pythonTests/linear_and_polynomial_fits.py
+++ b/test/pythonTests/linear_and_polynomial_fits.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 # Script to test linear and polynomial fits
 
 import random
@@ -31,6 +32,6 @@ f2=PolynomialFit(l1,curve1,5) #polynomial fit of degree 5
 f2.setColor("blue")
 f2.fit()
 
-print "#","linear coef. =",f1.results()[0]," ± ",f1.errors()[0],"\n# angular coef. =",f1.results()[1]," ± ",f1.errors()[1]
+print("#","linear coef. =",f1.results()[0]," ± ",f1.errors()[0],"\n# angular coef. =",f1.results()[1]," ± ",f1.errors()[1])
 g1.exportImage("linearAndPolyFits.png")
 app.exit()

--- a/test/pythonTests/nonlinear_and_gauss_fits.py
+++ b/test/pythonTests/nonlinear_and_gauss_fits.py
@@ -34,7 +34,7 @@ t1.confirmClose(False)
 f1=GaussFit(l1,curve1) #Gauss fit
 f1.setInitialValues(11,49.1,11,1) #*
 f1.fit()
-print f1.chiSquare()
+print(f1.chiSquare())
 #assert f1.chiSquare() < 1e-4,"f1.chiSquare() >=1e-4"
 assert f1.rSquare() > 0.99,"f1.rSquare() >= 0.99"
 

--- a/test/test.pro
+++ b/test/test.pro
@@ -24,11 +24,16 @@ OBJECTS_DIR    = ../tmp/test
 
 include(../config.pri)
 python {
+  PYTHONBIN = $$(PYTHON)
+  isEmpty( PYTHONBIN ) {
+    PYTHONBIN = python
+  }
+
   unix {
         macx {
         LIBS += -framework Python
       } else {
-        LIBS += $$system(python -c "\"from distutils import sysconfig; print '-lpython'+sysconfig.get_config_var('VERSION')\"")
+        LIBS += $$system($$PYTHONBIN -c "\"from distutils import sysconfig;import sys; sys.stdout.write('-lpython'+sysconfig.get_config_var('VERSION')+(sysconfig.get_config_var('ABIFLAGS') or ''))\"")
       }
   }
 }


### PR DESCRIPTION
The code allows to build SciDAVis with either python2 or python3 support from the same code basis.
To build with python3.6:
>   export PYTHON=python3
>   qmake PRESET=... CONFIG+=python ...
>   make

To build with python2.7:
>   export PYTHON=python2
>   qmake PRESET=... CONFIG+=python ...
>   make

Default build, with PYTHON not defined will be for the system's default version (command 'python')
