### PR TITLE
Bug fix to SF#403

### DIFF
--- a/libscidavis/src/MyWidget.h
+++ b/libscidavis/src/MyWidget.h
@@ -73,11 +73,12 @@ public:
     enum Status { Hidden = -1, Normal = 0, Minimized = 1, Maximized = 2 };
 
     //! Return the window label
-    virtual QString windowLabel() { return QString(w_label).replace("\n", "\\n"); };
+    virtual QString windowLabel() { return QString(w_label); };
     //! Set the window label
     virtual void setWindowLabel(const QString &s)
     {
-        w_label = s;
+        auto label = s;
+        w_label = label.replace("\n", " ").replace("\t", " ");
         updateCaption();
     };
 


### PR DESCRIPTION
This PR contains bugfix to [SF#403 ticket](https://sourceforge.net/p/scidavis/scidavis-bugs/403/).
In brief: for some reason, some `.opj` files contain graph (and other entities, apparently) with `\n` characters in labels. On project save, project file is stored incorrectly due to additional linebreak in file, therefore crash on load. 
I removed `replace("\n", "\\n");` in label getter, since linebreaks will never occur in the label anymore (what that was for anyway?..)