### PR TITLE
Load SciDAVis internal functions first and temporarily remove Spherical Bessel functions in scidavisrc.py

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # SciDAVis changelog
 
+=== Release 1.23 - 2018-06-04 ===
+- Bug fix release;
+- added Python 3 support
+- dropped Qt3 support
+- Russian translation updated
+- Origin import support updated
+
 # The events below are more for historical reference than for recording changes in SciDAVis
 
 # Changelog between versions 1.D1 and 1.22

--- a/scidavis/scidavisrc.py
+++ b/scidavis/scidavisrc.py
@@ -50,6 +50,84 @@ def import_to_global(modname, attrs=None, math=False):
 # Import standard math functions and constants into global namespace.
 import_to_global("math", None, True)
 
+# make Qt API available (it gets imported in any case by the scidavis module)
+global QtGui
+from PyQt4 import QtGui
+
+global QtCore
+from PyQt4 import QtCore
+
+global Qt
+from PyQt4.QtCore import Qt
+
+# import SciDAVis' classes to the global namespace (particularly useful for fits)
+for name in dir(__main__.scidavis):
+	setattr(__main__, name, getattr(__main__.scidavis, name))
+
+# import selected methods of ApplicationWindow into the global namespace
+appImports = (
+	"table", "newTable",
+	"matrix", "newMatrix",
+	"graph", "newGraph",
+	"note", "newNote",
+	"plot", "plotContour", "plotColorMap", "plotGrayScale",
+	"activeFolder", "rootFolder", "saveFolder",
+	"renameWindow", "clone",
+	"importImage"
+	)
+for name in appImports:
+	setattr(__main__,name,getattr(__main__.scidavis.app,name))
+
+# make Y columns indexable (using lookup in corresponding X column)
+def __column_getitem(self, index):
+  if self.plotDesignation() != "Y":
+    return None
+  x = self.x()
+  for row in range(self.rowCount()):
+      if x.columnMode() == "Numeric":
+          xval = x.valueAt(row)
+      elif x.columnMode() == "Text":
+          xval = x.textAt(row)
+      else:
+          xval = x.dateTimeAt(row)
+      if xval == index:
+          if self.columnMode() == "Numeric":
+              return self.valueAt(row)
+          elif self.columnMode() == "Text":
+              return self.textAt(row)
+          else:
+              return self.dateTimeAt(row)
+__main__.scidavis.Column.__getitem__ = __column_getitem
+
+def __column_setitem(self, index, value):
+  if self.plotDesignation() != "Y":
+    return None
+  x = self.x()
+  for row in range(x.rowCount()):
+      if x.columnMode() == "Numeric":
+          xval = x.valueAt(row)
+      elif x.columnMode() == "Text":
+          xval = x.textAt(row)
+      else:
+          xval = x.dateTimeAt(row)
+      if xval == index:
+          if self.columnMode() == "Numeric":
+              return self.setValueAt(row, value)
+          elif self.columnMode() == "Text":
+              return self.setTextAt(row, value)
+          else:
+              return self.setDateTimeAt(row, value)
+__main__.scidavis.Column.__setitem__ = __column_setitem
+
+# import utility module
+import sys
+sys.path.append(".")
+try:
+	import_to_global("scidavisUtil")
+	print("scidavisUtil successfully imported")
+except(ImportError): 
+	print("failed to import scidavisUtil")
+
 # Import selected parts of scipy.special (if available) into global namespace.
 # See www.scipy.org for information on SciPy and how to get it.
 have_scipy = False
@@ -76,7 +154,11 @@ try:
 		# Derivatives of Bessel Functions
 		"jvp", "yvp", "kvp", "ivp", "h1vp", "h2vp",
 		# Spherical Bessel Functions
-		"sph_jn", "sph_yn", "sph_jnyn", "sph_in", "sph_kn", "sph_inkn",
+		## if scipy version is < 1.0.0
+		#"sph_jn", "sph_yn", "sph_jnyn", "sph_in", "sph_kn", "sph_inkn",
+		## else
+		#"spherical_jn", "spherical_yn", "spherical_in", "spherical_kn",
+		### removing SBFs for a while, until someone finds a way for these two options to coexist
 		# Ricatti-Bessel Functions
 		"riccati_jn", "riccati_yn",
 		# Struve Functions
