### PR TITLE
Bugfix in non-ASCII Origin file imports

### DIFF
--- a/libscidavis/src/ApplicationWindow.cpp
+++ b/libscidavis/src/ApplicationWindow.cpp
@@ -125,7 +125,6 @@
 #include <QMdiSubWindow>
 #include <QTranslator>
 #include <QSplitter>
-#include <QSettings>
 #include <QApplication>
 #include <QMessageBox>
 #include <QPrinter>
@@ -3439,9 +3438,12 @@ void ApplicationWindow::open()
 {
 	OpenProjectDialog *open_dialog = new OpenProjectDialog(this, d_extended_open_dialog);
 	open_dialog->setDirectory(workingDir);
+	auto settings = getSettings();
+	open_dialog->setCodec(settings.value("/General/Dialogs/LastUsedOriginLocale", "").toString());
 	if (open_dialog->exec() != QDialog::Accepted || open_dialog->selectedFiles().isEmpty())
 		return;
 	workingDir = open_dialog->directory().path();
+    	settings.setValue("/General/Dialogs/LastUsedOriginLocale", open_dialog->codec());
 
 	switch(open_dialog->openMode()) {
 		case OpenProjectDialog::NewProject:
@@ -4231,8 +4233,7 @@ void ApplicationWindow::openTemplate()
 
 void ApplicationWindow::readSettings()
 {
-  QSettings settings;
-
+    auto settings = getSettings();
 	/* ---------------- group General --------------- */
 	settings.beginGroup("/General");
 #ifdef SEARCH_FOR_UPDATES
@@ -4508,13 +4509,7 @@ void ApplicationWindow::readSettings()
 
 void ApplicationWindow::saveSettings()
 {
-
-#ifdef Q_OS_MAC // Mac
-	QSettings settings(QSettings::IniFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
-#else
-	QSettings settings(QSettings::NativeFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
-#endif
-
+    auto settings = getSettings();
 	/* ---------------- group General --------------- */
 	settings.beginGroup("/General");
 #ifdef SEARCH_FOR_UPDATES
@@ -11791,6 +11786,7 @@ MultiLayer* ApplicationWindow::plotSpectrogram(Matrix *m, Graph::CurveType type)
 ApplicationWindow* ApplicationWindow::importOPJ(const QString& filename [[maybe_unused]])
 {
 #ifdef ORIGIN_IMPORT
+    auto codec = getSettings().value("/General/Dialogs/LastUsedOriginLocale", "").toString();
     if (filename.endsWith(".opj", Qt::CaseInsensitive) || filename.endsWith(".ogg", Qt::CaseInsensitive) || filename.endsWith(".org", Qt::CaseInsensitive))
     {
         QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
@@ -11804,14 +11800,14 @@ ApplicationWindow* ApplicationWindow::importOPJ(const QString& filename [[maybe_
         app->recentProjects.push_front(filename);
         app->updateRecentProjectsList();
 
-        ImportOPJ(app, filename);
+        ImportOPJ(app, filename, codec);
 
         QApplication::restoreOverrideCursor();
         return app;
     }
     else if (filename.endsWith(".ogm", Qt::CaseInsensitive) || filename.endsWith(".ogw", Qt::CaseInsensitive))
     {
-		ImportOPJ(this, filename);
+		ImportOPJ(this, filename, codec);
         recentProjects.removeAll(filename);
         recentProjects.push_front(filename);
         updateRecentProjectsList();
@@ -12397,7 +12393,10 @@ void ApplicationWindow::appendProject(const QString& fn)
         fn.contains(".ogw", Qt::CaseInsensitive) || fn.contains(".ogg", Qt::CaseInsensitive) ||
         fn.contains(".org", Qt::CaseInsensitive))
 #ifdef ORIGIN_IMPORT
-		ImportOPJ(this, fn);
+        {
+            auto codec = getSettings().value("/General/Dialogs/LastUsedOriginLocale", "").toString();
+            ImportOPJ(this, fn, codec);
+        }
 #else
 		{
                 QMessageBox::critical(this, tr("File opening error"),  tr("SciDAVis currently does not support Origin import. If you are interested in reviving and maintaining an Origin import filter, contact the developers.").arg(fn));
@@ -14155,4 +14154,13 @@ QStringList ApplicationWindow::tableWindows()
 	foreach(AbstractAspect *aspect, tables)
 		result.append(aspect->name());
 	return result;
+}
+
+QSettings ApplicationWindow::getSettings()
+{
+#ifdef Q_OS_MAC // Mac
+	return QSettings(QSettings::IniFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
+#else
+	return QSettings(QSettings::NativeFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
+#endif
 }

--- a/libscidavis/src/ApplicationWindow.cpp
+++ b/libscidavis/src/ApplicationWindow.cpp
@@ -3438,7 +3438,7 @@ void ApplicationWindow::open()
 {
 	OpenProjectDialog *open_dialog = new OpenProjectDialog(this, d_extended_open_dialog);
 	open_dialog->setDirectory(workingDir);
-	auto settings = getSettings();
+	auto& settings = getSettings();
 	open_dialog->setCodec(settings.value("/General/Dialogs/LastUsedOriginLocale", "").toString());
 	if (open_dialog->exec() != QDialog::Accepted || open_dialog->selectedFiles().isEmpty())
 		return;
@@ -4233,7 +4233,7 @@ void ApplicationWindow::openTemplate()
 
 void ApplicationWindow::readSettings()
 {
-    auto settings = getSettings();
+    auto& settings = getSettings();
 	/* ---------------- group General --------------- */
 	settings.beginGroup("/General");
 #ifdef SEARCH_FOR_UPDATES
@@ -4509,7 +4509,7 @@ void ApplicationWindow::readSettings()
 
 void ApplicationWindow::saveSettings()
 {
-    auto settings = getSettings();
+    auto& settings = getSettings();
 	/* ---------------- group General --------------- */
 	settings.beginGroup("/General");
 #ifdef SEARCH_FOR_UPDATES
@@ -14156,11 +14156,15 @@ QStringList ApplicationWindow::tableWindows()
 	return result;
 }
 
-QSettings ApplicationWindow::getSettings()
+QSettings& ApplicationWindow::getSettings()
 {
 #ifdef Q_OS_MAC // Mac
-	return QSettings(QSettings::IniFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
+	static QSettings d_settings(QSettings::IniFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
 #else
-	return QSettings(QSettings::NativeFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
+	static QSettings d_settings(QSettings::NativeFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
 #endif
+	return d_settings;
 }
+
+// initialize singleton
+static auto& SciDavisSettingsSingleton = ApplicationWindow::getSettings();

--- a/libscidavis/src/ApplicationWindow.h
+++ b/libscidavis/src/ApplicationWindow.h
@@ -46,6 +46,7 @@
 #include <QMenu>
 #include <QDockWidget>
 #include <QMdiArea>
+#include <QSettings>
 
 #ifdef _MSC_VER
 #define NOMINMAX
@@ -157,7 +158,8 @@ public:
   QString generateUniqueName(const QString& name, bool increment = true);
 
   bool batchMode() const {return m_batch;} ///< running a python batch script
-                                                                        
+  static QSettings getSettings();
+
 public slots:
   //! Copy the status bar text to the clipboard
   void copyStatusBarText();

--- a/libscidavis/src/ApplicationWindow.h
+++ b/libscidavis/src/ApplicationWindow.h
@@ -158,7 +158,7 @@ public:
   QString generateUniqueName(const QString& name, bool increment = true);
 
   bool batchMode() const {return m_batch;} ///< running a python batch script
-  static QSettings getSettings();
+  static QSettings& getSettings();
 
 public slots:
   //! Copy the status bar text to the clipboard

--- a/libscidavis/src/ConfigDialog.cpp
+++ b/libscidavis/src/ConfigDialog.cpp
@@ -58,7 +58,6 @@
 #include <QVBoxLayout>
 #include <QListWidget>
 #include <QFontMetrics>
-#include <QSettings>
 
 ConfigDialog::ConfigDialog( QWidget* parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
@@ -222,13 +221,8 @@ void ConfigDialog::initTablesPage()
 	boxTableRowHeight = new QSpinBox();
     boxTableRowHeight->setRange(15, 100);
 	tableRowHeightLayout->addWidget(boxTableRowHeight);
-#ifdef Q_OS_MAC
-    QSettings settings(QSettings::IniFormat,QSettings::UserScope,
-                      "SciDAVis", "SciDAVis");
-#else
-    QSettings settings(QSettings::NativeFormat,QSettings::UserScope,
-                       "SciDAVis", "SciDAVis");
-#endif
+
+	auto settings = ApplicationWindow::getSettings();
     settings.beginGroup("[Table]");
     boxTableRowHeight->setValue(settings.value("DefaultRowHeight", 20).toInt());
     settings.endGroup();
@@ -644,18 +638,11 @@ void ConfigDialog::initAppPage()
 
 	numericFormatLayout->setRowStretch(4, 1);
 
-	#ifdef Q_OS_MAC
-	    QSettings settings(QSettings::IniFormat,QSettings::UserScope,
-		              "SciDAVis", "SciDAVis");
-	#else
-	    QSettings settings(QSettings::NativeFormat,QSettings::UserScope,
-		               "SciDAVis", "SciDAVis");
-	#endif
-
-	    lblForeignSeparator  = new QLabel();
-	    numericFormatLayout->addWidget(lblForeignSeparator,4,0);
-	    boxUseForeignSeparator = new QCheckBox();
-	    boxUseForeignSeparator->setChecked(settings.value("/General/UseForeignSeparator").toBool());
+	auto settings = ApplicationWindow::getSettings();
+	lblForeignSeparator  = new QLabel();
+	numericFormatLayout->addWidget(lblForeignSeparator,4,0);
+	boxUseForeignSeparator = new QCheckBox();
+	boxUseForeignSeparator->setChecked(settings.value("/General/UseForeignSeparator").toBool());
     numericFormatLayout->addWidget(boxUseForeignSeparator,4,1);
 
     lblConvertToTextColumn  = new QLabel();
@@ -1236,13 +1223,7 @@ void ConfigDialog::apply()
 	// resize the list to the maximum width
 	itemsList->resize(itemsList->maximumWidth(),itemsList->height());
 
-#ifdef Q_OS_MAC
-    QSettings settings(QSettings::IniFormat,QSettings::UserScope,
-                      "SciDAVis", "SciDAVis");
-#else
-    QSettings settings(QSettings::NativeFormat,QSettings::UserScope,
-                       "SciDAVis", "SciDAVis");
-#endif
+	auto settings = ApplicationWindow::getSettings();
     settings.beginGroup("[Table]");
     settings.setValue("DefaultRowHeight", boxTableRowHeight->value());
     settings.endGroup();

--- a/libscidavis/src/ConfigDialog.cpp
+++ b/libscidavis/src/ConfigDialog.cpp
@@ -222,7 +222,7 @@ void ConfigDialog::initTablesPage()
     boxTableRowHeight->setRange(15, 100);
 	tableRowHeightLayout->addWidget(boxTableRowHeight);
 
-	auto settings = ApplicationWindow::getSettings();
+	auto& settings = ApplicationWindow::getSettings();
     settings.beginGroup("[Table]");
     boxTableRowHeight->setValue(settings.value("DefaultRowHeight", 20).toInt());
     settings.endGroup();
@@ -638,7 +638,7 @@ void ConfigDialog::initAppPage()
 
 	numericFormatLayout->setRowStretch(4, 1);
 
-	auto settings = ApplicationWindow::getSettings();
+	auto& settings = ApplicationWindow::getSettings();
 	lblForeignSeparator  = new QLabel();
 	numericFormatLayout->addWidget(lblForeignSeparator,4,0);
 	boxUseForeignSeparator = new QCheckBox();
@@ -1223,7 +1223,7 @@ void ConfigDialog::apply()
 	// resize the list to the maximum width
 	itemsList->resize(itemsList->maximumWidth(),itemsList->height());
 
-	auto settings = ApplicationWindow::getSettings();
+	auto& settings = ApplicationWindow::getSettings();
     settings.beginGroup("[Table]");
     settings.setValue("DefaultRowHeight", boxTableRowHeight->value());
     settings.endGroup();

--- a/libscidavis/src/OpenProjectDialog.h
+++ b/libscidavis/src/OpenProjectDialog.h
@@ -40,9 +40,13 @@ class OpenProjectDialog : public ExtensibleFileDialog
 		enum OpenMode { NewProject, NewFolder };
 		OpenProjectDialog(QWidget *parent=0, bool extended = true, Qt::WindowFlags flags = Qt::Widget);
 		OpenMode openMode() const { return (OpenMode) d_open_mode->currentIndex(); }
+		QString codec() const;
+		bool setCodec(const QString & codec);
 
 	private:
 		QComboBox *d_open_mode;
+		QComboBox *d_open_codec;
+		QWidget *d_advanced_options;
 
     protected slots:
 		void closeEvent(QCloseEvent* );

--- a/libscidavis/src/future/core/AbstractAspect.cpp
+++ b/libscidavis/src/future/core/AbstractAspect.cpp
@@ -360,7 +360,7 @@ void AbstractAspect::removeAllChildAspects()
 QVariant AbstractAspect::global(const QString &key)
 {
 	QString qualified_key = QString(staticMetaObject.className()) + "/" + key;
-	QVariant result = Private::g_settings->value(qualified_key);
+	QVariant result = Private::g_settings.value(qualified_key);
 	if (result.isValid())
 		return result;
 	else
@@ -369,7 +369,7 @@ QVariant AbstractAspect::global(const QString &key)
 
 void AbstractAspect::setGlobal(const QString &key, const QVariant &value)
 {
-	Private::g_settings->setValue(QString(staticMetaObject.className()) + "/" + key, value);
+	Private::g_settings.setValue(QString(staticMetaObject.className()) + "/" + key, value);
 }
 
 void AbstractAspect::setGlobalDefault(const QString &key, const QVariant &value)

--- a/libscidavis/src/future/core/AbstractAspect.cpp
+++ b/libscidavis/src/future/core/AbstractAspect.cpp
@@ -360,7 +360,7 @@ void AbstractAspect::removeAllChildAspects()
 QVariant AbstractAspect::global(const QString &key)
 {
 	QString qualified_key = QString(staticMetaObject.className()) + "/" + key;
-	QVariant result = Private::g_settings.value(qualified_key);
+	QVariant result = ApplicationWindow::getSettings().value(qualified_key);
 	if (result.isValid())
 		return result;
 	else
@@ -369,7 +369,7 @@ QVariant AbstractAspect::global(const QString &key)
 
 void AbstractAspect::setGlobal(const QString &key, const QVariant &value)
 {
-	Private::g_settings.setValue(QString(staticMetaObject.className()) + "/" + key, value);
+	ApplicationWindow::getSettings().setValue(QString(staticMetaObject.className()) + "/" + key, value);
 }
 
 void AbstractAspect::setGlobalDefault(const QString &key, const QVariant &value)

--- a/libscidavis/src/future/core/AspectPrivate.cpp
+++ b/libscidavis/src/future/core/AspectPrivate.cpp
@@ -33,8 +33,6 @@
 #include <stdexcept>
 using namespace std;
 
-QSettings AbstractAspect::Private::g_settings = ApplicationWindow::getSettings();
-
 QHash<QString, QVariant> AbstractAspect::Private::g_defaults;
 
 AbstractAspect::Private::Private(AbstractAspect * owner, const QString& name)

--- a/libscidavis/src/future/core/AspectPrivate.cpp
+++ b/libscidavis/src/future/core/AspectPrivate.cpp
@@ -33,12 +33,8 @@
 #include <stdexcept>
 using namespace std;
 
-QSettings * AbstractAspect::Private::g_settings =
-#ifdef Q_OS_MAC
-	new QSettings(QSettings::IniFormat, QSettings::UserScope, "SciDAVis", "SciDAVis");
-#else
-	new QSettings(QSettings::NativeFormat, QSettings::UserScope, "SciDAVis", "SciDAVis");
-#endif
+QSettings AbstractAspect::Private::g_settings = ApplicationWindow::getSettings();
+
 QHash<QString, QVariant> AbstractAspect::Private::g_defaults;
 
 AbstractAspect::Private::Private(AbstractAspect * owner, const QString& name)

--- a/libscidavis/src/future/core/AspectPrivate.h
+++ b/libscidavis/src/future/core/AspectPrivate.h
@@ -34,7 +34,7 @@
 #include <QString>
 #include <QDateTime>
 #include <QList>
-#include <QSettings>
+#include "ApplicationWindow.h"
 #include <QHash>
 
 //! Private data managed by AbstractAspect.
@@ -66,7 +66,7 @@ class AbstractAspect::Private
 
 		QString uniqueNameFor(const QString &current_name) const;
 
-		static QSettings * g_settings;
+		static QSettings g_settings;
 		static QHash<QString, QVariant> g_defaults;
 	
 	private:

--- a/libscidavis/src/future/core/AspectPrivate.h
+++ b/libscidavis/src/future/core/AspectPrivate.h
@@ -66,7 +66,6 @@ class AbstractAspect::Private
 
 		QString uniqueNameFor(const QString &current_name) const;
 
-		static QSettings g_settings;
 		static QHash<QString, QVariant> g_defaults;
 	
 	private:

--- a/libscidavis/src/future/core/Project.cpp
+++ b/libscidavis/src/future/core/Project.cpp
@@ -40,7 +40,6 @@
 #include <QString>
 #include <QKeySequence>
 #include <QMenu>
-#include <QSettings>
 #include <QPluginLoader>
 #include <QComboBox>
 #include <QFile>

--- a/libscidavis/src/future/core/column/ColumnPrivate.cpp
+++ b/libscidavis/src/future/core/column/ColumnPrivate.cpp
@@ -60,29 +60,32 @@ Column::Private::Private(Column * owner, SciDAVis::ColumnMode mode)
 	switch(mode)
 	{		
 		case SciDAVis::Numeric:
+		{
 			d_input_filter = new String2DoubleFilter();
 			d_output_filter = new Double2StringFilter();
-#ifdef LEGACY_CODE_0_2_x  // TODO: in a later version this must use the new global setting method
-			{
-				auto settings = ApplicationWindow::getSettings();
-				settings.beginGroup("/General");
-				static_cast<Double2StringFilter *>(d_output_filter)->setNumDigits(settings.value("/DecimalDigits", 14).toInt());
-				static_cast<Double2StringFilter *>(d_output_filter)->setNumericFormat(settings.value("/DefaultNumericFormat", 'f').toChar().toLatin1());
-				settings.endGroup(); // possible bug since there was no closing endGroup()
-			}
-#endif
+
+			auto& settings = ApplicationWindow::getSettings();
+			settings.beginGroup("/General");
+			static_cast<Double2StringFilter *>(d_output_filter)->setNumDigits(settings.value("/DecimalDigits", 14).toInt());
+			static_cast<Double2StringFilter *>(d_output_filter)->setNumericFormat(settings.value("/DefaultNumericFormat", 'f').toChar().toLatin1());
+			settings.endGroup(); // possible bug since there was no closing endGroup()
+
 			connect(static_cast<Double2StringFilter *>(d_output_filter), SIGNAL(formatChanged()),
-					d_owner, SLOT(notifyDisplayChange()));
+				d_owner, SLOT(notifyDisplayChange()));
 			d_data_type = SciDAVis::TypeDouble;
 			d_data = new QVector<double>();
 			break;
+		}
 		case SciDAVis::Text:
+		{
 			d_input_filter = new SimpleCopyThroughFilter();
 			d_output_filter = new SimpleCopyThroughFilter();
 			d_data_type = SciDAVis::TypeQString;
 			d_data = new QStringList();
 			break;
+		}
 		case SciDAVis::DateTime:
+		{
 			d_input_filter = new String2DateTimeFilter();
 			d_output_filter = new DateTime2StringFilter();
 			connect(static_cast<DateTime2StringFilter *>(d_output_filter), SIGNAL(formatChanged()),
@@ -90,7 +93,9 @@ Column::Private::Private(Column * owner, SciDAVis::ColumnMode mode)
 			d_data_type = SciDAVis::TypeQDateTime;
 			d_data = new QList<QDateTime>();
 			break;
+		}
 		case SciDAVis::Month:
+		{
 			d_input_filter = new String2MonthFilter();
 			d_output_filter = new DateTime2StringFilter();
 			static_cast<DateTime2StringFilter *>(d_output_filter)->setFormat("MMMM");
@@ -99,7 +104,9 @@ Column::Private::Private(Column * owner, SciDAVis::ColumnMode mode)
 			d_data_type = SciDAVis::TypeQDateTime;
 			d_data = new QList<QDateTime>();
 			break;
+		}
 		case SciDAVis::Day:
+		{
 			d_input_filter = new String2DayOfWeekFilter();
 			d_output_filter = new DateTime2StringFilter();
 			static_cast<DateTime2StringFilter *>(d_output_filter)->setFormat("dddd");
@@ -108,6 +115,7 @@ Column::Private::Private(Column * owner, SciDAVis::ColumnMode mode)
 			d_data_type = SciDAVis::TypeQDateTime;
 			d_data = new QList<QDateTime>();
 			break;
+		}
 	} // switch(mode)
 
 	d_plot_designation = SciDAVis::noDesignation;
@@ -127,43 +135,51 @@ Column::Private::Private(Column * owner, SciDAVis::ColumnDataType type, SciDAVis
 	switch(mode)
 	{		
 		case SciDAVis::Numeric:
+		{
 			d_input_filter = new String2DoubleFilter();
 			d_output_filter = new Double2StringFilter();
-#ifdef LEGACY_CODE_0_2_x  // TODO: in a later version this must use the new global setting method
-			{
-				auto settings = ApplicationWindow::getSettings();
-				settings.beginGroup("/General");
-				static_cast<Double2StringFilter *>(d_output_filter)->setNumDigits(settings.value("/DecimalDigits", 14).toInt());
-				static_cast<Double2StringFilter *>(d_output_filter)->setNumericFormat(settings.value("/DefaultNumericFormat", 'f').toChar().toLatin1());
-			}
-#endif
+
+			auto& settings = ApplicationWindow::getSettings();
+			settings.beginGroup("/General");
+			static_cast<Double2StringFilter *>(d_output_filter)->setNumDigits(settings.value("/DecimalDigits", 14).toInt());
+			static_cast<Double2StringFilter *>(d_output_filter)->setNumericFormat(settings.value("/DefaultNumericFormat", 'f').toChar().toLatin1());
+
 			connect(static_cast<Double2StringFilter *>(d_output_filter), SIGNAL(formatChanged()),
 				d_owner, SLOT(notifyDisplayChange()));
 			break;
+		}
 		case SciDAVis::Text:
+		{
 			d_input_filter = new SimpleCopyThroughFilter();
 			d_output_filter = new SimpleCopyThroughFilter();
 			break;
+		}
 		case SciDAVis::DateTime:
+		{
 			d_input_filter = new String2DateTimeFilter();
 			d_output_filter = new DateTime2StringFilter();
 			connect(static_cast<DateTime2StringFilter *>(d_output_filter), SIGNAL(formatChanged()),
 				d_owner, SLOT(notifyDisplayChange()));
 			break;
+		}
 		case SciDAVis::Month:
+		{
 			d_input_filter = new String2MonthFilter();
 			d_output_filter = new DateTime2StringFilter();
 			static_cast<DateTime2StringFilter *>(d_output_filter)->setFormat("MMMM");
 			connect(static_cast<DateTime2StringFilter *>(d_output_filter), SIGNAL(formatChanged()),
 				d_owner, SLOT(notifyDisplayChange()));
 			break;
+		}
 		case SciDAVis::Day:
+		{
 			d_input_filter = new String2DayOfWeekFilter();
 			d_output_filter = new DateTime2StringFilter();
 			static_cast<DateTime2StringFilter *>(d_output_filter)->setFormat("dddd");
 			connect(static_cast<DateTime2StringFilter *>(d_output_filter), SIGNAL(formatChanged()),
 				d_owner, SLOT(notifyDisplayChange()));
 			break;
+		}
 	} // switch(mode)
 
 	d_plot_designation = SciDAVis::noDesignation;
@@ -334,43 +350,51 @@ void Column::Private::setColumnMode(SciDAVis::ColumnMode mode, AbstractFilter *f
 	switch(mode)
 	{		
 		case SciDAVis::Numeric:
+		{
 			new_in_filter = new String2DoubleFilter();
 			new_out_filter = new Double2StringFilter();
-#ifdef LEGACY_CODE_0_2_x  // TODO: in a later version this must use the new global setting method
-			{
-				auto settings = ApplicationWindow::getSettings();
-				settings.beginGroup("/General");
-				static_cast<Double2StringFilter *>(new_out_filter)->setNumDigits(settings.value("/DecimalDigits", 14).toInt());
-				static_cast<Double2StringFilter *>(new_out_filter)->setNumericFormat(settings.value("/DefaultNumericFormat", 'f').toChar().toLatin1());
-			}
-#endif
+
+			auto& settings = ApplicationWindow::getSettings();
+			settings.beginGroup("/General");
+			static_cast<Double2StringFilter *>(new_out_filter)->setNumDigits(settings.value("/DecimalDigits", 14).toInt());
+			static_cast<Double2StringFilter *>(new_out_filter)->setNumericFormat(settings.value("/DefaultNumericFormat", 'f').toChar().toLatin1());
+
 			connect(static_cast<Double2StringFilter *>(new_out_filter), SIGNAL(formatChanged()),
 				d_owner, SLOT(notifyDisplayChange()));
 			break;
+		}
 		case SciDAVis::Text:
+		{
 			new_in_filter = new SimpleCopyThroughFilter();
 			new_out_filter = new SimpleCopyThroughFilter();
 			break;
+		}
 		case SciDAVis::DateTime:
+		{
 			new_in_filter = new String2DateTimeFilter();
 			new_out_filter = new DateTime2StringFilter();
 			connect(static_cast<DateTime2StringFilter *>(new_out_filter), SIGNAL(formatChanged()),
 				d_owner, SLOT(notifyDisplayChange()));
 			break;
+		}
 		case SciDAVis::Month:
+		{
 			new_in_filter = new String2MonthFilter();
 			new_out_filter = new DateTime2StringFilter();
 			static_cast<DateTime2StringFilter *>(new_out_filter)->setFormat("MMMM");
 			connect(static_cast<DateTime2StringFilter *>(new_out_filter), SIGNAL(formatChanged()),
 				d_owner, SLOT(notifyDisplayChange()));
 			break;
+		}
 		case SciDAVis::Day:
+		{
 			new_in_filter = new String2DayOfWeekFilter();
 			new_out_filter = new DateTime2StringFilter();
 			static_cast<DateTime2StringFilter *>(new_out_filter)->setFormat("dddd");
 			connect(static_cast<DateTime2StringFilter *>(new_out_filter), SIGNAL(formatChanged()),
 				d_owner, SLOT(notifyDisplayChange()));
 			break;
+		}
         default:
           throw runtime_error("invalid mode");
 	} // switch(mode)

--- a/libscidavis/src/future/core/column/ColumnPrivate.cpp
+++ b/libscidavis/src/future/core/column/ColumnPrivate.cpp
@@ -45,7 +45,7 @@
 #include "core/datatypes/Month2DoubleFilter.h"
 #include <QString>
 #include <QStringList>
-#include <QSettings>
+#include "ApplicationWindow.h"
 #include <QtDebug>
 
 #include <stdexcept>
@@ -64,11 +64,7 @@ Column::Private::Private(Column * owner, SciDAVis::ColumnMode mode)
 			d_output_filter = new Double2StringFilter();
 #ifdef LEGACY_CODE_0_2_x  // TODO: in a later version this must use the new global setting method
 			{
-#ifdef Q_OS_MAC // Mac
-				QSettings settings(QSettings::IniFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
-#else
-				QSettings settings(QSettings::NativeFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
-#endif
+				auto settings = ApplicationWindow::getSettings();
 				settings.beginGroup("/General");
 				static_cast<Double2StringFilter *>(d_output_filter)->setNumDigits(settings.value("/DecimalDigits", 14).toInt());
 				static_cast<Double2StringFilter *>(d_output_filter)->setNumericFormat(settings.value("/DefaultNumericFormat", 'f').toChar().toLatin1());
@@ -135,11 +131,7 @@ Column::Private::Private(Column * owner, SciDAVis::ColumnDataType type, SciDAVis
 			d_output_filter = new Double2StringFilter();
 #ifdef LEGACY_CODE_0_2_x  // TODO: in a later version this must use the new global setting method
 			{
-#ifdef Q_OS_MAC // Mac
-				QSettings settings(QSettings::IniFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
-#else
-				QSettings settings(QSettings::NativeFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
-#endif
+				auto settings = ApplicationWindow::getSettings();
 				settings.beginGroup("/General");
 				static_cast<Double2StringFilter *>(d_output_filter)->setNumDigits(settings.value("/DecimalDigits", 14).toInt());
 				static_cast<Double2StringFilter *>(d_output_filter)->setNumericFormat(settings.value("/DefaultNumericFormat", 'f').toChar().toLatin1());
@@ -346,11 +338,7 @@ void Column::Private::setColumnMode(SciDAVis::ColumnMode mode, AbstractFilter *f
 			new_out_filter = new Double2StringFilter();
 #ifdef LEGACY_CODE_0_2_x  // TODO: in a later version this must use the new global setting method
 			{
-#ifdef Q_OS_MAC // Mac
-				QSettings settings(QSettings::IniFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
-#else
-				QSettings settings(QSettings::NativeFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
-#endif
+				auto settings = ApplicationWindow::getSettings();
 				settings.beginGroup("/General");
 				static_cast<Double2StringFilter *>(new_out_filter)->setNumDigits(settings.value("/DecimalDigits", 14).toInt());
 				static_cast<Double2StringFilter *>(new_out_filter)->setNumericFormat(settings.value("/DefaultNumericFormat", 'f').toChar().toLatin1());
@@ -979,3 +967,4 @@ QString Column::Private::comment() const
 {
 	return d_owner->comment();
 }
+

--- a/libscidavis/src/future/core/datatypes/String2DoubleFilter.h
+++ b/libscidavis/src/future/core/datatypes/String2DoubleFilter.h
@@ -99,7 +99,7 @@ class String2DoubleFilter : public AbstractSimpleFilter
 
 	 	bool isAnyDecimalSeparatorAllowed() const
 		{
-		    auto settings = ApplicationWindow::getSettings();
+		    auto& settings = ApplicationWindow::getSettings();
 		    return settings.value("/General/UseForeignSeparator").toBool();
 		}
 

--- a/libscidavis/src/future/core/datatypes/String2DoubleFilter.h
+++ b/libscidavis/src/future/core/datatypes/String2DoubleFilter.h
@@ -34,7 +34,7 @@
 #include "lib/XmlStreamReader.h"
 #include <QXmlStreamWriter>
 #include <QtDebug>
-#include <QSettings>
+#include "ApplicationWindow.h"
 
 //! Locale-aware conversion filter QString -> double.
 class String2DoubleFilter : public AbstractSimpleFilter
@@ -99,12 +99,8 @@ class String2DoubleFilter : public AbstractSimpleFilter
 
 	 	bool isAnyDecimalSeparatorAllowed() const
 		{
-	#ifdef Q_OS_MAC // Mac
-		QSettings settings(QSettings::IniFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
-	#else
-		QSettings settings(QSettings::NativeFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
-	#endif
-		return settings.value("/General/UseForeignSeparator").toBool();
+		    auto settings = ApplicationWindow::getSettings();
+		    return settings.value("/General/UseForeignSeparator").toBool();
 		}
 
 		// convenience overload

--- a/libscidavis/src/future/table/TableView.cpp
+++ b/libscidavis/src/future/table/TableView.cpp
@@ -58,7 +58,7 @@
 #include <QGridLayout>
 #include <QScrollArea>
 #include <QMenu>
-#include <QSettings>
+#include "ApplicationWindow.h"
 
 #ifndef LEGACY_CODE_0_2_x
 TableView::TableView(future::Table *table)
@@ -98,13 +98,7 @@ void TableView::init()
 	d_main_layout->setContentsMargins(0, 0, 0, 0);
 	
 	d_view_widget = new TableViewWidget(this);
-#ifdef Q_OS_MAC
-    QSettings settings(QSettings::IniFormat,QSettings::UserScope,
-                      "SciDAVis", "SciDAVis");
-#else
-    QSettings settings(QSettings::NativeFormat,QSettings::UserScope,
-                       "SciDAVis", "SciDAVis");
-#endif
+    auto settings = ApplicationWindow::getSettings();
     settings.beginGroup("[Table]");
     int defaultRowHeight = settings.value("DefaultRowHeight", 20).toInt();
     settings.endGroup();

--- a/libscidavis/src/future/table/TableView.cpp
+++ b/libscidavis/src/future/table/TableView.cpp
@@ -98,7 +98,7 @@ void TableView::init()
 	d_main_layout->setContentsMargins(0, 0, 0, 0);
 	
 	d_view_widget = new TableViewWidget(this);
-    auto settings = ApplicationWindow::getSettings();
+    auto& settings = ApplicationWindow::getSettings();
     settings.beginGroup("[Table]");
     int defaultRowHeight = settings.value("DefaultRowHeight", 20).toInt();
     settings.endGroup();

--- a/libscidavis/src/future/table/future_Table.cpp
+++ b/libscidavis/src/future/table/future_Table.cpp
@@ -51,7 +51,7 @@
 #include <QToolBar>
 #include <QtDebug>
 #include <QMimeData>
-#include <QSettings>
+#include "ApplicationWindow.h"
 #if QT_VERSION>=QT_VERSION_CHECK(5,10,0)
 #include <QRandomGenerator>
 #endif
@@ -510,18 +510,13 @@ void Table::pasteIntoSelection()
 				cols_texts << cur_column;
 			}
 
-        #ifdef Q_OS_MAC // Mac
-            QSettings settings(QSettings::IniFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
-        #else
-            QSettings settings(QSettings::NativeFormat,QSettings::UserScope, "SciDAVis", "SciDAVis");
-        #endif
+            auto settings = ApplicationWindow::getSettings();
             bool convertToTextColumn = settings.value("/General/SetColumnTypeToTextOnInvalidInput", true).toBool();
 
             for (int c=0; c<cols && c<input_col_count; c++)
             {
                 Column * col_ptr = d_table_private.column(first_col + c);
-                if (convertToTextColumn)
-                if (col_ptr->columnMode() == SciDAVis::Numeric)
+                if (convertToTextColumn && (col_ptr->columnMode() == SciDAVis::Numeric))
                 {
                     auto filter = reinterpret_cast<String2DoubleFilter*>(col_ptr->inputFilter());
                     if (nullptr != filter)

--- a/libscidavis/src/future/table/future_Table.cpp
+++ b/libscidavis/src/future/table/future_Table.cpp
@@ -510,7 +510,7 @@ void Table::pasteIntoSelection()
 				cols_texts << cur_column;
 			}
 
-            auto settings = ApplicationWindow::getSettings();
+            auto& settings = ApplicationWindow::getSettings();
             bool convertToTextColumn = settings.value("/General/SetColumnTypeToTextOnInvalidInput", true).toBool();
 
             for (int c=0; c<cols && c<input_col_count; c++)

--- a/libscidavis/src/importOPJ.cpp
+++ b/libscidavis/src/importOPJ.cpp
@@ -83,7 +83,7 @@ QString posixTimeToString(time_t pt)
 }
 
 ImportOPJ::ImportOPJ(ApplicationWindow *app, const QString& filename, const QString& codec) :
-		mw(app)
+		mw(app), d_codec(nullptr)
 {
 	setCodec(codec);
 	xoffset=0;

--- a/libscidavis/src/importOPJ.h
+++ b/libscidavis/src/importOPJ.h
@@ -33,12 +33,13 @@
 
 #include "ApplicationWindow.h"
 #include <OriginFile.h>
+#include <QTextCodec>
 
 //! Origin project import class
 class ImportOPJ
 {
 public:
-	ImportOPJ(ApplicationWindow *app, const QString& filename);
+	ImportOPJ(ApplicationWindow *app, const QString& filename, const QString& codec);
 
 	bool createProjectTree(const OriginFile& opj);
 	bool importTables (const OriginFile& opj);
@@ -48,12 +49,15 @@ public:
 	int error(){return parse_error;};
 
 private:
+	bool setCodec(const QString& codecName);
+	QString decodeMbcs(char const * const input) const;
 	int translateOrigin2ScidavisLineStyle(int linestyle);
 	QString parseOriginText(const QString &str);
 	QString parseOriginTags(const QString &str);
 	int parse_error;
 	int xoffset;
 	ApplicationWindow *mw;
+	QTextCodec* d_codec;
 };
 
 #endif //IMPORTOPJ_H

--- a/libscidavis/src/importOPJ.h
+++ b/libscidavis/src/importOPJ.h
@@ -57,7 +57,7 @@ private:
 	int parse_error;
 	int xoffset;
 	ApplicationWindow *mw;
-	QTextCodec* d_codec;
+	QTextCodec* d_codec; // the codec object is owned by Qt, this is actually a weak pointer.
 };
 
 #endif //IMPORTOPJ_H

--- a/scidavis/src/main.cpp
+++ b/scidavis/src/main.cpp
@@ -32,7 +32,6 @@
 #include <QApplication>
 #include <QSplashScreen>
 #include <QTimer>
-#include <QSettings>
 
 #include <typeinfo>
 
@@ -160,9 +159,6 @@ struct Application: public QApplication
 int main( int argc, char ** argv )
 {
 
-#ifdef Q_OS_MAC // Mac
-    QSettings::setDefaultFormat(QSettings::IniFormat);
-#endif
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
     QCoreApplication::setOrganizationName("SciDAVis");
     QCoreApplication::setApplicationName("SciDAVis");


### PR DESCRIPTION
When one imports an `.opj` file containing non-latin characters anywhere (project name, labels, column descriptions, etc.), these are imported as "�" symbols (tested in Ubuntu 20.04 and Win 7). As I understand, `liborigin` imports strings as-is (i.e. byte sequence). However, I found that `.opj` files created in Windows with Russian locale contain strings encoded in [Windows-1251](https://en.wikipedia.org/wiki/Windows-1251) codepage. Therefore, it is a bug not to treat this properly during import. As always, I made the enhancement optional, so one can choose what codepage to use during import:
![Codepage choice](https://user-images.githubusercontent.com/71484368/103209755-6c5c9300-4936-11eb-9dd1-813c4776e994.png)
Most users will use `US-ASCII` codepage which is default. The last used locale is stored in settings and also used to open files from `Recent Projects` submenu. This bugfix, of course, needs testing, but from my point of view, everything is ok.

Also, `QSettings` in the project is now accessed from one place and there is no need to repeat macro every time.