### PR TITLE
Added an option to allow one to use either '.' or ',' as decimal separator on numerical input.

### DIFF
--- a/libscidavis/src/ConfigDialog.cpp
+++ b/libscidavis/src/ConfigDialog.cpp
@@ -644,6 +644,20 @@ void ConfigDialog::initAppPage()
 
 	numericFormatLayout->setRowStretch(4, 1);
 
+	#ifdef Q_OS_MAC
+	    QSettings settings(QSettings::IniFormat,QSettings::UserScope,
+		              "SciDAVis", "SciDAVis");
+	#else
+	    QSettings settings(QSettings::NativeFormat,QSettings::UserScope,
+		               "SciDAVis", "SciDAVis");
+	#endif
+
+	    lblForeignSeparator  = new QLabel();
+	    numericFormatLayout->addWidget(lblForeignSeparator,4,0);
+	    boxUseForeignSeparator = new QCheckBox();
+	    boxUseForeignSeparator->setChecked(settings.value("/General/UseForeignSeparator").toBool());
+    numericFormatLayout->addWidget(boxUseForeignSeparator,4,1);
+
 	appTabWidget->addTab( numericFormatPage, QString() );
 
 	connect( boxLanguage, SIGNAL( activated(int) ), this, SLOT( switchToLanguage(int) ) );
@@ -926,6 +940,7 @@ void ConfigDialog::languageChange()
   lblScriptingLanguage->setText(tr("Default scripting language"));
 
   lblDefaultNumericFormat->setText(tr("Default numeric format"));
+  lblForeignSeparator->setText(tr("Consider ',' and '.' interchangeable on input in numerical columns"));
   boxDefaultNumericFormat->clear();
   boxDefaultNumericFormat->addItem(tr("Decimal"), QVariant('f'));
   boxDefaultNumericFormat->addItem(tr("Scientific (e)"), QVariant('e'));
@@ -1223,6 +1238,7 @@ void ConfigDialog::apply()
     settings.beginGroup("[Table]");
     settings.setValue("DefaultRowHeight", boxTableRowHeight->value());
     settings.endGroup();
+    settings.setValue("/General/UseForeignSeparator", boxUseForeignSeparator->isChecked());
 }
 
 int ConfigDialog::curveStyle()

--- a/libscidavis/src/ConfigDialog.h
+++ b/libscidavis/src/ConfigDialog.h
@@ -146,9 +146,9 @@ private:
 	QCheckBox *boxSearchUpdates, *boxOrthogonal, *logBox, *plotLabelBox, *scaleErrorsBox;
 	QCheckBox *boxTitle, *boxFrame, *boxPlots3D, *boxPlots2D, *boxTables, *boxNotes, *boxFolders;
 	QCheckBox *boxSave, *boxBackbones, *boxAllAxes, *boxShowLegend, *boxSmoothMesh;
-	QCheckBox *boxAutoscaling, *boxShowProjection, *boxMatrices, *boxScaleFonts, *boxResize, *boxUseGroupSeparator;
+	QCheckBox *boxAutoscaling, *boxShowProjection, *boxMatrices, *boxScaleFonts, *boxResize, *boxUseGroupSeparator, *boxUseForeignSeparator;
 	QComboBox *boxMajTicks, *boxMinTicks, *boxStyle, *boxCurveStyle, *boxSeparator, *boxLanguage, *boxDecimalSeparator;
-	QLabel *lblDefaultNumericFormat;
+	QLabel *lblDefaultNumericFormat, *lblForeignSeparator;
 	QComboBox *boxDefaultNumericFormat;
 	QLabel *boxSeparatorPreview;
 	QLabel *lblTableRowHeight;

--- a/libscidavis/src/future/core/column/ColumnPrivate.cpp
+++ b/libscidavis/src/future/core/column/ColumnPrivate.cpp
@@ -72,6 +72,7 @@ Column::Private::Private(Column * owner, SciDAVis::ColumnMode mode)
 				settings.beginGroup("/General");
 				static_cast<Double2StringFilter *>(d_output_filter)->setNumDigits(settings.value("/DecimalDigits", 14).toInt());
 				static_cast<Double2StringFilter *>(d_output_filter)->setNumericFormat(settings.value("/DefaultNumericFormat", 'f').toChar().toLatin1());
+				settings.endGroup(); // possible bug since there was no closing endGroup()
 			}
 #endif
 			connect(static_cast<Double2StringFilter *>(d_output_filter), SIGNAL(formatChanged()),
@@ -978,4 +979,3 @@ QString Column::Private::comment() const
 {
 	return d_owner->comment();
 }
-


### PR DESCRIPTION
This PR is a feature proposal.
Many applications ignore machine locale and use inbuilt '.' (dot) decimal separator. Also, sometimes data comes from outer world and also contain 'foreign' decimal separator, either '.' or ',' (comma). It is very inconvenient to replace separators externally before putting them into table, and many applications (for example, gnuplot) allows one to use both separators simultaneously. Of course, this should not be mandatory, so I added this as an option under "Numerical format".
What is changed exactly:
With the option checked, one is able to input both "1.23" and "1,23" as valid numbers for "English" (1.234) and "French" (1,234) types of locale. For "German" (1.000,123) and possibly some other formats with multiple or non '.'/',' separators it will make the numerical input impossible/wrong. I don't know how to handle it and even if it is to be handled.
What is not conformant with project coding style:
I decided not to add a boolean variable to `ApplicationWindow ` to keep settings, writing to/reading from `QtSettings` directly instead. I see no point to duplicate variables.
Also fixed a small (possible) bug in `ColumnPrivate.cpp`.