### PR TITLE
Group separator copy/paste bug

### DIFF
--- a/libscidavis/src/future/table/future_Table.cpp
+++ b/libscidavis/src/future/table/future_Table.cpp
@@ -31,7 +31,6 @@
 #include "table/future_Table.h"
 #include "core/Project.h"
 #include "lib/ActionManager.h"
-
 #include <QItemSelectionModel>
 #include <QTime>
 #include <QtGlobal>
@@ -385,7 +384,12 @@ void Table::copySelection()
 				else if (col_ptr->dataType() == SciDAVis::TypeDouble)
 				{
 					Double2StringFilter * out_fltr = static_cast<Double2StringFilter *>(col_ptr->outputFilter());
-					output_str += QLocale().toString(col_ptr->valueAt(first_row + r),
+                    // create a copy of current locale
+                    QLocale noSeparators;
+                    // we do not need separators on output!
+                    noSeparators.setNumberOptions(noSeparators.numberOptions() | QLocale::OmitGroupSeparator);
+                    // convert using modified locale
+					output_str += noSeparators.toString(col_ptr->valueAt(first_row + r),
 							out_fltr->numericFormat(), 16); // copy with max. precision
 				}
 				else


### PR DESCRIPTION
Hello!
There is a bug connected with selection copy from a table with group separator option enabled.

Steps to reproduce:
1. Create an empty project
2. Make sure "group separators" option is enabled in preferences
3. Type in (or paste) any number long enough to be group-separated, e.g. 1234567890
4. Copy it whatever way
5. Paste and get the number split into several columns, e.g. 1	234	567	890.
or
6. Paste the result in your favorite text editor, e.g. gedit, also get number split into 1	234	567	890.
This behavior does not depend on format settings of the origin cell.

The pull request fixes the bug by using temporary locale when copying. I'm not sure if it is good to create a copy of locale each time, but also I'm not sure how to store such locale once and reuse in terms of current code organization.
Also, sorry for misindentation in the code, in CodeBlocks it looked good.