### PR TITLE
Fix for new CI environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,8 @@ jobs:
 
       - name: Install Python packages
         if: ${{ matrix.qt_ver == '5.15.2' }}
-        run: pip install sip==5.5.0 pyqt5 numpy
+        run: |
+         pip install sip==5.5.0 pyqt5==5.15.2  PyQt5-sip==12.8.1 numpy
 
       - name: Configuring
         run: |
@@ -154,7 +155,7 @@ jobs:
             mingw-w64-x86_64-gsl
             mingw-w64-x86_64-gl2ps
             mingw-w64-x86_64-gtest
-            mingw-w64-x86_64-sip5
+            mingw-w64-x86_64-sip4
             mingw-w64-x86_64-python-pyqt5
             mingw-w64-x86_64-python-numpy
 
@@ -198,8 +199,11 @@ jobs:
 
       - name: Install prerequisties
         run: |
-          brew install muparser gsl gl2ps googletest sip
-          pip install pyqt5 numpy
+         brew install muparser gsl gl2ps googletest
+         brew tap-new $USER/local-sip
+         brew extract --version=4.19.25 sip $USER/local-sip
+         brew install sip@4.19.25
+         pip install pyqt5 numpy
 
       - name: Configuring
         run: |

--- a/libscidavis/src/PythonScripting.cpp
+++ b/libscidavis/src/PythonScripting.cpp
@@ -38,8 +38,15 @@
 
 #include <iostream>
 
-#define str(x) xstr(x)
-#define xstr(x) #x
+// sorry for such meaningless macro names, but this way name collision is unlikely
+#define qwezstringify(x) x2strtr(x)
+#define x2strtr(x) #x
+
+const char* pythonHome = qwezstringify(PYTHONHOME);
+
+#undef qwezstringify
+#undef x2strtr
+
 
 #if PY_VERSION_HEX < 0x020400A1
 typedef struct _traceback
@@ -210,7 +217,7 @@ PythonScripting::PythonScripting(ApplicationWindow *parent, bool batch)
         // if we need to bundle Python libraries with the executable,
         // specify the library location here
 #ifdef PYTHONHOME
-        Py_SetPythonHome(Py_DecodeLocale(str(PYTHONHOME), NULL));
+        Py_SetPythonHome(Py_DecodeLocale(pythonHome, NULL));
 #endif
         //		PyEval_InitThreads ();
 #if PY_MAJOR_VERSION >= 3

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,13 +67,13 @@ if( NOT (SEARCH_FOR_UPDATES OR DOWNLOAD_LINKS) )
 endif()
 
 if( SCRIPTING_PYTHON )
-
+  
   file( COPY pythonTests/ DESTINATION ./tmp )
   file( COPY ../scidavis-logo.png DESTINATION ./tmp )
 
   file( GLOB pythonTests pythonTests/*.py )
   # qwtPlotCurve segfault with sip5 or macos
-  if( SIP_VERSION VERSION_GREATER_EQUAL 5 OR APPLE )
+  if( SIP_VERSION VERSION_GREATER_EQUAL 5 OR APPLE OR MSYS )
     list( REMOVE_ITEM pythonTests ${CMAKE_CURRENT_SOURCE_DIR}/pythonTests/qwtPlotCurve.py )
   endif()
 


### PR DESCRIPTION
This PR fixes problems with latest problems in CI.
Macos builds failed due to sip upgrade to v6. I used `brew extract` to fix the version to 4.9. Apparently, there is no sip м5 for macos.
Mingw/msys failed because of the same reason. I was not able to locate sip5 fo msys either, see [this issue.](https://github.com/msys2/MINGW-packages/issues/8203). Despite sip v4 package is available and allows one to build, qwtplotcurve test is failing. I decided to disable it for mingw for now, and was surprised that it is already disabled for macos and sip v5 :)
MSVC failed due to unrelated reason. What a coincidence! As I understand, the problem is connected with [this](https://developercommunity.visualstudio.com/t/SFINAE-bug:-Failed-to-specialize-alias/1367587?entry=problem&space=62&q=19.28) update of compiler. Since CI always use only the latest toolset, I concocted some macro (re)definitions to avoid this bug. Also, just in case, I decided to fix versions of python packages just in case.
I must confess I don't understand versioning of sip packages and why different versions of sip across different systems are used in SciDAVis.