### PR TITLE
Suggested fix for different location of .sip

### DIFF
--- a/libscidavis/python-sipcmd.py
+++ b/libscidavis/python-sipcmd.py
@@ -26,6 +26,8 @@
 ############################################################################
 
 
+import os
+import warnings
 import sys, sipconfig
 config = sipconfig.Configuration()
 
@@ -44,6 +46,15 @@ except ImportError:
 
 sipBin = config.sip_bin
 sipDir = config.default_sip_dir+'/'+pyqt
+if sys.version_info[0] >= 3 and sys.version_info[1] >= 7 and pyqt == 'PyQt5':
+    from importlib.metadata import distribution
+    dist = distribution(pyqt)
+    sip = [p for p in dist.files if p.name == 'QtCoremod.sip']
+    assert len(sip) == 1
+    sipDir = str(dist.locate_file(sip[0]).parent.parent)
+else:
+    if not os.path.exists(sipDir):
+        warnings.warn('sipDir does not exists, %s' % sipDir)
 
 sipFlags =  PYQT_CONFIGURATION['sip_flags']
 

--- a/libscidavis/python.pri
+++ b/libscidavis/python.pri
@@ -26,8 +26,12 @@
     osx_dist {
       DEFINES += PYTHONHOME=/Applications/scidavis.app/Contents/Resources
     } 
+    SIP_FAILURE = TRUE
     system(mkdir -p $${SIP_DIR})
-    system($$system($$PYTHONBIN python-sipcmd.py PyQt$$QT_MAJOR_VERSION) $$system($$PYTHONBIN-config --includes) -c $${SIP_DIR}  src/scidavis.sip)
+    system($$system($$PYTHONBIN python-sipcmd.py PyQt$$QT_MAJOR_VERSION) $$system($$PYTHONBIN-config --includes) -c $${SIP_DIR}  src/scidavis.sip): SIP_FAILURE = FALSE
+    equals(SIP_FAILURE, "TRUE") {
+        error(`$$PYTHONBIN python-sipcmd.py PyQt$$QT_MAJOR_VERSION` `$$PYTHONBIN-config --includes` -c $${SIP_DIR}  src/scidavis.sip FAILED in $$PWD)
+    }
   }
 
   win32 {


### PR DESCRIPTION
While trying to pack scidavis-qt5 for Arch Linux, I came across a problem with
the hard-coded location of the .sip files in python-sipcmd.py. I don't know whether
the suggested fix works for distributions other than Arch (Python 3.8.1, PyQt5 version 5.14.1)

python2-pyqt5
/usr/share/sip/PyQt5/QtCore/QtCoremod.sip
python-pyqt5
/usr/lib/python3.8/site-packages/PyQt5/bindings/QtCore/QtCoremod.sip

Furthermore, it is really useful if qmake just gives up when sip fails