### PR TITLE
Bugfix for SF#131

### DIFF
--- a/libscidavis/src/Matrix.cpp
+++ b/libscidavis/src/Matrix.cpp
@@ -413,6 +413,10 @@ bool Matrix::recalculate()
     saveCellsToMemory();
     double dx = fabs(xEnd() - xStart()) / (double)(numRows() - 1);
     double dy = fabs(yEnd() - yStart()) / (double)(numCols() - 1);
+    std::pair<double, bool> invalidValue(std::numeric_limits<double>::quiet_NaN(), false);
+    std::vector<std::vector<std::pair<double, bool>>> calculatedValues(
+            endRow - startRow + 1,
+            std::vector<std::pair<double, bool>>(endCol - startCol + 1, invalidValue));
     for (int row = startRow; row <= endRow; row++)
         for (int col = startCol; col <= endCol; col++) {
             if (!isCellSelected(row, col))
@@ -431,8 +435,9 @@ bool Matrix::recalculate()
                 QApplication::restoreOverrideCursor();
                 return false;
             }
-            setCell(row, col, ret.toDouble());
+            calculatedValues[row - startRow][col - startCol] = std::pair(ret.toDouble(), true);
         }
+    d_future_matrix->setCells(startRow, startCol, calculatedValues);
     forgetSavedCells();
 
     blockSignals(false);

--- a/libscidavis/src/future/matrix/future_Matrix.h
+++ b/libscidavis/src/future/matrix/future_Matrix.h
@@ -223,6 +223,12 @@ public slots:
     //! Clear the whole matrix (i.e. set all cells to 0.0)
     void clear();
     void transpose();
+
+    std::vector<std::vector<std::pair<double, bool>>>
+    getCells(const int startRow, const int endRow, const int startCol, const int endCol) const;
+
+    void setCells(const int startRow, const int startCol,
+                  const std::vector<std::vector<std::pair<double, bool>>> &values);
     void mirrorVertically();
     void mirrorHorizontally();
 
@@ -438,6 +444,13 @@ public:
     double yEnd() const;
     QString formula() const;
     void setFormula(const QString &formula);
+
+    std::vector<std::vector<std::pair<double, bool>>>
+    getCells(const int startRow, const int endRow, const int startCol, const int endCol) const;
+
+	void setCells(const int startRow, const int startCol,
+                const std::vector<std::vector<std::pair<double, bool>>> &values);
+
     void setXStart(double x);
     void setXEnd(double x);
     void setYStart(double y);

--- a/libscidavis/src/future/matrix/matrixcommands.cpp
+++ b/libscidavis/src/future/matrix/matrixcommands.cpp
@@ -532,3 +532,28 @@ void MatrixMirrorVerticallyCmd::undo()
 ///////////////////////////////////////////////////////////////////////////
 // end of class MatrixMirrorVerticallyCmd
 ///////////////////////////////////////////////////////////////////////////
+
+MatrixSetCellsCmd::MatrixSetCellsCmd(
+        future::Matrix::Private *private_obj, int first_row, int last_row, int first_column,
+        int last_column, const std::vector<std::vector<std::pair<double, bool>>> &values,
+        QUndoCommand *parent)
+    : QUndoCommand(parent), d_private_obj{ private_obj },
+      d_first_row{ first_row },
+      d_last_row{ last_row },
+      d_first_column{ first_column },
+      d_last_column{ last_column },
+      d_values{ values },
+      d_old_values{ private_obj->getCells(first_row, last_row, first_column, last_column) }
+{
+    setText(QObject::tr("%1: set values for multiple cells").arg(d_private_obj->name()));
+}
+
+void MatrixSetCellsCmd::redo() 
+{
+    d_private_obj->setCells(d_first_row, d_first_column, d_values);
+}
+
+void MatrixSetCellsCmd::undo() 
+{
+    d_private_obj->setCells(d_first_row, d_first_column, d_old_values);
+}

--- a/libscidavis/src/future/matrix/matrixcommands.h
+++ b/libscidavis/src/future/matrix/matrixcommands.h
@@ -387,6 +387,42 @@ private:
 ///////////////////////////////////////////////////////////////////////////
 
 ///////////////////////////////////////////////////////////////////////////
+// class MatrixSetCellsCmd
+///////////////////////////////////////////////////////////////////////////
+//! Set cell values for multiple cells at once
+class MatrixSetCellsCmd : public QUndoCommand
+{
+public:
+    MatrixSetCellsCmd(future::Matrix::Private *private_obj, int first_row, int last_row,
+                      int first_column, int last_column,
+                      const std::vector<std::vector<std::pair<double, bool>>> &values,
+                      QUndoCommand *parent = 0);
+
+    void redo() override;
+    void undo() override;
+
+private:
+    //! The private object to modify
+    future::Matrix::Private * const d_private_obj;
+    //! The index of the first row
+    const int d_first_row;
+    //! The index of the last row
+    const int d_last_row;
+    //! The index of the first column
+    const int d_first_column;
+    //! The index of the last column
+    const int d_last_column;
+    //! New cell values
+    const std::vector<std::vector<std::pair<double, bool>>> d_values;
+    //! Backup of the changed values
+    const std::vector<std::vector<std::pair<double, bool>>> d_old_values;
+};
+
+///////////////////////////////////////////////////////////////////////////
+// end of class MatrixSetCellsCmd
+///////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////
 // class MatrixTransposeCmd
 ///////////////////////////////////////////////////////////////////////////
 //! Transpose the matrix


### PR DESCRIPTION
Bugfix for [SF#131](https://sourceforge.net/p/scidavis/scidavis-bugs/131/): matrices processing are now fast upon undoing a formula.

NB: MSVC_Qt_5.12.10 builds successfully and MSVC_Qt_5.15.2 does not. The `PythonScripting.cpp` (is not changed in this PR) makes problems. I would like to fix this, but I don't know how. I would be very grateful for advice.