### PR TITLE
Update python-sipcmd.py

### DIFF
--- a/libscidavis/python-sipcmd.py
+++ b/libscidavis/python-sipcmd.py
@@ -46,7 +46,7 @@ except ImportError:
 
 sipBin = config.sip_bin
 sipDir = config.default_sip_dir+'/'+pyqt
-if sys.version_info[0] >= 3 and sys.version_info[1] >= 7 and pyqt == 'PyQt5':
+if sys.version_info[0] >= 3 and sys.version_info[1] >= 8 and pyqt == 'PyQt5':
     from importlib.metadata import distribution
     dist = distribution(pyqt)
     sip = [p for p in dist.files if p.name == 'QtCoremod.sip']


### PR DESCRIPTION
importlib.metadata will only work with python 3.8 and newer.