### PR TITLE
bugfix for fit error messages in loop and subtle refactor

### DIFF
--- a/libscidavis/src/ExponentialFit.cpp
+++ b/libscidavis/src/ExponentialFit.cpp
@@ -100,21 +100,13 @@ void ExponentialFit::storeCustomFitResults(const vector<double> &par)
         d_results[1] = 1.0 / d_results[1];
 }
 
-void ExponentialFit::calculateFitCurveData(const vector<double> &par, double *X, double *Y)
+bool ExponentialFit::calculateFitCurveData(const vector<double> &par, std::vector<double> &X,
+                                           std::vector<double> &Y)
 {
-    if (d_gen_function) {
-        double X0 = d_x[0];
-        double step = (d_x[d_n - 1] - X0) / (d_points - 1);
-        for (int i = 0; i < d_points; i++) {
-            X[i] = X0 + i * step;
-            Y[i] = par[0] * exp(-par[1] * X[i]) + par[2];
-        }
-    } else {
-        for (int i = 0; i < d_points; i++) {
-            X[i] = d_x[i];
-            Y[i] = par[0] * exp(-par[1] * X[i]) + par[2];
-        }
-    }
+    generateX(X);
+    for (int i = 0; i < d_points; i++)
+        Y[i] = par[0] * exp(-par[1] * X[i]) + par[2];
+    return true;
 }
 
 /*****************************************************************************
@@ -175,21 +167,13 @@ void TwoExpFit::storeCustomFitResults(const vector<double> &par)
     d_results[3] = 1.0 / d_results[3];
 }
 
-void TwoExpFit::calculateFitCurveData(const vector<double> &par, double *X, double *Y)
+bool TwoExpFit::calculateFitCurveData(const vector<double> &par, std::vector<double> &X,
+                                      std::vector<double> &Y)
 {
-    if (d_gen_function) {
-        double X0 = d_x[0];
-        double step = (d_x[d_n - 1] - X0) / (d_points - 1);
-        for (int i = 0; i < d_points; i++) {
-            X[i] = X0 + i * step;
-            Y[i] = par[0] * exp(-par[1] * X[i]) + par[2] * exp(-par[3] * X[i]) + par[4];
-        }
-    } else {
-        for (int i = 0; i < d_points; i++) {
-            X[i] = d_x[i];
-            Y[i] = par[0] * exp(-par[1] * X[i]) + par[2] * exp(-par[3] * X[i]) + par[4];
-        }
-    }
+    generateX(X);
+    for (int i = 0; i < d_points; i++)
+        Y[i] = par[0] * exp(-par[1] * X[i]) + par[2] * exp(-par[3] * X[i]) + par[4];
+    return true;
 }
 
 /*****************************************************************************
@@ -254,21 +238,12 @@ void ThreeExpFit::storeCustomFitResults(const vector<double> &par)
     d_results[5] = 1.0 / d_results[5];
 }
 
-void ThreeExpFit::calculateFitCurveData(const vector<double> &par, double *X, double *Y)
+bool ThreeExpFit::calculateFitCurveData(const vector<double> &par, std::vector<double> &X,
+                                        std::vector<double> &Y)
 {
-    if (d_gen_function) {
-        double X0 = d_x[0];
-        double step = (d_x[d_n - 1] - X0) / (d_points - 1);
-        for (int i = 0; i < d_points; i++) {
-            X[i] = X0 + i * step;
-            Y[i] = par[0] * exp(-X[i] * par[1]) + par[2] * exp(-X[i] * par[3])
-                    + par[4] * exp(-X[i] * par[5]) + par[6];
-        }
-    } else {
-        for (int i = 0; i < d_points; i++) {
-            X[i] = d_x[i];
-            Y[i] = par[0] * exp(-X[i] * par[1]) + par[2] * exp(-X[i] * par[3])
-                    + par[4] * exp(-X[i] * par[5]) + par[6];
-        }
-    }
+    generateX(X);
+    for (int i = 0; i < d_points; i++)
+        Y[i] = par[0] * exp(-X[i] * par[1]) + par[2] * exp(-X[i] * par[3])
+                + par[4] * exp(-X[i] * par[5]) + par[6];
+    return true;
 }

--- a/libscidavis/src/ExponentialFit.h
+++ b/libscidavis/src/ExponentialFit.h
@@ -45,7 +45,8 @@ public:
 private:
     void init();
     void storeCustomFitResults(const std::vector<double> &) override;
-    void calculateFitCurveData(const std::vector<double> &, double *, double *) override;
+    bool calculateFitCurveData(const std::vector<double> &, std::vector<double> &,
+                               std::vector<double> &) override;
 
     bool is_exp_growth;
 };
@@ -63,7 +64,8 @@ public:
 private:
     void init();
     void storeCustomFitResults(const std::vector<double> &) override;
-    void calculateFitCurveData(const std::vector<double> &, double *, double *) override;
+    bool calculateFitCurveData(const std::vector<double> &, std::vector<double> &,
+                               std::vector<double> &) override;
 };
 
 class ThreeExpFit : public Fit
@@ -79,6 +81,7 @@ public:
 private:
     void init();
     void storeCustomFitResults(const std::vector<double> &par) override;
-    void calculateFitCurveData(const std::vector<double> &, double *, double *) override;
+    bool calculateFitCurveData(const std::vector<double> &, std::vector<double> &,
+                               std::vector<double> &) override;
 };
 #endif

--- a/libscidavis/src/Fit.h
+++ b/libscidavis/src/Fit.h
@@ -122,14 +122,22 @@ private:
     virtual void storeCustomFitResults(const std::vector<double> &par) { d_results = par; }
 
 protected:
+    //! Generates argument values wrt to d_gen_function
+    void generateX(std::vector<double> &X) const;
+
     //! Adds the result curve as a FunctionCurve to the plot, if d_gen_function = true
-    void insertFitFunctionCurve(const QString &name, double *x, double *y, int penWidth = 1);
+    void insertFitFunctionCurve(const QString &name, std::vector<double> &, std::vector<double> &,
+                                int penWidth = 1);
 
     //! Adds the result curve to the plot
     virtual void generateFitCurve(const std::vector<double> &);
 
     //! Calculates the data for the output fit curve and store itin the X an Y vectors
-    virtual void calculateFitCurveData(const std::vector<double> &, double *, double *) { }
+    virtual bool calculateFitCurveData(const std::vector<double> &, std::vector<double> &,
+                                       std::vector<double> &)
+    {
+        return false;
+    }
 
     //! Output string added to the result log
     virtual QString logFitInfo(const std::vector<double> &par, int iterations, int status,

--- a/libscidavis/src/FitDialog.cpp
+++ b/libscidavis/src/FitDialog.cpp
@@ -561,7 +561,7 @@ void FitDialog::saveUserFunction()
     }
     if (editBox->toPlainText().contains(boxName->text())) {
         QMessageBox::critical(this, tr("Input function error"),
-                              tr("You can't define functions recursevely!"));
+                              tr("You can't define functions recursively!"));
         editBox->setFocus();
         return;
     }

--- a/libscidavis/src/MultiPeakFit.h
+++ b/libscidavis/src/MultiPeakFit.h
@@ -56,7 +56,7 @@ private:
     void generateFitCurve(const std::vector<double> &) override;
     static QString peakFormula(int peakIndex, PeakProfile profile);
     //! Inserts a peak function curve into the plot
-    void insertPeakFunctionCurve(double *x, double *y, int peak);
+    void insertPeakFunctionCurve(std::vector<double> &x, std::vector<double> &y, int peak);
     void storeCustomFitResults(const std::vector<double> &) override;
 
     //! Used by the GaussFit and LorentzFit derived classes to calculate initial values for the parameters
@@ -117,6 +117,7 @@ public:
 
 private:
     void init();
-    void calculateFitCurveData(const std::vector<double> &, double *, double *) override;
+    bool calculateFitCurveData(const std::vector<double> &, std::vector<double> &,
+                               std::vector<double> &) override;
 };
 #endif

--- a/libscidavis/src/NonLinearFit.h
+++ b/libscidavis/src/NonLinearFit.h
@@ -45,7 +45,8 @@ public:
     void setFormula(const QString &s);
 
 private:
-    void calculateFitCurveData(const std::vector<double> &, double *, double *) override;
+    bool calculateFitCurveData(const std::vector<double> &, std::vector<double> &,
+                               std::vector<double> &) override;
     void init();
 };
 #endif

--- a/libscidavis/src/PluginFit.cpp
+++ b/libscidavis/src/PluginFit.cpp
@@ -148,21 +148,12 @@ bool PluginFit::load(const QString &pluginName)
     return true;
 }
 
-void PluginFit::calculateFitCurveData(const vector<double> &par, double *X, double *Y)
+bool PluginFit::calculateFitCurveData(const vector<double> &par, std::vector<double> &X,
+                                      std::vector<double> &Y)
 {
-    if (d_gen_function) {
-        double X0 = d_x[0];
-        double step = (d_x[d_n - 1] - X0) / (d_points - 1);
-        for (int i = 0; i < d_points; i++) {
-            X[i] = X0 + i * step;
-            // TODO: f_eval's signature should have const double*
-            Y[i] = f_eval(X[i], const_cast<double *>(&par[0]));
-        }
-    } else {
-        for (int i = 0; i < d_points; i++) {
-            X[i] = d_x[i];
-            // TODO second par should be const double*
-            Y[i] = f_eval(X[i], const_cast<double *>(&par[0]));
-        }
-    }
+    generateX(X);
+    for (int i = 0; i < d_points; i++)
+        // TODO second par should be const double*
+        Y[i] = f_eval(X[i], const_cast<double *>(&par[0]));
+    return true;
 }

--- a/libscidavis/src/PluginFit.h
+++ b/libscidavis/src/PluginFit.h
@@ -46,7 +46,8 @@ public:
 private:
     void init();
     typedef double (*fitFunctionEval)(double, double *);
-    void calculateFitCurveData(const std::vector<double> &, double *, double *) override;
+    bool calculateFitCurveData(const std::vector<double> &, std::vector<double> &,
+                               std::vector<double> &) override;
     fitFunctionEval f_eval;
 };
 #endif

--- a/libscidavis/src/PolynomialFit.cpp
+++ b/libscidavis/src/PolynomialFit.cpp
@@ -99,29 +99,17 @@ QStringList PolynomialFit::generateParameterList(int order)
     return lst;
 }
 
-void PolynomialFit::calculateFitCurveData(const vector<double> &par, double *X, double *Y)
+bool PolynomialFit::calculateFitCurveData(const vector<double> &par, std::vector<double> &X,
+                                          std::vector<double> &Y)
 {
-    if (d_gen_function) {
-        double X0 = d_x[0];
-        double step = (d_x[d_n - 1] - X0) / (d_points - 1);
-        for (int i = 0; i < d_points; i++) {
-            X[i] = X0 + i * step;
-            double yi = 0.0;
-            for (unsigned j = 0; j < d_p; j++)
-                yi += par[j] * pow(X[i], j);
-
-            Y[i] = yi;
-        }
-    } else {
-        for (int i = 0; i < d_points; i++) {
-            X[i] = d_x[i];
-            double yi = 0.0;
-            for (unsigned j = 0; j < d_p; j++)
-                yi += par[j] * pow(X[i], j);
-
-            Y[i] = yi;
-        }
+    generateX(X);
+    for (int i = 0; i < d_points; i++) {
+        double yi = 0.0;
+        for (unsigned j = 0; j < d_p; j++)
+            yi += par[j] * pow(X[i], j);
+        Y[i] = yi;
     }
+    return true;
 }
 
 void PolynomialFit::fit()
@@ -290,19 +278,11 @@ void LinearFit::fit()
     generateFitCurve(d_results);
 }
 
-void LinearFit::calculateFitCurveData(const vector<double> &par, double *X, double *Y)
+bool LinearFit::calculateFitCurveData(const vector<double> &par, std::vector<double> &X,
+                                      std::vector<double> &Y)
 {
-    if (d_gen_function) {
-        double X0 = d_x[0];
-        double step = (d_x[d_n - 1] - X0) / (d_points - 1);
-        for (int i = 0; i < d_points; i++) {
-            X[i] = X0 + i * step;
-            Y[i] = par[0] + par[1] * X[i];
-        }
-    } else {
-        for (int i = 0; i < d_points; i++) {
-            X[i] = d_x[i];
-            Y[i] = par[0] + par[1] * X[i];
-        }
-    }
+    generateX(X);
+    for (int i = 0; i < d_points; i++)
+        Y[i] = par[0] + par[1] * X[i];
+    return true;
 }

--- a/libscidavis/src/PolynomialFit.h
+++ b/libscidavis/src/PolynomialFit.h
@@ -50,7 +50,8 @@ public:
 
 private:
     void init();
-    void calculateFitCurveData(const std::vector<double> &, double *, double *) override;
+    bool calculateFitCurveData(const std::vector<double> &, std::vector<double> &,
+                               std::vector<double> &) override;
 
     int d_order;
     bool show_legend;
@@ -70,6 +71,7 @@ public:
 
 private:
     void init();
-    void calculateFitCurveData(const std::vector<double> &, double *, double *) override;
+    bool calculateFitCurveData(const std::vector<double> &, std::vector<double> &,
+                               std::vector<double> &) override;
 };
 #endif

--- a/libscidavis/src/SigmoidalFit.cpp
+++ b/libscidavis/src/SigmoidalFit.cpp
@@ -77,21 +77,13 @@ void SigmoidalFit::init()
     d_formula = "(A1-A2)/(1+exp((x-x0)/dx))+A2";
 }
 
-void SigmoidalFit::calculateFitCurveData(const vector<double> &par, double *X, double *Y)
+bool SigmoidalFit::calculateFitCurveData(const vector<double> &par, std::vector<double> &X,
+                                         std::vector<double> &Y)
 {
-    if (d_gen_function) {
-        double X0 = d_x[0];
-        double step = (d_x[d_n - 1] - X0) / (d_points - 1);
-        for (int i = 0; i < d_points; i++) {
-            X[i] = X0 + i * step;
-            Y[i] = (par[0] - par[1]) / (1 + exp((X[i] - par[2]) / par[3])) + par[1];
-        }
-    } else {
-        for (int i = 0; i < d_points; i++) {
-            X[i] = d_x[i];
-            Y[i] = (par[0] - par[1]) / (1 + exp((X[i] - par[2]) / par[3])) + par[1];
-        }
-    }
+    generateX(X);
+    for (int i = 0; i < d_points; i++)
+        Y[i] = (par[0] - par[1]) / (1 + exp((X[i] - par[2]) / par[3])) + par[1];
+    return true;
 }
 
 void SigmoidalFit::guessInitialValues()

--- a/libscidavis/src/SigmoidalFit.h
+++ b/libscidavis/src/SigmoidalFit.h
@@ -44,7 +44,7 @@ public:
 
 private:
     void init();
-    void calculateFitCurveData(const std::vector<double> &, double *, double *) override;
+    bool calculateFitCurveData(const std::vector<double> &, std::vector<double> &, std::vector<double> &) override;
 };
 
 #endif


### PR DESCRIPTION
Steps to reproduce the bug:
Choose data to fit, open "Fit Wizard"
Use custom invalid expression, like `a+scrt(x)` (the typo intended)
Try to fit and get 1+n error messages about an invalid parenthesis, where n is the number of datapoints.

Fixed this bug and also refactored some related code, mostly changed `double*` to `std::vector<double>` and made a function to generate x-vector, since the largest part of code in `calculateFitCurveData` in all the derived classes did the same thing.

Also, I'm not sure why MinGW test fails, since it fails for `master` in my repo and succeeds in upstream (this repo). See [upstream](https://github.com/highperformancecoder/scidavis/commit/83a36a6ceabc7b1ccffbfbf75e2ccf75947ae41b) and [fork](https://github.com/Suthiro/scidavis/commit/83a36a6ceabc7b1ccffbfbf75e2ccf75947ae41b) commits pointing to the same node `83a36a6ceabc7b1ccffbfbf75e2ccf75947ae41b` with different CI results. What?