### PR TITLE
Fix bug #341: continued.

### DIFF
--- a/libscidavis/src/future/table/future_Table.cpp
+++ b/libscidavis/src/future/table/future_Table.cpp
@@ -498,7 +498,7 @@ void Table::pasteIntoSelection()
 			}
 
 			// regular expression for numeric data
-			QRegExp floatorintrx = QRegExp("^[-+]?(?=.*\\d)\\d*\\.?\\d*([eE][-+]?\\d+)?$");
+			QRegExp floatorintrx = QRegExp("^[-+]?(?=[^eE]*\\d)\\d*\\.?\\d*([eE][-+]?\\d+)?$");
 			for (int c=0; c<cols && c<input_col_count; c++)
 			{
 				Column * col_ptr = d_table_private.column(first_col + c);


### PR DESCRIPTION
The regex still had a flaw. 
My initial idea was to prevent '.' match the regex, but after your comment I realised that '+.E3' matches and should not.
Hence, a new regex is needed.
