### PR TITLE
Qt4 to Qt5, third step

### DIFF
--- a/config.pri
+++ b/config.pri
@@ -281,9 +281,19 @@ contains(PRESET, linux_package) {
 	### Mixing Qt 4.2 and Qt >= 4.3 compiled stuff may also 
 	### cause problems.
 
-	exists(/usr/include/qwt5) {INCLUDEPATH+=/usr/include/qwt5} 
+    equals(QT_MAJOR_VERSION, 5) {
+        exists(/usr/include/qwt5-qt5) {INCLUDEPATH+=/usr/include/qwt5-qt5}
+
+        system (ls /usr/lib*/libqwt5-qt5.so) {
+            LIBS+=-lqwt5-qt5
+        }
+        system (ls /usr/lib*/libqwtplot3d-qt5.so) {
+         LIBS+=-lqwtplot3d-qt5
+        }
+    } else {
+        exists(/usr/include/qwt5) {INCLUDEPATH+=/usr/include/qwt5}
         exists (/usr/include/qwt-qt4) {INCLUDEPATH+=/usr/include/qwt-qt4}
-	exists(/usr/include/qwt5-qt4) {INCLUDEPATH+=/usr/include/qwt5-qt4}
+        exists(/usr/include/qwt5-qt4) {INCLUDEPATH+=/usr/include/qwt5-qt4}
 
         system (ls /usr/lib*/libqwt5.so) {
            LIBS+=-lqwt5
@@ -302,6 +312,7 @@ contains(PRESET, linux_package) {
         } else {
          LIBS+=-lqwtplot3d
         }
+    }
 
         INCLUDEPATH = "$(HOME)/usr/include" $$INCLUDEPATH
         QMAKE_LIBDIR = "$(HOME)/usr/lib" $$QMAKE_LIBDIR

--- a/libscidavis/libscidavis.pro
+++ b/libscidavis/libscidavis.pro
@@ -1,9 +1,7 @@
 # enable C++11 support
-greaterThan(QT_MAJOR_VERSION, 3){
-  CONFIG += c++11
-} else {
-  QMAKE_CXXFLAGS += -std=c++0x
-}
+equals(QT_MAJOR_VERSION, 5) { CONFIG += c++11 }
+equals(QT_MAJOR_VERSION, 4) { QMAKE_CXXFLAGS += -std=c++11 }
+equals(QT_MAJOR_VERSION, 3) { QMAKE_CXXFLAGS += -std=c++0x }
 
 TEMPLATE=lib
 CONFIG+=staticlib uic

--- a/libscidavis/libscidavis.pro
+++ b/libscidavis/libscidavis.pro
@@ -1,5 +1,5 @@
 # enable C++11 support
-greaterThan(QT_MAJOR_VERSION, 4){
+greaterThan(QT_MAJOR_VERSION, 3){
   CONFIG += c++11
 } else {
   QMAKE_CXXFLAGS += -std=c++0x
@@ -8,7 +8,7 @@ greaterThan(QT_MAJOR_VERSION, 4){
 TEMPLATE=lib
 CONFIG+=staticlib uic
 TARGET=scidavis
-QMAKE_CLEAN+=${TARGET}
+QMAKE_CLEAN += $$TARGET
 
 include(../config.pri)
 

--- a/libscidavis/libscidavis.pro
+++ b/libscidavis/libscidavis.pro
@@ -31,7 +31,9 @@ DEFINES       += MANUAL_PATH="\\\"$$replace(manual.path," ","\\ ")\\\""
 !mxe {
      win32:DEFINES += QT_DLL QT_THREAD_SUPPORT
 }
+
 QT            += opengl network svg xml
+equals(QT_MAJOR_VERSION, 5) { QT += printsupport }
 
 MOC_DIR        = ../tmp/scidavis
 OBJECTS_DIR    = ../tmp/libscidavis

--- a/libscidavis/python-sipcmd.py
+++ b/libscidavis/python-sipcmd.py
@@ -34,6 +34,9 @@ try:
 except IndexError:
     pyqt = 'PyQt4'
 
+if (pyqt not in ['PyQt4','PyQt5']):
+    pyqt = 'PyQt4'
+
 try:
     exec("from "+pyqt+".QtCore import PYQT_CONFIGURATION")
 except ImportError:

--- a/libscidavis/python.pri
+++ b/libscidavis/python.pri
@@ -27,13 +27,13 @@
       DEFINES += PYTHONHOME=/Applications/scidavis.app/Contents/Resources
     } 
     system(mkdir -p $${SIP_DIR})
-    system($$system($$PYTHONBIN python-sipcmd.py) $$system($$PYTHONBIN-config --includes) -c $${SIP_DIR}  src/scidavis.sip)
+    system($$system($$PYTHONBIN python-sipcmd.py PyQt$$QT_MAJOR_VERSION) $$system($$PYTHONBIN-config --includes) -c $${SIP_DIR}  src/scidavis.sip)
   }
 
   win32 {
   mxe {
      DEFINES += SIP_STATIC_MODULE
-    system($$system($$PYTHONBIN python-sipcmd.py) -c $${SIP_DIR} src/scidavis.sip)
+    system($$system($$PYTHONBIN python-sipcmd.py PyQt$$QT_MAJOR_VERSION) -c $${SIP_DIR} src/scidavis.sip)
   } else {
     INCLUDEPATH += $$system(call ../python-includepath.py)
     # TODO: fix the command below (only really necessary if SIP_DIR != MOC/OBJECTS_DIR)

--- a/libscidavis/python.pri
+++ b/libscidavis/python.pri
@@ -22,7 +22,7 @@
   }
 
   unix {
-    INCLUDEPATH += $$system($$PYTHONBIN-config --includes|sed -e 's/-I//')
+    INCLUDEPATH += $$system($$PYTHONBIN-config --includes|sed -e 's/-I//g')
     osx_dist {
       DEFINES += PYTHONHOME=/Applications/scidavis.app/Contents/Resources
     } 

--- a/libscidavis/src/ApplicationWindow.cpp
+++ b/libscidavis/src/ApplicationWindow.cpp
@@ -241,12 +241,17 @@ ApplicationWindow::ApplicationWindow()
 	folders->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
 	folders->setContextMenuPolicy(Qt::CustomContextMenu);
 
-	folders->header()->setClickable( false );
 	folders->setHeaderLabels(QStringList() << tr("Folder") << QString() );
 	folders->setRootIsDecorated( true );
 	folders->setColumnWidth(1,0); // helps autoScroll
 	folders->hideColumn(1); // helps autoScroll
+#if QT_VERSION >= 0x050000
+	folders->header()->setSectionsClickable( false );
+	folders->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
+#else
+	folders->header()->setClickable( false );
 	folders->header()->setResizeMode(QHeaderView::ResizeToContents);
+#endif
 	folders->header()->hide();
 	folders->setSelectionMode(QTreeWidget::SingleSelection);
 

--- a/libscidavis/src/ApplicationWindow.cpp
+++ b/libscidavis/src/ApplicationWindow.cpp
@@ -4212,7 +4212,7 @@ void ApplicationWindow::readSettings()
 	QLocale::setDefault(temp_locale);
 
 	d_decimal_digits = settings.value("/DecimalDigits", 6).toInt();
-	d_default_numeric_format = settings.value("/DefaultNumericFormat", 'g').toChar().toAscii();
+	d_default_numeric_format = settings.value("/DefaultNumericFormat", 'g').toChar().toLatin1();
 
 	//restore geometry of main window
 	restoreGeometry(settings.value("/ProjectWindow/Geometry").toByteArray());

--- a/libscidavis/src/ApplicationWindow.cpp
+++ b/libscidavis/src/ApplicationWindow.cpp
@@ -1576,14 +1576,14 @@ void ApplicationWindow::setListViewLabel(const QString& caption,const QString& l
 {
 	QTreeWidgetItem *it=lv->findItems ( caption, Qt::MatchExactly | Qt::MatchCaseSensitive ).value(0);
 	if (it)
-		it->setText(5,label);
+		it->setText(4,label);
 }
 
 void ApplicationWindow::setListViewDate(const QString& caption,const QString& date)
 {
 	QTreeWidgetItem *it=lv->findItems ( caption, Qt::MatchExactly | Qt::MatchCaseSensitive ).value(0);
 	if (it)
-		it->setText(4,date);
+		it->setText(3,date);
 }
 
 void ApplicationWindow::setListView(const QString& caption,const QString& view)

--- a/libscidavis/src/ApplicationWindow.cpp
+++ b/libscidavis/src/ApplicationWindow.cpp
@@ -155,6 +155,7 @@
 #include <QDebug>
 #include <QTextCodec>
 #include <QScrollBar>
+#include <QMimeData>
 
 #include <zlib.h>
 

--- a/libscidavis/src/ApplicationWindow.h
+++ b/libscidavis/src/ApplicationWindow.h
@@ -461,6 +461,7 @@ public slots:
   static void about();
   //! Return a version string ("SciDAVis x.y.z")
   static QString versionString();
+  static int qtVersion() {return QT_VERSION;}
   void windowsMenuAboutToShow();
   void windowsMenuActivated( bool );
   void removeCurves(const QString& name);

--- a/libscidavis/src/AssociationsDialog.cpp
+++ b/libscidavis/src/AssociationsDialog.cpp
@@ -61,10 +61,17 @@ AssociationsDialog::AssociationsDialog( QWidget* parent, Qt::WindowFlags fl )
     vl->addLayout(hbox1);
 
 	table = new QTableWidget(3, 5);
+	table->verticalHeader()->hide();
+#if QT_VERSION >= 0x050000
+	table->horizontalHeader()->setSectionsClickable( false );
+	table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+	table->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+#else
 	table->horizontalHeader()->setClickable( false );
 	table->horizontalHeader()->setResizeMode(QHeaderView::Stretch);
-	table->verticalHeader()->hide();
 	table->verticalHeader()->setResizeMode(QHeaderView::ResizeToContents);
+#endif
+
 	table->setMaximumHeight(8*table->rowHeight(0));
 	table->setHorizontalHeaderLabels(QStringList() << tr("Column") << tr("X") << tr("Y") << tr("xErr") << tr("yErr"));
     vl->addWidget(table);

--- a/libscidavis/src/AxesDialog.cpp
+++ b/libscidavis/src/AxesDialog.cpp
@@ -1207,7 +1207,7 @@ bool AxesDialog::updatePlot()
 		try
 		{
 			MyParser parser;
-			parser.SetExpr(from.toAscii().constData());
+			parser.SetExpr(from.toUtf8().constData());
 			start=parser.Eval();
 		}
 		catch(mu::ParserError &e)
@@ -1219,7 +1219,7 @@ bool AxesDialog::updatePlot()
 		try
 		{
 			MyParser parser;
-			parser.SetExpr(to.toAscii().constData());
+			parser.SetExpr(to.toUtf8().constData());
 			end=parser.Eval();
 		}
 		catch(mu::ParserError &e)
@@ -1233,7 +1233,7 @@ bool AxesDialog::updatePlot()
 			try
 			{
 				MyParser parser;
-				parser.SetExpr(step.toAscii().constData());
+				parser.SetExpr(step.toUtf8().constData());
 				stp=parser.Eval();
 			}
 			catch(mu::ParserError &e)
@@ -1333,7 +1333,7 @@ bool AxesDialog::updatePlot()
 						parser.DefineVar("x", &value);
 					else if (formula.contains("y"))
 						parser.DefineVar("y", &value);
-					parser.SetExpr(formula.toAscii().constData());
+					parser.SetExpr(formula.toUtf8().constData());
 					parser.Eval();
 				}
 				catch(mu::ParserError &e)

--- a/libscidavis/src/ColorMapEditor.cpp
+++ b/libscidavis/src/ColorMapEditor.cpp
@@ -47,10 +47,16 @@ ColorMapEditor::ColorMapEditor(QWidget* parent)
 table = new QTableWidget();
 table->setColumnCount(2);
 table->setSelectionMode(QAbstractItemView::SingleSelection);
-table->verticalHeader()->setResizeMode(QHeaderView::ResizeToContents);
 table->verticalHeader()->hide();		
+#if QT_VERSION >= 0x050000
+table->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+table->horizontalHeader()->setSectionsClickable( false );
+table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+#else
+table->verticalHeader()->setResizeMode(QHeaderView::ResizeToContents);
 table->horizontalHeader()->setClickable( false );
 table->horizontalHeader()->setResizeMode(QHeaderView::Stretch);
+#endif
 table->viewport()->setMouseTracking(true);
 table->viewport()->installEventFilter(this);
 table->setHorizontalHeaderLabels(QStringList() << tr("Level") << tr("Color"));

--- a/libscidavis/src/ConfigDialog.cpp
+++ b/libscidavis/src/ConfigDialog.cpp
@@ -1145,7 +1145,7 @@ void ConfigDialog::apply()
 	int currentBoxIndex = boxDefaultNumericFormat->currentIndex();
 	if (currentBoxIndex > -1)
 	{
-		app->d_default_numeric_format = boxDefaultNumericFormat->itemData(currentBoxIndex).toChar().toAscii();
+		app->d_default_numeric_format = boxDefaultNumericFormat->itemData(currentBoxIndex).toChar().toLatin1();
 	}
 
     if(boxUseGroupSeparator->isChecked())

--- a/libscidavis/src/ExtensibleFileDialog.cpp
+++ b/libscidavis/src/ExtensibleFileDialog.cpp
@@ -35,6 +35,11 @@ ExtensibleFileDialog::ExtensibleFileDialog(QWidget *parent, bool extended, Qt::W
 {
 	d_extension = 0;
 
+#if QT_VERSION >= 0x050000
+	// needed to extend the Qt5 QFileDialog
+	setOption(QFileDialog::DontUseNativeDialog, true);
+#endif
+
 	d_extension_toggle = new QPushButton(tr("<< &Advanced"));
 	d_extension_toggle->setCheckable(true);
 	if (extended)

--- a/libscidavis/src/FFTDialog.cpp
+++ b/libscidavis/src/FFTDialog.cpp
@@ -139,7 +139,7 @@ void FFTDialog::accept()
   try
     {
       MyParser parser;
-      parser.SetExpr(boxSampling->text().toAscii().constData());
+      parser.SetExpr(boxSampling->text().toUtf8().constData());
       sampling=parser.Eval();
     }
   catch(mu::ParserError &e)

--- a/libscidavis/src/FilterDialog.cpp
+++ b/libscidavis/src/FilterDialog.cpp
@@ -115,7 +115,7 @@ double from = 0.0, to = 0.0;
 try
 	{
 	MyParser parser;
-	parser.SetExpr(boxStart->text().replace(",", ".").toAscii().constData());
+	parser.SetExpr(boxStart->text().replace(",", ".").toUtf8().constData());
 	from = parser.Eval();
 	}
 catch(mu::ParserError &e)

--- a/libscidavis/src/FitDialog.cpp
+++ b/libscidavis/src/FitDialog.cpp
@@ -114,13 +114,21 @@ void FitDialog::initFitPage()
 
 	boxParams = new QTableWidget();
     boxParams->setColumnCount(3);
+#if QT_VERSION >= 0x050000
+    boxParams->horizontalHeader()->setSectionsClickable(false);
+    boxParams->horizontalHeader()->setSectionResizeMode (0, QHeaderView::ResizeToContents);
+    boxParams->horizontalHeader()->setSectionResizeMode (1, QHeaderView::Stretch);
+    boxParams->horizontalHeader()->setSectionResizeMode (2, QHeaderView::ResizeToContents);
+    boxParams->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+#else
     boxParams->horizontalHeader()->setClickable(false);
     boxParams->horizontalHeader()->setResizeMode (0, QHeaderView::ResizeToContents);
     boxParams->horizontalHeader()->setResizeMode (1, QHeaderView::Stretch);
     boxParams->horizontalHeader()->setResizeMode (2, QHeaderView::ResizeToContents);
+    boxParams->verticalHeader()->setResizeMode(QHeaderView::ResizeToContents);
+#endif
     QStringList header = QStringList() << tr("Parameter") << tr("Value") << tr("Constant");
     boxParams->setHorizontalHeaderLabels(header);
-    boxParams->verticalHeader()->setResizeMode(QHeaderView::ResizeToContents);
     boxParams->verticalHeader()->hide();
     gl1->addWidget(boxParams, 3, 1);
 

--- a/libscidavis/src/FitDialog.cpp
+++ b/libscidavis/src/FitDialog.cpp
@@ -1046,7 +1046,7 @@ void FitDialog::accept()
 	try
 	{
 		MyParser parser;
-		parser.SetExpr(CONFS(from).toAscii().constData());
+		parser.SetExpr(CONFS(from).toUtf8().constData());
 		start=parser.Eval();
 	}
 	catch(mu::ParserError &e)
@@ -1059,7 +1059,7 @@ void FitDialog::accept()
 	try
 	{
 		MyParser parser;
-		parser.SetExpr(CONFS(to).toAscii().constData());
+		parser.SetExpr(CONFS(to).toUtf8().constData());
 		end=parser.Eval();
 	}
 	catch(mu::ParserError &e)
@@ -1080,7 +1080,7 @@ void FitDialog::accept()
 	try
 	{
 		MyParser parser;
-		parser.SetExpr(CONFS(tolerance).toAscii().constData());
+		parser.SetExpr(CONFS(tolerance).toUtf8().constData());
 		eps=parser.Eval();
 	}
 	catch(mu::ParserError &e)
@@ -1298,7 +1298,7 @@ bool FitDialog::validInitialValues()
 		try
 		{
 			MyParser parser;
-			parser.SetExpr(CONFS(boxParams->item(i,1)->text()).toAscii().constData());
+			parser.SetExpr(CONFS(boxParams->item(i,1)->text()).toUtf8().constData());
 			parser.Eval();
 		}
 		catch (mu::ParserError &e)

--- a/libscidavis/src/Folder.cpp
+++ b/libscidavis/src/Folder.cpp
@@ -38,7 +38,6 @@
 #include <qevent.h>
 #include <qpoint.h>
 #include <qmessagebox.h>
-#include <qmime.h>
 #include <qstringlist.h>
 #include <qapplication.h>
 #include <qcursor.h>
@@ -46,6 +45,7 @@
 #include <QKeyEvent>
 #include <QDropEvent>
 #include <QMouseEvent>
+#include <QDrag>
 
 Folder::Folder( Folder *parent, const QString &name )
 	: QObject(parent), d_active_window(0)

--- a/libscidavis/src/FunctionCurve.cpp
+++ b/libscidavis/src/FunctionCurve.cpp
@@ -101,7 +101,7 @@ bool FunctionCurve::loadData(int points)
 				double x;
 				for (i=0, x=d_from; i<points; i++, x+=step) {
 					X[i] = x;
-					script->setDouble(x, d_variable.toAscii().constData());
+					script->setDouble(x, d_variable.toUtf8().constData());
 					QVariant result = script->eval();
 					if (result.type() != QVariant::Double) {
 						delete[] X;
@@ -120,8 +120,8 @@ bool FunctionCurve::loadData(int points)
 				int i;
 				double par;
 				for (i=0, par=d_from; i<points; i++, par+=step) {
-					script_x->setDouble(par, d_variable.toAscii().constData());
-					script_y->setDouble(par, d_variable.toAscii().constData());
+					script_x->setDouble(par, d_variable.toUtf8().constData());
+					script_y->setDouble(par, d_variable.toUtf8().constData());
 					QVariant result_x = script_x->eval();
 					QVariant result_y = script_y->eval();
 					if (result_x.type() != QVariant::Double || result_y.type() != QVariant::Double) {

--- a/libscidavis/src/FunctionDialog.cpp
+++ b/libscidavis/src/FunctionDialog.cpp
@@ -270,7 +270,7 @@ bool FunctionDialog::acceptFunction()
 	try
 	{
 		MyParser parser;
-		parser.SetExpr(from.toAscii().constData());
+		parser.SetExpr(from.toUtf8().constData());
 		start=parser.Eval();
 	}
 	catch(mu::ParserError &e)
@@ -282,7 +282,7 @@ bool FunctionDialog::acceptFunction()
 	try
 	{
 		MyParser parser;
-		parser.SetExpr(to.toAscii().constData());
+		parser.SetExpr(to.toUtf8().constData());
 		end=parser.Eval();
 	}
 	catch(mu::ParserError &e)
@@ -335,7 +335,7 @@ bool FunctionDialog::acceptParametric()
 	try
 	{
 		MyParser parser;
-		parser.SetExpr(from.toAscii().constData());
+		parser.SetExpr(from.toUtf8().constData());
 		start=parser.Eval();
 	}
 	catch(mu::ParserError &e)
@@ -348,7 +348,7 @@ bool FunctionDialog::acceptParametric()
 	try
 	{
 		MyParser parser;
-		parser.SetExpr(to.toAscii().constData());
+		parser.SetExpr(to.toUtf8().constData());
 		end=parser.Eval();
 	}
 	catch(mu::ParserError &e)
@@ -403,7 +403,7 @@ bool FunctionDialog::acceptPolar()
 	try
 	{
 		MyParser parser;
-		parser.SetExpr(from.toAscii().constData());
+		parser.SetExpr(from.toUtf8().constData());
 		start=parser.Eval();
 	}
 	catch(mu::ParserError &e)
@@ -416,7 +416,7 @@ bool FunctionDialog::acceptPolar()
 	try
 	{
 		MyParser parser;
-		parser.SetExpr(to.toAscii().constData());
+		parser.SetExpr(to.toUtf8().constData());
 		end=parser.Eval();
 	}
 	catch(mu::ParserError &e)

--- a/libscidavis/src/Graph.cpp
+++ b/libscidavis/src/Graph.cpp
@@ -1399,7 +1399,16 @@ void Graph::exportVector(const QString& fileName, int, bool color, bool keepAspe
 
     printer.setOutputFileName(fileName);
     if (fileName.contains(".eps"))
-    	printer.setOutputFormat(QPrinter::PostScriptFormat);
+    {
+#if QT_VERSION >= 0x050000
+        QMessageBox::warning(this, tr("Warning"),
+            tr("Output in postscript format is not available for Qt5, using PDF"));
+        printer.setOutputFormat(QPrinter::PdfFormat);
+        printer.setOutputFileName(fileName+".pdf");
+#else
+        printer.setOutputFormat(QPrinter::PostScriptFormat);
+#endif
+	}
 
     if (color)
 		printer.setColorMode(QPrinter::Color);

--- a/libscidavis/src/Graph.cpp
+++ b/libscidavis/src/Graph.cpp
@@ -389,12 +389,12 @@ void Graph::setLabelsNumericFormat(int axis, int format, int prec, const QString
 	const QwtScaleDiv div = sd_old->scaleDiv ();
 
 	if (format == Plot::Superscripts){
-		QwtSupersciptsScaleDraw *sd = new QwtSupersciptsScaleDraw(*static_cast<const ScaleDraw*>(d_plot->axisScaleDraw(axis)), formula.toAscii().constData());
+		QwtSupersciptsScaleDraw *sd = new QwtSupersciptsScaleDraw(*static_cast<const ScaleDraw*>(d_plot->axisScaleDraw(axis)), formula.toUtf8().constData());
 		sd->setLabelFormat('s', prec);
 		sd->setScaleDiv(div);
 		d_plot->setAxisScaleDraw (axis, sd);
 	} else {
-		ScaleDraw *sd = new ScaleDraw(*static_cast<const ScaleDraw*>(d_plot->axisScaleDraw(axis)), formula.toAscii().constData());
+		ScaleDraw *sd = new ScaleDraw(*static_cast<const ScaleDraw*>(d_plot->axisScaleDraw(axis)), formula.toUtf8().constData());
 		sd->enableComponent(QwtAbstractScaleDraw::Labels, true);
 		sd->setScaleDiv(div);
 

--- a/libscidavis/src/Graph3D.cpp
+++ b/libscidavis/src/Graph3D.cpp
@@ -70,7 +70,7 @@ double UserFunction::operator()(double x, double y)
 		parser.DefineVar("x", &x);
 		parser.DefineVar("y", &y);
 
-		parser.SetExpr((const std::string)formula.toAscii().constData());
+		parser.SetExpr((const std::string)formula.toUtf8().constData());
 		result=parser.Eval();
 	}
 	catch(mu::ParserError &e)

--- a/libscidavis/src/IntDialog.cpp
+++ b/libscidavis/src/IntDialog.cpp
@@ -127,7 +127,7 @@ else
 	try
 		{
 		MyParser parser;
-		parser.SetExpr((boxStart->text()).toAscii().constData());
+		parser.SetExpr((boxStart->text()).toUtf8().constData());
 		start=parser.Eval();
 
 		if(start<minx)
@@ -173,7 +173,7 @@ else
 	try
 		{
 		MyParser parser;
-		parser.SetExpr((boxEnd->text()).toAscii().constData());
+		parser.SetExpr((boxEnd->text()).toUtf8().constData());
 		stop = parser.Eval();
 		if(stop > maxx)
 			{

--- a/libscidavis/src/InterpolationDialog.cpp
+++ b/libscidavis/src/InterpolationDialog.cpp
@@ -118,7 +118,7 @@ double from, to;
 try
 	{
 	MyParser parser;
-	parser.SetExpr(boxStart->text().replace(",", ".").toAscii().constData());
+	parser.SetExpr(boxStart->text().replace(",", ".").toUtf8().constData());
 	from = parser.Eval();
 	}
 catch(mu::ParserError &e)
@@ -131,7 +131,7 @@ catch(mu::ParserError &e)
 try
 	{
 	MyParser parser;
-	parser.SetExpr(boxEnd->text().replace(",", ".").toAscii().constData());
+	parser.SetExpr(boxEnd->text().replace(",", ".").toUtf8().constData());
 	to = parser.Eval();
 	}
 catch(mu::ParserError &e)

--- a/libscidavis/src/Matrix.cpp
+++ b/libscidavis/src/Matrix.cpp
@@ -257,7 +257,7 @@ void Matrix::setNumericFormat(const QChar& f, int prec)
 	if (d_future_matrix->numericFormat() == f && d_future_matrix->displayedDigits() == prec)
 		return;
 
-	d_future_matrix->setNumericFormat(f.toAscii());
+	d_future_matrix->setNumericFormat(f.toLatin1());
 	d_future_matrix->setDisplayedDigits(prec);
 
 	emit modifiedWindow(this);
@@ -265,7 +265,7 @@ void Matrix::setNumericFormat(const QChar& f, int prec)
 
 void Matrix::setTextFormat(const QChar &format, int precision)
 {
-	d_future_matrix->setNumericFormat(format.toAscii());
+	d_future_matrix->setNumericFormat(format.toLatin1());
 	d_future_matrix->setDisplayedDigits(precision);
 }
 

--- a/libscidavis/src/MuParserScript.cpp
+++ b/libscidavis/src/MuParserScript.cpp
@@ -400,7 +400,7 @@ Column *MuParserScript::resolveColumnPath(const QString &path) {
 	QStringList pathComponents;
 	QString current;
 	for (int i=0; i<path.size(); ++i)
-		switch(path.at(i).toAscii()) {
+		switch(path.at(i).toLatin1()) {
 			case '/':
 				pathComponents << current;
 				current.clear();
@@ -502,7 +502,7 @@ bool MuParserScript::translateLegacyFunctions(QString &input) {
 		for (int i = functionStart+legacyFunction.matchedLength(), parenthesisLevel = 1;
 				parenthesisLevel > 0 && i < input.size();
 				i++) {
-			switch (input.at(i).toAscii()) {
+			switch (input.at(i).toLatin1()) {
 				case '"':
 					currentArgument += '"';
 					for (i++; i < input.size() && input.at(i) != QChar('"'); i++)
@@ -651,7 +651,7 @@ bool MuParserScript::compile(bool asFunction) {
 	bool inString = false;
 	int commentStart = -1;
 	for (int i=0; i<intermediate.size(); i++)
-		switch (intermediate.at(i).toAscii()) {
+		switch (intermediate.at(i).toLatin1()) {
 			case '"':
 				if (commentStart < 0) inString = !inString;
 				break;

--- a/libscidavis/src/MultiLayer.cpp
+++ b/libscidavis/src/MultiLayer.cpp
@@ -685,7 +685,16 @@ void MultiLayer::exportVector(const QString& fileName, int, bool color, bool kee
   printer.setFullPage(true);
   printer.setOutputFileName(fileName);
   if (fileName.contains(".eps"))
+  {
+#if QT_VERSION >= 0x050000
+    QMessageBox::warning(this, tr("Warning"),
+      tr("Output in postscript format is not available for Qt5, using PDF"));
+    printer.setOutputFormat(QPrinter::PdfFormat);
+    printer.setOutputFileName(fileName+".pdf");
+#else
     printer.setOutputFormat(QPrinter::PostScriptFormat);
+#endif
+  }
 
   if (color)
     printer.setColorMode(QPrinter::Color);

--- a/libscidavis/src/Plot3DDialog.cpp
+++ b/libscidavis/src/Plot3DDialog.cpp
@@ -834,7 +834,7 @@ bool Plot3DDialog::updatePlot()
 		try
 		{
 			MyParser parser;
-			parser.SetExpr(from.toAscii().constData());
+			parser.SetExpr(from.toUtf8().constData());
 			start=parser.Eval();
 		}
 		catch(mu::ParserError &e)
@@ -847,7 +847,7 @@ bool Plot3DDialog::updatePlot()
 		try
 		{
 			MyParser parser;
-			parser.SetExpr(to.toAscii().constData());
+			parser.SetExpr(to.toUtf8().constData());
 			end=parser.Eval();
 		}
 		catch(mu::ParserError &e)

--- a/libscidavis/src/PlotDialog.cpp
+++ b/libscidavis/src/PlotDialog.cpp
@@ -2091,7 +2091,7 @@ bool PlotDialog::validInput()
 		try
 		{
 			MyParser parser;
-			parser.SetExpr((histogramBeginBox->text()).toAscii().constData());
+			parser.SetExpr((histogramBeginBox->text()).toUtf8().constData());
 			start=parser.Eval();
 		}
 		catch(mu::ParserError &e)
@@ -2110,7 +2110,7 @@ bool PlotDialog::validInput()
 		try
 		{
 			MyParser parser;
-			parser.SetExpr((histogramEndBox->text()).toAscii().constData());
+			parser.SetExpr((histogramEndBox->text()).toUtf8().constData());
 			end=parser.Eval();
 		}
 		catch(mu::ParserError &e)
@@ -2136,7 +2136,7 @@ bool PlotDialog::validInput()
 		try
 		{
 			MyParser parser;
-			parser.SetExpr((binSizeBox->text()).toAscii().constData());
+			parser.SetExpr((binSizeBox->text()).toUtf8().constData());
 			stp=parser.Eval();
 		}
 		catch(mu::ParserError &e)

--- a/libscidavis/src/ScaleDraw.cpp
+++ b/libscidavis/src/ScaleDraw.cpp
@@ -66,7 +66,7 @@ double ScaleDraw::transformValue(double value) const
 			else if (formula_string.contains("y"))
 				parser.DefineVar("y", &value);
 
-			parser.SetExpr(formula_string.toAscii().constData());
+			parser.SetExpr(formula_string.toUtf8().constData());
 			lbl=parser.Eval();
 			}
 		catch(mu::ParserError &)

--- a/libscidavis/src/SurfaceDialog.cpp
+++ b/libscidavis/src/SurfaceDialog.cpp
@@ -161,7 +161,7 @@ double fromX, toX, fromY,toY, fromZ,toZ;
 try
 	{
 	MyParser parser;
-	parser.SetExpr(Xfrom.toAscii().constData());
+	parser.SetExpr(Xfrom.toUtf8().constData());
 	fromX=parser.Eval();
 	}
 catch(mu::ParserError &e)
@@ -173,7 +173,7 @@ catch(mu::ParserError &e)
 try
 	{
 	MyParser parser;
-	parser.SetExpr(Xto.toAscii().constData());
+	parser.SetExpr(Xto.toUtf8().constData());
 	toX=parser.Eval();
 	}
 catch(mu::ParserError &e)
@@ -186,7 +186,7 @@ catch(mu::ParserError &e)
 try
 	{
 	MyParser parser;
-	parser.SetExpr(Yfrom.toAscii().constData());
+	parser.SetExpr(Yfrom.toUtf8().constData());
 	fromY=parser.Eval();
 	}
 catch(mu::ParserError &e)
@@ -198,7 +198,7 @@ catch(mu::ParserError &e)
 try
 	{
 	MyParser parser;
-	parser.SetExpr(Yto.toAscii().constData());
+	parser.SetExpr(Yto.toUtf8().constData());
 	toY=parser.Eval();
 	}
 catch(mu::ParserError &e)
@@ -210,7 +210,7 @@ catch(mu::ParserError &e)
 try
 	{
 	MyParser parser;
-	parser.SetExpr(Zfrom.toAscii().constData());
+	parser.SetExpr(Zfrom.toUtf8().constData());
 	fromZ=parser.Eval();
 	}
 catch(mu::ParserError &e)
@@ -222,7 +222,7 @@ catch(mu::ParserError &e)
 try
 	{
 	MyParser parser;
-	parser.SetExpr(Zto.toAscii().constData());
+	parser.SetExpr(Zto.toUtf8().constData());
 	toZ=parser.Eval();
 	}
 catch(mu::ParserError &e)
@@ -248,7 +248,7 @@ try
 	MyParser parser;
 	parser.DefineVar("x", &x);
 	parser.DefineVar("y", &y);
-	parser.SetExpr(formula.toAscii().constData());
+	parser.SetExpr(formula.toUtf8().constData());
 
 	x=fromX; y=fromY;
 	parser.Eval();

--- a/libscidavis/src/future/core/AspectPrivate.cpp
+++ b/libscidavis/src/future/core/AspectPrivate.cpp
@@ -175,7 +175,7 @@ QString AbstractAspect::Private::caption() const
 	for(int pos=magic.indexIn(result, 0); pos >= 0; pos=magic.indexIn(result, pos)) {
 		QString replacement;
 		int length;
-		switch(magic.cap(1).at(0).toAscii()) {
+		switch(magic.cap(1).at(0).toLatin1()) {
 			case '%': replacement = "%"; length=2; break;
 			case 'n': replacement = d_name; length=2; break;
 			case 'c': replacement = d_comment; length=2; break;

--- a/libscidavis/src/future/core/column/ColumnPrivate.cpp
+++ b/libscidavis/src/future/core/column/ColumnPrivate.cpp
@@ -71,7 +71,7 @@ Column::Private::Private(Column * owner, SciDAVis::ColumnMode mode)
 #endif
 				settings.beginGroup("/General");
 				static_cast<Double2StringFilter *>(d_output_filter)->setNumDigits(settings.value("/DecimalDigits", 14).toInt());
-				static_cast<Double2StringFilter *>(d_output_filter)->setNumericFormat(settings.value("/DefaultNumericFormat", 'f').toChar().toAscii());
+				static_cast<Double2StringFilter *>(d_output_filter)->setNumericFormat(settings.value("/DefaultNumericFormat", 'f').toChar().toLatin1());
 			}
 #endif
 			connect(static_cast<Double2StringFilter *>(d_output_filter), SIGNAL(formatChanged()),
@@ -141,7 +141,7 @@ Column::Private::Private(Column * owner, SciDAVis::ColumnDataType type, SciDAVis
 #endif
 				settings.beginGroup("/General");
 				static_cast<Double2StringFilter *>(d_output_filter)->setNumDigits(settings.value("/DecimalDigits", 14).toInt());
-				static_cast<Double2StringFilter *>(d_output_filter)->setNumericFormat(settings.value("/DefaultNumericFormat", 'f').toChar().toAscii());
+				static_cast<Double2StringFilter *>(d_output_filter)->setNumericFormat(settings.value("/DefaultNumericFormat", 'f').toChar().toLatin1());
 			}
 #endif
 			connect(static_cast<Double2StringFilter *>(d_output_filter), SIGNAL(formatChanged()),
@@ -352,7 +352,7 @@ void Column::Private::setColumnMode(SciDAVis::ColumnMode mode, AbstractFilter *f
 #endif
 				settings.beginGroup("/General");
 				static_cast<Double2StringFilter *>(new_out_filter)->setNumDigits(settings.value("/DecimalDigits", 14).toInt());
-				static_cast<Double2StringFilter *>(new_out_filter)->setNumericFormat(settings.value("/DefaultNumericFormat", 'f').toChar().toAscii());
+				static_cast<Double2StringFilter *>(new_out_filter)->setNumericFormat(settings.value("/DefaultNumericFormat", 'f').toChar().toLatin1());
 			}
 #endif
 			connect(static_cast<Double2StringFilter *>(new_out_filter), SIGNAL(formatChanged()),

--- a/libscidavis/src/future/core/datatypes/Double2StringFilter.cpp
+++ b/libscidavis/src/future/core/datatypes/Double2StringFilter.cpp
@@ -51,7 +51,7 @@ bool Double2StringFilter::load(XmlStreamReader * reader)
 			reader->raiseError(tr("missing or invalid format attribute(s)"));
 		else
 		{
-			setNumericFormat( format_str.at(0).toAscii() );
+			setNumericFormat( format_str.at(0).toLatin1() );
 			setNumDigits( digits );
 		}
 	}

--- a/libscidavis/src/future/matrix/MatrixView.cpp
+++ b/libscidavis/src/future/matrix/MatrixView.cpp
@@ -134,10 +134,17 @@ void MatrixView::init()
 
 	QHeaderView * h_header = d_view_widget->horizontalHeader();
 	QHeaderView * v_header = d_view_widget->verticalHeader();
+#if QT_VERSION >= 0x050000
+	v_header->setSectionResizeMode(QHeaderView::Interactive);
+	h_header->setSectionResizeMode(QHeaderView::Interactive);
+	v_header->setSectionsMovable(false);
+	h_header->setSectionsMovable(false);
+#else
 	v_header->setResizeMode(QHeaderView::Interactive);
 	h_header->setResizeMode(QHeaderView::Interactive);
 	v_header->setMovable(false);
 	h_header->setMovable(false);
+#endif
 	v_header->setDefaultSectionSize(future::Matrix::defaultRowHeight());
 	h_header->setDefaultSectionSize(future::Matrix::defaultColumnWidth());
 

--- a/libscidavis/src/future/matrix/future_Matrix.cpp
+++ b/libscidavis/src/future/matrix/future_Matrix.cpp
@@ -1237,7 +1237,7 @@ bool Matrix::readDisplayElement(XmlStreamReader * reader)
 		reader->raiseError(tr("invalid or missing numeric format"));
 		return false;
 	}
-	setNumericFormat(str.at(0).toAscii());
+	setNumericFormat(str.at(0).toLatin1());
 	
 	bool ok;
 	int digits = reader->readAttributeInt("displayed_digits", &ok);

--- a/libscidavis/src/future/matrix/future_Matrix.cpp
+++ b/libscidavis/src/future/matrix/future_Matrix.cpp
@@ -38,6 +38,10 @@
 #include <QtCore>
 #include <QtGui>
 #include <QtDebug>
+#include <QMenu>
+#include <QInputDialog>
+#include <QFileDialog>
+#include <QProgressDialog>
 
 #include <stdlib.h>
 #include <math.h>

--- a/libscidavis/src/future/table/TableView.cpp
+++ b/libscidavis/src/future/table/TableView.cpp
@@ -114,7 +114,11 @@ void TableView::init()
 	d_main_layout->addWidget(d_view_widget);
 	
 	d_horizontal_header = new TableDoubleHeaderView();
+#if QT_VERSION >= 0x050000
+    d_horizontal_header->setSectionsClickable(true);
+#else
     d_horizontal_header->setClickable(true);
+#endif
     d_horizontal_header->setHighlightSections(true);
 	d_view_widget->setHorizontalHeader(d_horizontal_header);
 
@@ -146,10 +150,17 @@ void TableView::init()
 	d_view_widget->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
 	QHeaderView * v_header = d_view_widget->verticalHeader();
+#if QT_VERSION >= 0x050000
+	v_header->setSectionResizeMode(QHeaderView::Interactive);
+	v_header->setSectionsMovable(false);
+	d_horizontal_header->setSectionResizeMode(QHeaderView::Interactive);
+	d_horizontal_header->setSectionsMovable(true);
+#else
 	v_header->setResizeMode(QHeaderView::Interactive);
 	v_header->setMovable(false);
 	d_horizontal_header->setResizeMode(QHeaderView::Interactive);
 	d_horizontal_header->setMovable(true);
+#endif
 	connect(d_horizontal_header, SIGNAL(sectionMoved(int,int,int)), this, SLOT(handleHorizontalSectionMoved(int,int,int)));
 	connect(d_horizontal_header, SIGNAL(sectionDoubleClicked(int)), this, SLOT(handleHorizontalHeaderDoubleClicked(int)));
 	

--- a/libscidavis/src/future/table/future_Table.cpp
+++ b/libscidavis/src/future/table/future_Table.cpp
@@ -51,6 +51,7 @@
 #include <QClipboard>
 #include <QToolBar>
 #include <QtDebug>
+#include <QMimeData>
 
 #include "table/TableModel.h"
 #include "table/TableView.h"

--- a/libscidavis/src/globals.cpp
+++ b/libscidavis/src/globals.cpp
@@ -177,7 +177,7 @@ QString SciDAVis::releaseDateString()
 
 QString SciDAVis::enumValueToString(int key, const QString& enum_name)
 {
-	int index = staticMetaObject.indexOfEnumerator(enum_name.toAscii());
+	int index = staticMetaObject.indexOfEnumerator(enum_name.toUtf8());
 	if(index == -1) return QString("invalid");
 	QMetaEnum meta_enum = staticMetaObject.enumerator(index);
 	return QString(meta_enum.valueToKey(key));
@@ -185,9 +185,9 @@ QString SciDAVis::enumValueToString(int key, const QString& enum_name)
 
 int SciDAVis::enumStringToValue(const QString& string, const QString& enum_name)
 {
-	int index = staticMetaObject.indexOfEnumerator(enum_name.toAscii());
+	int index = staticMetaObject.indexOfEnumerator(enum_name.toUtf8());
 	if(index == -1) return -1;
 	QMetaEnum meta_enum = staticMetaObject.enumerator(index);
-	return meta_enum.keyToValue(string.toAscii());
+	return meta_enum.keyToValue(string.toUtf8());
 }
 

--- a/libscidavis/src/importOPJ.cpp
+++ b/libscidavis/src/importOPJ.cpp
@@ -682,7 +682,7 @@ bool ImportOPJ::importGraphs(const OriginFile &opj)
 					continue;
 				}
 				QString tableName;
-				switch(data[0].toAscii())
+				switch(data[0].toLatin1())
 				{
 				case 'T':
 				case 'E':

--- a/libscidavis/src/scidavis.sip
+++ b/libscidavis/src/scidavis.sip
@@ -316,7 +316,7 @@ class Table: MyWidget
 			if (col < 0) {\
 				sipIsErr = 1;\
 				PyErr_Format(PyExc_ValueError, "There's no column named %s in table %s!", PYUNICODE_AsUTF8(tmp),\
-						sipCpp->name().toAscii().constData());\
+						sipCpp->name().toUtf8().constData());\
 				Py_DECREF(tmp);\
 			}\
 		}\

--- a/libscidavis/src/scidavis.sip
+++ b/libscidavis/src/scidavis.sip
@@ -35,6 +35,11 @@
 %Import QtCore/QtCoremod.sip
 %Import QtGui/QtGuimod.sip
 
+%If (Qt_5_0_0 -)
+%Import QtWidgets/QtWidgetsmod.sip
+%Import QtPrintSupport/QtPrintSupportmod.sip
+%End
+
 %ModuleHeaderCode
 #if PY_MAJOR_VERSION >= 3
 #define PYUNICODE_AsUTF8     PyUnicode_AsUTF8

--- a/scidavis.pro
+++ b/scidavis.pro
@@ -6,11 +6,9 @@
 #################################################
 
 # enable C++11 support
-greaterThan(QT_MAJOR_VERSION, 3){
-  CONFIG += c++11
-} else {
-  QMAKE_CXXFLAGS += -std=c++0x
-}
+equals(QT_MAJOR_VERSION, 5) { CONFIG += c++11 }
+equals(QT_MAJOR_VERSION, 4) { QMAKE_CXXFLAGS += -std=c++11 }
+equals(QT_MAJOR_VERSION, 3) { QMAKE_CXXFLAGS += -std=c++0x }
 
 TEMPLATE = subdirs
 

--- a/scidavis.pro
+++ b/scidavis.pro
@@ -6,7 +6,7 @@
 #################################################
 
 # enable C++11 support
-greaterThan(QT_MAJOR_VERSION, 4){
+greaterThan(QT_MAJOR_VERSION, 3){
   CONFIG += c++11
 } else {
   QMAKE_CXXFLAGS += -std=c++0x

--- a/scidavis/basic.pri
+++ b/scidavis/basic.pri
@@ -23,6 +23,9 @@ DEFINES       += MANUAL_PATH="\\\"$$replace(manual.path," ","\\ ")\\\""
      win32:DEFINES += QT_DLL QT_THREAD_SUPPORT
 }
 QT            += opengl network svg xml
+equals(QT_MAJOR_VERSION, 5){
+    QT += printsupport
+}
 
 MOC_DIR        = ../tmp/scidavis
 OBJECTS_DIR    = ../tmp/scidavis

--- a/scidavis/scidavis.pro
+++ b/scidavis/scidavis.pro
@@ -1,9 +1,7 @@
 # enable C++11 support
-greaterThan(QT_MAJOR_VERSION, 3){
-  CONFIG += c++11
-} else {
-  QMAKE_CXXFLAGS += -std=c++0x
-}
+equals(QT_MAJOR_VERSION, 5) { CONFIG += c++11 }
+equals(QT_MAJOR_VERSION, 4) { QMAKE_CXXFLAGS += -std=c++11 }
+equals(QT_MAJOR_VERSION, 3) { QMAKE_CXXFLAGS += -std=c++0x }
 
 INCLUDEPATH += ../libscidavis ../libscidavis/src 
 LIBS += -L../libscidavis -lscidavis

--- a/scidavis/scidavis.pro
+++ b/scidavis/scidavis.pro
@@ -1,5 +1,5 @@
 # enable C++11 support
-greaterThan(QT_MAJOR_VERSION, 4){
+greaterThan(QT_MAJOR_VERSION, 3){
   CONFIG += c++11
 } else {
   QMAKE_CXXFLAGS += -std=c++0x
@@ -14,13 +14,7 @@ include(../config.pri)
 include( basic.pri )
 python {include( python.pri )}
 
-#QMAKE_CLEAN+=${TARGET}
-# why doesn't the previous line work???
-win32 {
-QMAKE_CLEAN+=scidavis.exe
-} else {
-QMAKE_CLEAN+=scidavis
-}
+QMAKE_CLEAN += $$TARGET
 
 ### this is the program itself
 INSTALLS        += target

--- a/scidavis/scidavisUtil.py
+++ b/scidavis/scidavisUtil.py
@@ -214,7 +214,10 @@ def exportTableToTeX(t, filename=None):
 		exportToTeX(table, filename=None):
 		Export table as TeX-tabular to filename. If filename==None, popup a file selection dialog.
 	"""
-	from PyQt4.QtGui import QFileDialog
+	if (scidavis.app.qtVersion() >= 0x050000):
+		from PyQt5.QtWidgets import QFileDialog
+	else:
+		from PyQt4.QtGui import QFileDialog
 	if not filename:
 		filename=QFileDialog.getSaveFileName(scidavis.app,"SciDAVis - Export TeX table","","All files *;;TeX documents (*.tex *.TEX);;");
 	f=open(filename,'w')

--- a/scidavis/scidavisrc.py
+++ b/scidavis/scidavisrc.py
@@ -55,14 +55,15 @@ def import_to_global(modname, attrs=None, math=False):
 import_to_global("math", None, True)
 
 # make Qt API available (it gets imported in any case by the scidavis module)
-global QtGui
-from PyQt4 import QtGui
-
-global QtCore
-from PyQt4 import QtCore
-
-global Qt
-from PyQt4.QtCore import Qt
+global QtGui, QtCore, Qt
+if (scidavis.app.qtVersion() >= 0x050000):
+	global QtWidgets
+	from PyQt5 import QtGui, QtWidgets, QtCore
+	from PyQt5.QtCore import Qt
+else:
+	from PyQt4 import QtGui, QtCore
+	from PyQt4.QtCore import Qt
+print("Using Qt", QtCore.QT_VERSION_STR)
 
 # import SciDAVis' classes to the global namespace (particularly useful for fits)
 for name in dir(__main__.scidavis):

--- a/test/pythonTests/integration_with_python-crash.py
+++ b/test/pythonTests/integration_with_python-crash.py
@@ -1,6 +1,6 @@
 app.loadProject("integration_with_python-crash.sciprj")
-lower_limit = 0
-upper_limit = 30
+lower_limit = 0.
+upper_limit = 30.
 g=graph("Graph1")
 curveName="Table1_2"
 integral = Integration(g.activeLayer(),curveName,lower_limit,upper_limit)

--- a/test/test.pro
+++ b/test/test.pro
@@ -19,6 +19,7 @@ POST_TARGETDEPS=../libscidavis/libscidavis.a
 
 CONFIG        += qt warn_on exceptions opengl thread zlib
 QT            += opengl network svg xml
+equals(QT_MAJOR_VERSION, 5) { QT += printsupport }
 MOC_DIR        = ../tmp/scidavis
 OBJECTS_DIR    = ../tmp/test
 

--- a/test/test.pro
+++ b/test/test.pro
@@ -3,11 +3,9 @@
 ######################################################################
 
 # enable C++11 support
-greaterThan(QT_MAJOR_VERSION, 3){
-  CONFIG += c++11
-} else {
-  QMAKE_CXXFLAGS += -std=c++0x
-}
+equals(QT_MAJOR_VERSION, 5) { CONFIG += c++11 }
+equals(QT_MAJOR_VERSION, 4) { QMAKE_CXXFLAGS += -std=c++11 }
+equals(QT_MAJOR_VERSION, 3) { QMAKE_CXXFLAGS += -std=c++0x }
 
 TEMPLATE = app
 TARGET = unittests

--- a/test/test.pro
+++ b/test/test.pro
@@ -3,7 +3,7 @@
 ######################################################################
 
 # enable C++11 support
-greaterThan(QT_MAJOR_VERSION, 4){
+greaterThan(QT_MAJOR_VERSION, 3){
   CONFIG += c++11
 } else {
   QMAKE_CXXFLAGS += -std=c++0x


### PR DESCRIPTION
This code allows to build SciDAVis with either Qt5 or Qt4.
Qt version is chosen by using the corresponding qmake binary.
For the Qt5 version a port of qwtplot3d and qwt5 to Qt5 is needed.
Fedora and Debian already have a package for qwtplot3d-qt5.
For qwt5-qt5 you can get and compile the code at https://github.com/gbm19/qwt5-qt5
The pull request also contains some small bug fixes unrelated to Qt5.
