### PR TITLE
Remove hardcoded location of qwtplot3d headers

### DIFF
--- a/libscidavis/src/Bar.cpp
+++ b/libscidavis/src/Bar.cpp
@@ -28,8 +28,8 @@
  ***************************************************************************/
 #include <qbitmap.h>
 
-#include <qwtplot3d/qwt3d_color.h>
-#include <qwtplot3d/qwt3d_plot.h>
+#include <qwt3d_color.h>
+#include <qwt3d_plot.h>
 #include "Bar.h"
 
 using namespace Qwt3D;

--- a/libscidavis/src/Bar.h
+++ b/libscidavis/src/Bar.h
@@ -29,7 +29,7 @@
 #ifndef BARS_H
 #define BARS_H
 
-#include <qwtplot3d/qwt3d_plot.h>
+#include <qwt3d_plot.h>
 
 //! 3D bars (modifed enrichment from QwtPlot3D)
 class Bar : public Qwt3D::VertexEnrichment

--- a/libscidavis/src/Cone3D.cpp
+++ b/libscidavis/src/Cone3D.cpp
@@ -27,8 +27,8 @@
  *                                                                         *
  ***************************************************************************/
 #include <math.h>
-#include <qwtplot3d/qwt3d_color.h>
-#include <qwtplot3d/qwt3d_plot.h>
+#include <qwt3d_color.h>
+#include <qwt3d_plot.h>
 #include "Cone3D.h"
 
 using namespace Qwt3D;

--- a/libscidavis/src/Cone3D.h
+++ b/libscidavis/src/Cone3D.h
@@ -29,7 +29,7 @@
 #ifndef MYCONES_H
 #define MYCONES_H
 
-#include <qwtplot3d/qwt3d_plot.h>
+#include <qwt3d_plot.h>
 
 //! 3D cone class (based on QwtPlot3D)
 class Cone3D : public Qwt3D::VertexEnrichment

--- a/libscidavis/src/Graph3D.cpp
+++ b/libscidavis/src/Graph3D.cpp
@@ -44,8 +44,8 @@
 #include <QCursor>
 #include <QImageWriter>
 
-#include <qwtplot3d/qwt3d_io_gl2ps.h>
-#include <qwtplot3d/qwt3d_coordsys.h>
+#include <qwt3d_io_gl2ps.h>
+#include <qwt3d_coordsys.h>
 
 #include <gsl/gsl_vector.h>
 #include <fstream>

--- a/libscidavis/src/Graph3D.h
+++ b/libscidavis/src/Graph3D.h
@@ -29,8 +29,8 @@
 #ifndef GRAPH3D_H
 #define GRAPH3D_H
 
-#include <qwtplot3d/qwt3d_surfaceplot.h>
-#include <qwtplot3d/qwt3d_function.h>
+#include <qwt3d_surfaceplot.h>
+#include <qwt3d_function.h>
 
 #include <QTimer>
 #include <QVector>

--- a/libscidavis/src/Plot3DDialog.cpp
+++ b/libscidavis/src/Plot3DDialog.cpp
@@ -48,7 +48,7 @@
 #include <QFontDialog>
 #include <QColorDialog>
 
-#include <qwtplot3d/qwt3d_color.h>
+#include <qwt3d_color.h>
 
 Plot3DDialog::Plot3DDialog( QWidget* parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )


### PR DESCRIPTION
In Fedora, qwtplot3d-qt5-devel stores the qwtplot3d headers at /usr/include/qt5/qwtplot3d-qt5.
Thus compiling SciDAVIS with qt5 would not find  <qwtplot3d/qwt3d_plot.h> at that location and use the headers from qwtplot3d-qt4-devel at /usr/include/qwtplot3d, that match the requested <qwtplot3d/qwt3d_plot.h>.