@@ -246,83 +328,3 @@ try:
 		import_to_global("pygsl.sf", special_functions_doublets, True)
 		print("Loaded %d special functions from pygsl.sf." % (len(special_functions) + len(special_functions_doublets)))
 except(ImportError): pass
-
-
-# make Qt API available (it gets imported in any case by the scidavis module)
-global QtGui
-from PyQt4 import QtGui
-
-global QtCore
-from PyQt4 import QtCore
-
-global Qt
-from PyQt4.QtCore import Qt
-
-# import SciDAVis' classes to the global namespace (particularly useful for fits)
-for name in dir(__main__.scidavis):
-	setattr(__main__, name, getattr(__main__.scidavis, name))
-
-# import selected methods of ApplicationWindow into the global namespace
-appImports = (
-	"table", "newTable",
-	"matrix", "newMatrix",
-	"graph", "newGraph",
-	"note", "newNote",
-	"plot", "plotContour", "plotColorMap", "plotGrayScale",
-	"activeFolder", "rootFolder", "saveFolder",
-	"renameWindow", "clone",
-	"importImage"
-	)
-for name in appImports:
-	setattr(__main__,name,getattr(__main__.scidavis.app,name))
-
-# make Y columns indexable (using lookup in corresponding X column)
-def __column_getitem(self, index):
-  if self.plotDesignation() != "Y":
-    return None
-  x = self.x()
-  for row in range(self.rowCount()):
-      if x.columnMode() == "Numeric":
-          xval = x.valueAt(row)
-      elif x.columnMode() == "Text":
-          xval = x.textAt(row)
-      else:
-          xval = x.dateTimeAt(row)
-      if xval == index:
-          if self.columnMode() == "Numeric":
-              return self.valueAt(row)
-          elif self.columnMode() == "Text":
-              return self.textAt(row)
-          else:
-              return self.dateTimeAt(row)
-__main__.scidavis.Column.__getitem__ = __column_getitem
-
-def __column_setitem(self, index, value):
-  if self.plotDesignation() != "Y":
-    return None
-  x = self.x()
-  for row in range(x.rowCount()):
-      if x.columnMode() == "Numeric":
-          xval = x.valueAt(row)
-      elif x.columnMode() == "Text":
-          xval = x.textAt(row)
-      else:
-          xval = x.dateTimeAt(row)
-      if xval == index:
-          if self.columnMode() == "Numeric":
-              return self.setValueAt(row, value)
-          elif self.columnMode() == "Text":
-              return self.setTextAt(row, value)
-          else:
-              return self.setDateTimeAt(row, value)
-__main__.scidavis.Column.__setitem__ = __column_setitem
-
-# import utility module
-import sys
-sys.path.append(".")
-try:
-	import_to_global("scidavisUtil")
-	print("scidavisUtil successfully imported")
-except(ImportError): 
-	print("failed to import scidavisUtil")
-


### PR DESCRIPTION
I faced an issue when running SciDAVis with SciPy 1.1.0 installed: SciDAVis internal functions were not loaded because Spherical Bessel functions changed name or were deprecated since SciPy 1.0.0 [1] and this caused errors that prevented the loading of the rest of the "scidavisrc.py" script. By changing the load order solved my problem (and can solve that of others too).
I also thought it would be better to remove Spherical Bessel functions from "scidavisrc.py" in order to avoid any other possible issue with deprecated functions in SciPy, whose versions are notably different among Linux distributions.
SciPy versions < 1.0.0 use "sph_jn", "sph_yn", "sph_jnyn", "sph_in", "sph_kn", "sph_inkn" while SciPy versions >= 1.0.0 use "spherical_jn", "spherical_yn", "spherical_in", "spherical_kn"

[1] https://github.com/scipy/scipy/releases/tag/v1.0.0 - see "Deprecated features"
