### PR TITLE
Bug with pasting valid numerical data into numerical columns

### DIFF
--- a/libscidavis/src/ConfigDialog.cpp
+++ b/libscidavis/src/ConfigDialog.cpp
@@ -658,6 +658,13 @@ void ConfigDialog::initAppPage()
 	    boxUseForeignSeparator->setChecked(settings.value("/General/UseForeignSeparator").toBool());
     numericFormatLayout->addWidget(boxUseForeignSeparator,4,1);
 
+    lblConvertToTextColumn  = new QLabel();
+    numericFormatLayout->addWidget(lblConvertToTextColumn,5,0);
+
+    boxConvertToTextColumn = new QCheckBox();
+    boxConvertToTextColumn->setChecked(settings.value("/General/SetColumnTypeToTextOnInvalidInput", true).toBool());
+    numericFormatLayout->addWidget(boxConvertToTextColumn,5,1);
+
 	appTabWidget->addTab( numericFormatPage, QString() );
 
 	connect( boxLanguage, SIGNAL( activated(int) ), this, SLOT( switchToLanguage(int) ) );
@@ -941,6 +948,7 @@ void ConfigDialog::languageChange()
 
   lblDefaultNumericFormat->setText(tr("Default numeric format"));
   lblForeignSeparator->setText(tr("Consider ',' and '.' interchangeable on input in numerical columns"));
+  lblConvertToTextColumn->setText(tr("Convert numerical columns to text columns when pasting non-numeric values"));
   boxDefaultNumericFormat->clear();
   boxDefaultNumericFormat->addItem(tr("Decimal"), QVariant('f'));
   boxDefaultNumericFormat->addItem(tr("Scientific (e)"), QVariant('e'));
@@ -1239,6 +1247,7 @@ void ConfigDialog::apply()
     settings.setValue("DefaultRowHeight", boxTableRowHeight->value());
     settings.endGroup();
     settings.setValue("/General/UseForeignSeparator", boxUseForeignSeparator->isChecked());
+    settings.setValue("/General/SetColumnTypeToTextOnInvalidInput", boxConvertToTextColumn->isChecked());
 }
 
 int ConfigDialog::curveStyle()

--- a/libscidavis/src/ConfigDialog.h
+++ b/libscidavis/src/ConfigDialog.h
@@ -146,9 +146,9 @@ private:
 	QCheckBox *boxSearchUpdates, *boxOrthogonal, *logBox, *plotLabelBox, *scaleErrorsBox;
 	QCheckBox *boxTitle, *boxFrame, *boxPlots3D, *boxPlots2D, *boxTables, *boxNotes, *boxFolders;
 	QCheckBox *boxSave, *boxBackbones, *boxAllAxes, *boxShowLegend, *boxSmoothMesh;
-	QCheckBox *boxAutoscaling, *boxShowProjection, *boxMatrices, *boxScaleFonts, *boxResize, *boxUseGroupSeparator, *boxUseForeignSeparator;
+	QCheckBox *boxAutoscaling, *boxShowProjection, *boxMatrices, *boxScaleFonts, *boxResize, *boxUseGroupSeparator, *boxUseForeignSeparator, *boxConvertToTextColumn;
 	QComboBox *boxMajTicks, *boxMinTicks, *boxStyle, *boxCurveStyle, *boxSeparator, *boxLanguage, *boxDecimalSeparator;
-	QLabel *lblDefaultNumericFormat, *lblForeignSeparator;
+	QLabel *lblDefaultNumericFormat, *lblForeignSeparator, *lblConvertToTextColumn;
 	QComboBox *boxDefaultNumericFormat;
 	QLabel *boxSeparatorPreview;
 	QLabel *lblTableRowHeight;

--- a/libscidavis/src/future/core/column/Column.cpp
+++ b/libscidavis/src/future/core/column/Column.cpp
@@ -595,6 +595,11 @@ AbstractSimpleFilter * Column::outputFilter() const
   return d_column_private->outputFilter(); 
 }
 
+AbstractSimpleFilter * Column::inputFilter() const
+{
+  return d_column_private->inputFilter();
+}
+
 bool Column::isInvalid(int row) const 
 { 
   return d_column_private->isInvalid(row); 

--- a/libscidavis/src/future/core/column/Column.h
+++ b/libscidavis/src/future/core/column/Column.h
@@ -162,6 +162,14 @@ public:
    * the column's data type to strings (usualy to display in a view).
    */
   AbstractSimpleFilter * outputFilter() const;
+
+  //! Return the input filter (for string -> data type conversion)
+  /**
+   * This method is mainly used to get a filter that can convert
+   * the column's strings to a data-type (usually to check the input).
+   */
+  AbstractSimpleFilter * inputFilter() const;
+
   //! Return a wrapper column object used for String I/O.
   ColumnStringIO * asStringColumn() const { return d_string_io; }
 


### PR DESCRIPTION
There is a bug with pasting valid numerical data into numerical columns when the locale is not "English" (1.000)

Steps to reproduce the bug:
1. Choose any locale format except (1.000) in the settings
2. Clipboard should contain any valid number with decimal separator (e.g. 1,234) or just copy any cell with such value.
3. Paste the cell whatever way in a numerical column
The column is now set to "Text" type despite having correct numerical value in the cell.

The `future_Table` uses it's own way to validate the input based on a regex. However, numerical column has an input filter for the same reason. The regex does not necessarily match the locale-aware and other settings-aware input filter of a column. Therefore, I exposed input filter of a column to validate an arbitrary string when data is pasted.

Also, I added a possibility to control the behavior when non-numeric data is pasted in to a numerical column: either ignore (set corresponding cells to invalid) or paste as is and convert whole column to text. The option is available through GUI and is on by default (i.e. converting whole column).
