### PR TITLE
Fix bug #337: Fonts getting bigger after restore/minimize action

### DIFF
--- a/libscidavis/src/Graph.cpp
+++ b/libscidavis/src/Graph.cpp
@@ -112,6 +112,7 @@ Graph::Graph(QWidget* parent, QString name, Qt::WFlags f)
 	drawAxesBackbone = true;
 	m_autoscale = true;
 	autoScaleFonts = false;
+	hidden_size = QSize();
 	d_antialiasing = true;
 	d_scale_on_print = true;
 	d_print_cropmarks = false;
@@ -4085,15 +4086,24 @@ void Graph::updateMarkersBoundingRect()
 	}
 	d_plot->replot();
 }
+void Graph::hideEvent(QHideEvent *e)
+{
+	Q_UNUSED(e);
+	hidden_size = size();
+}
 
 void Graph::resizeEvent ( QResizeEvent *e )
 {
-	if (ignoreResize || !this->isVisible())
+	if (ignoreResize)
+		return;
+	QSize oldSize=e->oldSize();
+	if (!this->isVisible() || !oldSize.isValid())
+		oldSize = hidden_size;
+	if (!oldSize.isValid())
 		return;
 
 	if (autoScaleFonts)
 	{
-		QSize oldSize=e->oldSize();
 		QSize size=e->size();
 
 		double ratio=(double)size.height()/(double)oldSize.height();

--- a/libscidavis/src/Graph.h
+++ b/libscidavis/src/Graph.h
@@ -641,6 +641,7 @@ public slots:
 		bool ignoresResizeEvents(){return ignoreResize;};
 		void setIgnoreResizeEvents(bool ok){ignoreResize=ok;};
 		void resizeEvent(QResizeEvent *e);
+		void hideEvent(QHideEvent *e);
 		void scaleFonts(double factor);
 		//@}
 
@@ -729,6 +730,7 @@ signals:
 		//! Render hint for plot items.
 		bool d_antialiasing;
 		bool autoScaleFonts;
+		QSize hidden_size;
 		bool d_scale_on_print, d_print_cropmarks;
 		int selectedAxis;
 		QStringList axesFormulas;


### PR DESCRIPTION
Minimizing a window does not trigger a resizeEvent, but a hideEvent.
Thus the added code tracks window size before gets hidden.