### PR TITLE
compiles under arch

### DIFF
--- a/libscidavis/src/ApplicationWindow.cpp
+++ b/libscidavis/src/ApplicationWindow.cpp
@@ -14042,7 +14042,7 @@ void ApplicationWindow::showHistory()
 
 QStringList ApplicationWindow::tableWindows()
 {
-	QList<AbstractAspect *> tables = d_project->descendantsThatInherit("::future::Table");
+	QList<AbstractAspect *> tables = d_project->descendantsThatInherit("future::Table");
 	QStringList result;
 	foreach(AbstractAspect *aspect, tables)
           result.append(aspect->name().c_str());

--- a/libscidavis/src/ApplicationWindow.cpp
+++ b/libscidavis/src/ApplicationWindow.cpp
@@ -2655,7 +2655,7 @@ TableStatistics *ApplicationWindow::newTableStatistics(Table *base, int type, QL
 
 void ApplicationWindow::removeDependentTableStatistics(const AbstractAspect *aspect)
 {
-	future::Table *future_table = qobject_cast<future::Table *>(const_cast<AbstractAspect *>(aspect));
+	::future::Table *future_table = qobject_cast<::future::Table *>(const_cast<AbstractAspect *>(aspect));
 	if (!future_table) return;
 	QList<MyWidget*> windows = windowsList();
 	foreach(MyWidget *win, windows)
@@ -13984,13 +13984,13 @@ void ApplicationWindow::selectPlotType(int type)
 void ApplicationWindow::handleAspectAdded(const AbstractAspect *parent, int index)
 {
 	AbstractAspect * aspect = parent->child(index);
-	future::Matrix * matrix = qobject_cast<future::Matrix *>(aspect);
+	::future::Matrix * matrix = qobject_cast<::future::Matrix *>(aspect);
 	if (matrix)
 	{
 		initMatrix(static_cast<Matrix *>(matrix->view()));
 		return;
 	}
-	future::Table * table = qobject_cast<future::Table *>(aspect);
+	::future::Table * table = qobject_cast<::future::Table *>(aspect);
 	if (table)
 	{
 		initTable(static_cast<Table *>(table->view()));
@@ -14001,13 +14001,13 @@ void ApplicationWindow::handleAspectAdded(const AbstractAspect *parent, int inde
 void ApplicationWindow::handleAspectAboutToBeRemoved(const AbstractAspect *parent, int index)
 {
 	AbstractAspect * aspect = parent->child(index);
-	future::Matrix * matrix = qobject_cast<future::Matrix *>(aspect);
+	::future::Matrix * matrix = qobject_cast<::future::Matrix *>(aspect);
 	if (matrix)
 	{
 		closeWindow(static_cast<Matrix *>(matrix->view()));
 		return;
 	}
-	future::Table * table = qobject_cast<future::Table *>(aspect);
+	::future::Table * table = qobject_cast<::future::Table *>(aspect);
 	if (table)
 	{
 		closeWindow(static_cast<Table *>(table->view()));
@@ -14042,7 +14042,7 @@ void ApplicationWindow::showHistory()
 
 QStringList ApplicationWindow::tableWindows()
 {
-	QList<AbstractAspect *> tables = d_project->descendantsThatInherit("future::Table");
+	QList<AbstractAspect *> tables = d_project->descendantsThatInherit("::future::Table");
 	QStringList result;
 	foreach(AbstractAspect *aspect, tables)
           result.append(aspect->name().c_str());

--- a/libscidavis/src/future/core/Project.h
+++ b/libscidavis/src/future/core/Project.h
@@ -43,7 +43,7 @@ class AbstractScriptingEngine;
  * Project manages an undo stack and is responsible for creating ProjectWindow instances
  * as views on itself.
  */
-class Project : public future::Folder
+class Project : public ::future::Folder
 {
 	Q_OBJECT
 
@@ -73,7 +73,7 @@ class Project : public future::Folder
 #endif
 		virtual QMenu *createContextMenu() const;
 		//@}
-		virtual QMenu *createFolderContextMenu(const future::Folder * folder) const;
+		virtual QMenu *createFolderContextMenu(const ::future::Folder * folder) const;
 
 		AbstractScriptingEngine * scriptingEngine() const;
 

--- a/scidavis/scidavis.pro
+++ b/scidavis/scidavis.pro
@@ -17,7 +17,11 @@ python {
   }
   unix: {
         LIBS+=$$system($$PYTHONBIN findBoostPythonLib.py)
-        LIBS+=$$system($$PYTHONBIN-config --libs --embed)
+        system($$PYTHONBIN-config --embed > /dev/null) {
+            LIBS+=$$system($$PYTHONBIN-config --libs --embed)
+        } else {
+            LIBS+=$$system($$PYTHONBIN-config --libs)
+        }
       }
   message($$LIBS)
            

--- a/scidavis/scidavis.pro
+++ b/scidavis/scidavis.pro
@@ -17,7 +17,7 @@ python {
   }
   unix: {
         LIBS+=$$system($$PYTHONBIN findBoostPythonLib.py)
-        LIBS+=$$system($$PYTHONBIN-config --ldflags)
+        LIBS+=$$system($$PYTHONBIN-config --libs --embed)
       }
   message($$LIBS)
            


### PR DESCRIPTION
Hello, I've tried to package the classdesc-python branch for Arch Linux. The following changes seem to me reasonable for including into upstream.

- There are again conflicts with references to `std::future` like #130 
- in `scidavis/scidavis.pro` I do not get `-lpython...` without `python-config --libs --embed`
